### PR TITLE
Fix GROOVY-4841 - Adding null to null results in null now

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/NullObject.java
+++ b/src/main/org/codehaus/groovy/runtime/NullObject.java
@@ -106,6 +106,9 @@ public class NullObject extends GroovyObjectSupport {
      * @return the concatenated string
      */
     public Object plus(String s) {
+        if (is(s)) {
+            return null;
+        }
         return getMetaClass().invokeMethod(this, "toString", new Object[]{}) + s;
     }
 

--- a/src/test/org/codehaus/groovy/runtime/NullObjectTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/NullObjectTest.groovy
@@ -56,6 +56,13 @@ class NullObjectTest extends GroovyTestCase {
         assert null.hello() == "Greeting from null"
         null.setMetaClass(oldMC)
     }
+
+    void testNullBigDecimalAddOperator() {
+        BigDecimal a = null
+        BigDecimal b = null
+        BigDecimal c = a+b
+        assert c == null
+    }
 }
 
 class MyCategory {


### PR DESCRIPTION
The commit fixes issue GROOVY-4841. 

The plus-method of NullObject has been extended to check the passed parameter for being also a NullObject-instance. If a null is detected, the method will not longer concatenate strings but just return a null-value instead. So we have the following behaviour: null + null = null.

Also added the test-case described within the issue to NullObjectTest.
