### PR TITLE
GROOVY-5144: JsonSlurper does not handle backslashes at the end of a String

### DIFF
--- a/src/main/groovy/json/JsonLexer.java
+++ b/src/main/groovy/json/JsonLexer.java
@@ -105,12 +105,17 @@ public class JsonLexer implements Iterator<JsonToken> {
                 StringBuilder currentContent = new StringBuilder("\"");
                 // consume the first double quote starting the string
                 reader.read();
+                boolean isEscaped = false;
                 for (;;) {
                     int read = reader.read();
                     if (read == -1) return null;
-                    currentContent.append((char) read);
 
-                    if (currentContent.charAt(currentContent.length() - 1) == '"' && currentContent.charAt(currentContent.length() - 2) != '\\' &&
+                    isEscaped = (!isEscaped && currentContent.charAt(currentContent.length() - 1) == '\\');
+
+                    char charRead = (char) read;
+                    currentContent.append(charRead);
+
+                    if (charRead == '"' && !isEscaped &&
                             possibleTokenType.matching(currentContent.toString())) {
                         token.setEndLine(reader.getLine());
                         token.setEndColumn(reader.getColumn());

--- a/src/test/groovy/json/JsonLexerTest.groovy
+++ b/src/test/groovy/json/JsonLexerTest.groovy
@@ -134,5 +134,12 @@ class JsonLexerTest extends GroovyTestCase {
         assert lexer.nextToken().value == "Guill\\aume"
         assert lexer.nextToken().type == JsonTokenType.CLOSE_BRACKET
         assert lexer.nextToken() == null
+
+        lexer = new JsonLexer(new StringReader('["c:\\\\"]'))
+
+        assert lexer.nextToken().type == JsonTokenType.OPEN_BRACKET
+        assert lexer.nextToken().value == "c:\\"
+        assert lexer.nextToken().type == JsonTokenType.CLOSE_BRACKET
+        assert lexer.nextToken() == null
     }
 }

--- a/src/test/groovy/json/JsonSlurperTest.groovy
+++ b/src/test/groovy/json/JsonSlurperTest.groovy
@@ -145,7 +145,7 @@ class JsonSlurperTest extends GroovyTestCase {
         shouldFail(JsonException) { parser.parseText('["a", true')  }
     }
 
-    void testBackSlashEscapting() {
+    void testBackSlashEscaping() {
         def json = new JsonBuilder()
 
         json.person {
@@ -158,5 +158,15 @@ class JsonSlurperTest extends GroovyTestCase {
 
         def slurper = new JsonSlurper()
         assert slurper.parseText(jsonstring).person.name == "Guill\\aume"
+
+        assert parser.parseText('{"a":"\\\\"}') == [a: '\\']
+        assert parser.parseText('{"a":"C:\\\\\\"Documents and Settings\\"\\\\"}') == [a: 'C:\\"Documents and Settings"\\']
+        assert parser.parseText('{"a":"c:\\\\GROOVY5144\\\\","y":"z"}') == [a: 'c:\\GROOVY5144\\', y: 'z']
+
+        assert parser.parseText('["c:\\\\GROOVY5144\\\\","d"]') == ['c:\\GROOVY5144\\', 'd']
+
+        shouldFail(JsonException) {
+            parser.parseText('{"a":"c:\\\"}')
+        }
     }
 }


### PR DESCRIPTION
This is a patch to track whether or not the current char is escaped so the end of string can be accurately determined.  JsonLexer was assuming that any backslash before a quote was escaping the quote, even if that backslash itself was escaped by a prior backslash.
