### PR TITLE
GROOVY-5283 Add a collate method to List

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -1966,12 +1966,11 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
     }
 
     /**
-     * Collates this list into sub-lists of length <code>size</code>. Any remaining elements in
-     * the list after the subdivision will be dropped.
+     * Collates this list into sub-lists of length <code>size</code>.
      * Example:
      * <pre class="groovyTestCase">def list = [ 1, 2, 3, 4, 5, 6, 7 ]
      * def coll = list.collate( 3 )
-     * assert coll == [ [ 1, 2, 3 ], [ 4, 5, 6 ] ]</pre>
+     * assert coll == [ [ 1, 2, 3 ], [ 4, 5, 6 ], [ 7 ] ]</pre>
      *
      * @param self          a List
      * @param size          the length of each sub-list in the returned list
@@ -1979,16 +1978,16 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @since 1.8.7
      */
     public static <T> List<List<T>> collate( List<T> self, int size ) {
-        return collate( self, size, size, false ) ;
+        return collate( self, size, size, true ) ;
     }
 
     /**
      * Collates this list into sub-lists of length <code>size</code> stepping through the code <code>step</code>
-     * elements for each subList.  Any remaining elements in the list after the subdivision will be dropped.
+     * elements for each subList.
      * Example:
      * <pre class="groovyTestCase">def list = [ 1, 2, 3, 4 ]
      * def coll = list.collate( 3, 1 )
-     * assert coll == [ [ 1, 2, 3 ], [ 2, 3, 4 ] ]</pre>
+     * assert coll == [ [ 1, 2, 3 ], [ 2, 3, 4 ], [ 3, 4 ], [ 4 ] ]</pre>
      *
      * @param self          a List
      * @param size          the length of each sub-list in the returned list
@@ -1997,7 +1996,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @since 1.8.7
      */
     public static <T> List<List<T>> collate( List<T> self, int size, int step ) {
-        return collate( self, size, step, false ) ;
+        return collate( self, size, step, true ) ;
     }
 
     /**
@@ -2005,8 +2004,8 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * the list after the subdivision will be dropped if <code>keepRemainder</code> is false.
      * Example:
      * <pre class="groovyTestCase">def list = [ 1, 2, 3, 4, 5, 6, 7 ]
-     * def coll = list.collate( 3, true )
-     * assert coll == [ [ 1, 2, 3 ], [ 4, 5, 6 ], [ 7 ] ]</pre>
+     * def coll = list.collate( 3, false )
+     * assert coll == [ [ 1, 2, 3 ], [ 4, 5, 6 ] ]</pre>
      *
      * @param self          a List
      * @param size          the length of each sub-list in the returned list
@@ -2024,8 +2023,8 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * <code>keepRemainder</code> is false.
      * Example:
      * <pre class="groovyTestCase">def list = [ 1, 2, 3, 4 ]
-     * def coll = list.collate( 3, 1, true )
-     * assert coll == [ [ 1, 2, 3 ], [ 2, 3, 4 ], [ 3, 4 ], [ 4 ] ]</pre>
+     * assert list.collate( 3, 1, true  ) == [ [ 1, 2, 3 ], [ 2, 3, 4 ], [ 3, 4 ], [ 4 ] ]
+     * assert list.collate( 3, 1, false ) == [ [ 1, 2, 3 ], [ 2, 3, 4 ] ]</pre>
      *
      * @param self          a List
      * @param size          the length of each sub-list in the returned list

--- a/src/test/groovy/CollateTest.groovy
+++ b/src/test/groovy/CollateTest.groovy
@@ -19,19 +19,19 @@
 class CollateTest extends GroovyTestCase {
   void testSimple() {
     def list = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
-    assert list.collate( 3 ) == [ [ 1, 2, 3 ], [ 4, 5, 6 ], [ 7, 8, 9 ] ]
+    assert list.collate( 3 ) == [ [ 1, 2, 3 ], [ 4, 5, 6 ], [ 7, 8, 9 ], [ 10 ] ]
   }
 
   void testRemain() {
     def list = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
-    assert list.collate( 3, true ) == [ [ 1, 2, 3 ], [ 4, 5, 6 ], [ 7, 8, 9 ], [ 10 ] ]
+    assert list.collate( 3, false ) == [ [ 1, 2, 3 ], [ 4, 5, 6 ], [ 7, 8, 9 ] ]
   }
 
   void testStepSimple() {
     def list = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
     def expected = [ [ 1, 2, 3 ], [ 2, 3, 4 ], [ 3, 4, 5 ],
                      [ 4, 5, 6 ], [ 5, 6, 7 ], [ 6, 7, 8 ],
-                     [ 7, 8, 9 ], [ 8, 9, 10 ] ]
+                     [ 7, 8, 9 ], [ 8, 9, 10 ], [ 9, 10 ], [ 10 ] ]
     assert list.collate( 3, 1 ) == expected
   }
 
@@ -39,8 +39,8 @@ class CollateTest extends GroovyTestCase {
     def list = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
     def expected = [ [ 1, 2, 3 ], [ 2, 3, 4 ], [ 3, 4, 5 ],
                      [ 4, 5, 6 ], [ 5, 6, 7 ], [ 6, 7, 8 ],
-                     [ 7, 8, 9 ], [ 8, 9, 10 ], [ 9, 10 ], [ 10 ] ]
-    assert list.collate( 3, 1, true ) == expected
+                     [ 7, 8, 9 ], [ 8, 9, 10 ] ]
+    assert list.collate( 3, 1, false ) == expected
   }
 
   void testTwoDimensions() {
@@ -52,8 +52,8 @@ class CollateTest extends GroovyTestCase {
 
   void testLargeStep() {
     def list = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
-    assert list.collate( 2, 4       ) == [ [ 1, 2 ], [ 5, 6 ], [ 9, 10 ] ]
-    assert list.collate( 2, 4, true ) == [ [ 1, 2 ], [ 5, 6 ], [ 9, 10 ] ]
+    assert list.collate( 2, 4, false ) == [ [ 1, 2 ], [ 5, 6 ], [ 9, 10 ] ]
+    assert list.collate( 2, 4        ) == [ [ 1, 2 ], [ 5, 6 ], [ 9, 10 ] ]
   }
 
   void testEmpty() {
@@ -76,16 +76,16 @@ class CollateTest extends GroovyTestCase {
   void testChaining() {
     def list = 1..15
     def expected = [ [ [ 1, 2, 3],  [ 4, 5, 6] ],
-                     [ [ 7, 8, 9],  [10,11,12] ] ]
+                     [ [ 7, 8, 9],  [10,11,12] ],
+                     [ [13,14,15]              ] ]
     assert list.collate( 3 ).collate( 2 ) == expected
   }
 
   void testChainingRemain() {
     def list = 1..15
     def expected = [ [ [ 1, 2, 3],  [ 4, 5, 6] ],
-                     [ [ 7, 8, 9],  [10,11,12] ],
-                     [ [13,14,15]              ] ]
-    assert list.collate( 3 ).collate( 2, true ) == expected
+                     [ [ 7, 8, 9],  [10,11,12] ] ]
+    assert list.collate( 3 ).collate( 2, false ) == expected
   }
 
   void testSimpleUsecase() {


### PR DESCRIPTION
I have often found a need for collating or partitioning a List into a List of sub-lists of a given size.

This question has been asked on StackOverflow a couple of times as well

ie:

```
[1,2,3,4,5].collate( 3 ) == [ [ 1, 2, 3 ], [ 4, 5 ] ]
```

This could be chained to generate a multi-dimensional list of lists, ie:

```
(1..9).collate( 3 ).collate( 2 ) == [ [ [1,2,3], [4,5,6] ],
                                      [ [7,8,9]          ] ]
```

Hope the pull request is ok...  I think I covered all bases with my tests
