### PR TITLE
GROOVY-5170: GroovyRowResult and GroovyResultSet are Inconsistent

### DIFF
--- a/src/main/groovy/sql/GroovyRowResult.java
+++ b/src/main/groovy/sql/GroovyRowResult.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2003-2007 the original author or authors.
+ * Copyright 2003-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -61,11 +61,21 @@ public class GroovyRowResult extends GroovyObjectSupport implements Map {
             // if property exists and value is null, return null
             if (result.containsKey(propertyUpper)) 
                 return null;
-            throw new MissingPropertyException(property, GroovyRowResult.class);
+            return getPropertyIgnoreCase(property);
         }
         catch (Exception e) {
             throw new MissingPropertyException(property, GroovyRowResult.class, e);
         }
+    }
+
+    private Object getPropertyIgnoreCase(String property) {
+        for (Object key : result.keySet()) {
+            if (!(key instanceof String))
+                continue;
+            if (property.equalsIgnoreCase((String)key))
+                return result.get(key);
+        }
+        throw new MissingPropertyException(property, GroovyRowResult.class);
     }
 
     /**

--- a/src/test/groovy/sql/GroovyRowResultTest.groovy
+++ b/src/test/groovy/sql/GroovyRowResultTest.groovy
@@ -1,6 +1,19 @@
+/*
+ * Copyright 2003-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package groovy.sql
-
-import java.util.LinkedHashMap
 
 class GroovyRowResultTest extends GroovyTestCase {
 
@@ -54,14 +67,9 @@ class GroovyRowResultTest extends GroovyTestCase {
         assert row.lower == "brown"
         assert row.upper == "fox"
         assert row.UPPER == "fox"
-        
-        try {
-            assert row.LOWER == "brown"
-            assert false
-        } catch (MissingPropertyException mpe) {
-        } catch (Exception e) {
-            assert false
-        }
+
+        assert row.LOWER == "brown"
+        assert row.mixed == "quick"
 
         try {
             println row.foo


### PR DESCRIPTION
Fix to GroovyRowResult so that properties can be accessed case insensitively as they are with the GroovyResultSet.
