### PR TITLE
Enum linenumber fix

### DIFF
--- a/src/main/org/codehaus/groovy/antlr/AntlrParserPlugin.java
+++ b/src/main/org/codehaus/groovy/antlr/AntlrParserPlugin.java
@@ -670,6 +670,8 @@ public class AntlrParserPlugin extends ASTHelper implements ParserPlugin, Groovy
         ClassNode oldNode = classNode;
         enumClass.addAnnotations(annotations);
         classNode = enumClass;
+        configureAST(classNode, enumNode);
+
         assertNodeType(OBJBLOCK, node);
         objectBlock(node);
         classNode = oldNode;

--- a/src/test/org/codehaus/groovy/antlr/AntlrParserPluginTest.groovy
+++ b/src/test/org/codehaus/groovy/antlr/AntlrParserPluginTest.groovy
@@ -39,4 +39,19 @@ class AntlrParserPluginTest extends GroovyTestCase {
         assert result[2].lastColumnNumber == 14
 
     }
+
+    void testEnumLineNumbers() {
+
+        def result = new AstBuilder().buildFromString(org.codehaus.groovy.control.CompilePhase.CONVERSION, false,  '''
+            enum Color {
+
+            }
+        ''')
+
+        assert result[1].getClass() == org.codehaus.groovy.ast.ClassNode
+        assert result[1].lineNumber == 2
+        assert result[1].lastLineNumber == 4
+        assert result[1].columnNumber == 13
+        assert result[1].lastColumnNumber == 14
+    }
 }


### PR DESCRIPTION
Hello,

This is a commit to fix the linenumber information in enums, which is currently set to -1 in Groovy 1.8 and Groovy 2.0. This commit fixes that, and is needed for CodeNarc, which uses a lot of rules to check on this property. These rules, for example the UnnecessaryPublicModifierRule. 

Erik Pragt
