### PR TITLE
GROOVY-5216: Sql.newInstance(Map) should handle parameter non-destructively

### DIFF
--- a/src/main/groovy/sql/Sql.java
+++ b/src/main/groovy/sql/Sql.java
@@ -362,34 +362,39 @@ public class Sql {
      * @throws ClassNotFoundException if the class cannot be found or loaded
      */
     public static Sql newInstance(Map<String, Object> args) throws SQLException, ClassNotFoundException {
+        if (!args.containsKey("url"))
+            throw new IllegalArgumentException("Argument 'url' is required");
+
         if (args.containsKey("driverClassName") && args.containsKey("driver"))
             throw new IllegalArgumentException("Only one of 'driverClassName' and 'driver' should be provided");
-        Object driverClassName = args.remove("driverClassName");
-        if (driverClassName == null) driverClassName = args.remove("driver");
+
+        // Make a copy so destructive operations will not affect the caller
+        Map<String, Object> sqlArgs = new HashMap<String, Object>(args);
+
+        Object driverClassName = sqlArgs.remove("driverClassName");
+        if (driverClassName == null) driverClassName = sqlArgs.remove("driver");
         if (driverClassName != null) loadDriver(driverClassName.toString());
 
-        Object url = args.remove("url");
-        if (url == null) throw new IllegalArgumentException("Argument 'url' is required");
-
-        Properties props = (Properties) args.remove("properties");
-        if (props != null && args.containsKey("user"))
+        Properties props = (Properties) sqlArgs.remove("properties");
+        if (props != null && sqlArgs.containsKey("user"))
             throw new IllegalArgumentException("Only one of 'properties' and 'user' should be supplied");
-        if (props != null && args.containsKey("password"))
+        if (props != null && sqlArgs.containsKey("password"))
             throw new IllegalArgumentException("Only one of 'properties' and 'password' should be supplied");
-        if (args.containsKey("user") ^ args.containsKey("password"))
+        if (sqlArgs.containsKey("user") ^ sqlArgs.containsKey("password"))
             throw new IllegalArgumentException("Found one but not both of 'user' and 'password'");
 
+        Object url = sqlArgs.remove("url");
         Connection connection;
-        if (props != null) connection = DriverManager.getConnection(url.toString(), props);
-        else if (args.containsKey("user")) {
-            Object user = args.remove("user");
-            Object password = args.remove("password");
+        if (props != null) connection = DriverManager.getConnection(url.toString(), new Properties(props));
+        else if (sqlArgs.containsKey("user")) {
+            Object user = sqlArgs.remove("user");
+            Object password = sqlArgs.remove("password");
             connection = DriverManager.getConnection(url.toString(),
                     (user == null ? null : user.toString()),
                     (password == null ? null : password.toString()));
         } else connection = DriverManager.getConnection(url.toString());
 
-        Sql result = (Sql) InvokerHelper.invokeConstructorOf(Sql.class, args);
+        Sql result = (Sql) InvokerHelper.invokeConstructorOf(Sql.class, sqlArgs);
         result.setConnection(connection);
         return result;
     }

--- a/src/test/groovy/sql/SqlCompleteTest.groovy
+++ b/src/test/groovy/sql/SqlCompleteTest.groovy
@@ -429,6 +429,64 @@ class SqlCompleteTest extends TestHelper {
         assert names[1] == ["NAME":"coffee"]
     }
 
+    void testNewInstanceMapMustContainUrl() {
+        shouldFail(IllegalArgumentException) {
+            Sql.newInstance(driver: 'org.hsqldb.jdbcDriver', user: 'scott', password: 'tiger')
+        }
+    }
+
+    void testNewInstanceMapShouldNotContainDriverAndDriverClassName() {
+        shouldFail(IllegalArgumentException) {
+            Sql.newInstance(driver: 'a', driverClassName: 'b')
+        }
+    }
+
+    void testNewInstanceMapShouldNotHavePropertiesAndAccountInfo() {
+        def args = [url: getURI(), user: 'sa', password: '']
+        args.properties = [:] as Properties
+        shouldFail(IllegalArgumentException) {
+            Sql.newInstance(args)
+        }
+    }
+
+    void testNewInstanceMapShouldRequireUserAndPasswordIfOneIsProvided() {
+        shouldFail(IllegalArgumentException) {
+            Sql.newInstance(url: getURI(), driver: 'org.hsqldb.jdbcDriver', user: 'scott')
+        }
+        shouldFail(IllegalArgumentException) {
+            Sql.newInstance(url: getURI(), driver: 'org.hsqldb.jdbcDriver', password: 'tiger')
+        }
+    }
+
+    void testNewInstanceMapNotDestructiveGROOVY5216() {
+        String url = getURI()
+        String driver = 'org.hsqldb.jdbcDriver'
+        String user = 'sa'
+        String password = ''
+
+        // First pass with user/password and no properties
+        def args = [url: url, driver: driver, user: user, password: password]
+        def sql = Sql.newInstance(args)
+        assert 4 == args.size()
+        assert url == args.url
+        assert driver == args.driver
+        assert user == args.user
+        assert password == args.password
+
+        // Second pass with properties
+        def props = new Properties()
+        props.user = user
+        props.password = password
+        def args2 = [url: url, driver: driver, properties: props]
+        def sql2 = Sql.newInstance(args2)
+        assert 3 == args2.size()
+        assert url == args.url
+        assert driver == args.driver
+        assert 2 == props.size()
+        assert user == props.user
+        assert password == props.password
+    }
+
 }
 
 class PersonDTO {


### PR DESCRIPTION
The url guard statement was moved to the top before any driver loading would take place.  Otherwise, just making copies of the args (and also the properties - Oracle adds a protocol prop).  Added some other tests for the newInstance(Map) method as well.

I know it looks like quite a bit of change and I may not have placed the tests in the desired class.  But thought I'd offer the patch in case it may be of use.
