### PR TITLE
Fix for GROOVY-5247

### DIFF
--- a/src/main/groovy/json/JsonOutput.groovy
+++ b/src/main/groovy/json/JsonOutput.groovy
@@ -139,10 +139,12 @@ class JsonOutput {
      * @return a JSON object representation for a map
      */
     static String toJson(Map m) {
-        if(m.containsKey(null)) {
-            throw new IllegalArgumentException('Null key for a Map not allowed')
-        }
-        "{" + m.collect { k, v -> toJson(k.toString()) + ':' + toJson(v) }.join(',') + "}"
+        "{" + m.collect { k, v ->
+                if (k == null) {
+                    throw new IllegalArgumentException('Null key for a Map not allowed')
+                }
+                toJson(k.toString()) + ':' + toJson(v)
+        }.join(',') + "}"
     }
 
     /**

--- a/src/test/groovy/json/JsonOutputTest.groovy
+++ b/src/test/groovy/json/JsonOutputTest.groovy
@@ -287,6 +287,12 @@ class JsonOutputTest extends GroovyTestCase {
             toJson([(null): 1])
         }
     }
+
+    void testGROOVY5247() {
+        def m = new TreeMap()
+        m.a = 1
+        assert toJson(m) == '{"a":1}'
+    }
 }
 
 @Canonical


### PR DESCRIPTION
Fixes issue introduced by GROOVY-5162 (commit c5456c808f0af5a) that causes a NPE when checking for null keys on certain Map implementations (i.e., TreeMap, Hashtable).
