### PR TITLE
GROOVY-4617: Error when running groovysh with verbose option (-v)

### DIFF
--- a/src/main/org/codehaus/groovy/tools/shell/Groovysh.groovy
+++ b/src/main/org/codehaus/groovy/tools/shell/Groovysh.groovy
@@ -143,7 +143,7 @@ class Groovysh extends Shell {
                 log.debug("Evaluating buffer...")
 
                 if (io.verbose) {
-                    displayBuffer(buffer)
+                    displayBuffer(current)
                 }
 
                 // Evaluate the current buffer w/imports and dummy statement


### PR DESCRIPTION
I provided some details about this in the Jira comments.

I generally feel uncomfortable about submitting pull requests without a corresponding test, but since the change seemed trivial enough and I didn't see any tests for the other options such as `--debug` I didn't write a new test for this.  Hope that is ok, if not I can probably come up with a quick test.
