### PR TITLE
GROOVY-5224: groovy.util.Node plus operator assuming all children are not strings

### DIFF
--- a/src/main/groovy/util/Node.java
+++ b/src/main/groovy/util/Node.java
@@ -177,9 +177,7 @@ public class Node implements Serializable {
             parent.appendNode(child.name(), child.attributes(), child.value());
         }
 
-        for (Node child : leftOvers) {
-            this.parent().children().add(child);
-        }
+        this.parent().children().addAll(leftOvers);
     }
 
     protected static void setMetaClass(final MetaClass metaClass, Class nodeClass) {

--- a/src/test/groovy/util/NodeTest.groovy
+++ b/src/test/groovy/util/NodeTest.groovy
@@ -192,6 +192,34 @@ public class NodeTest extends GroovyTestCase {
         assert foo.baz.bar[0] == bar2
     }
 
+    public void testPlus() {
+        Node root = new Node(null, 'root')
+        Node first = new Node(root, 'first')
+
+        root.first + { second('some text') }
+
+        assert 2 == root.children().size()
+        assert 'some text' == root.second.text()
+    }
+
+    public void testPlusWithMixedContent() {
+        Node root = new Node(null, 'root')
+        Node beforeString = new Node(root, 'beforeString')
+        root.children().add('some text')
+        Node afterString = new Node(root, 'afterString')
+        assert 3 == root.children().size()
+
+        root.afterString + { foo() }
+        assert 4 == root.children().size()
+
+        // GROOVY-5224 - would fail with
+        //   java.lang.ClassCastException: java.lang.String cannot be cast to groovy.util.Node
+        root.beforeString + { bar() }
+        assert 5 == root.children().size()
+
+        assert 'some text' == root.children().get(2)
+    }
+
     protected void dump(Node node) {
         NodePrinter printer = new NodePrinter();
         printer.print(node);


### PR DESCRIPTION
This fixes the issue reported.  Even though the List returned from children() may contain mixed content of types Node and String, typing the local `List<Node>/ArrayList<Node>` wasn't causing any issues so I left as is.  But can understand if a different approach is taken.  Hopefully at least the tests may be of use.
