### PR TITLE
GROOVY-4835: provide a @NotYetImplemented AST transform for test cases of not yet implemented features (@Hackergarten contribution)

### DIFF
--- a/src/main/groovy/transform/NotYetImplemented.java
+++ b/src/main/groovy/transform/NotYetImplemented.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2003-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package groovy.transform;
+
+import org.codehaus.groovy.transform.GroovyASTTransformationClass;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Method annotation used to invert test case results. If a JUnit 3/4 test case method is
+ * annotated with {@code @NotYetImplemented} the test will fail if no test failure occurs and it will pass
+ * if a test failure occurs.<p/>
+ *
+ * This is helpful for tests that don't currently work but should work one day,
+ * when the tested functionality has been implemented.<p/>
+ *
+ * The idea for this AST transformation originated in {@link groovy.util.GroovyTestCase#notYetImplemented()}.
+ *
+ * @author Dierk König
+ * @author Andre Steingress
+ */
+@java.lang.annotation.Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+@GroovyASTTransformationClass("org.codehaus.groovy.transform.NotYetImplementedASTTransformation")
+public @interface NotYetImplemented {
+}

--- a/src/main/org/codehaus/groovy/transform/NotYetImplementedASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/NotYetImplementedASTTransformation.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2003-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.groovy.transform;
+
+import junit.framework.AssertionFailedError;
+import org.codehaus.groovy.ast.*;
+import org.codehaus.groovy.ast.expr.ArgumentListExpression;
+import org.codehaus.groovy.ast.expr.ConstantExpression;
+import org.codehaus.groovy.ast.expr.ConstructorCallExpression;
+import org.codehaus.groovy.ast.stmt.*;
+import org.codehaus.groovy.control.CompilePhase;
+import org.codehaus.groovy.control.SourceUnit;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+/**
+ * Handles generation of code for the {@code @NotYetImplemented} annotation.
+ * 
+ * @see groovy.transform.NotYetImplemented
+ *
+ * @author Dierk König
+ * @author Andre Steingress
+ */
+@GroovyASTTransformation(phase = CompilePhase.CANONICALIZATION)
+public class NotYetImplementedASTTransformation extends AbstractASTTransformation {
+
+    private static final ClassNode CATCHED_THROWABLE_TYPE = ClassHelper.make(Throwable.class);
+    private static final ClassNode ASSERTION_FAILED_ERROR_TYPE = ClassHelper.make(AssertionFailedError.class);
+
+    public void visit(ASTNode[] nodes, SourceUnit source) {
+        if (nodes.length != 2 || !(nodes[0] instanceof AnnotationNode) || !(nodes[1] instanceof AnnotatedNode)) {
+            throw new RuntimeException("Internal error: expecting [AnnotationNode, AnnotatedNode] but got: " + Arrays.asList(nodes));
+        }
+
+        AnnotationNode annotationNode = (AnnotationNode) nodes[0];
+        ASTNode node = nodes[1];
+
+        if (!(node instanceof MethodNode))  {
+            addError("@NotYetImplemented must only be applied on test methods!",node);
+            return;
+        }
+
+        MethodNode methodNode = (MethodNode) node;
+
+        ArrayList<Statement> statements = new ArrayList<Statement>();
+        Statement statement = methodNode.getCode();
+        if (statement instanceof BlockStatement)  {
+            statements.addAll(((BlockStatement) statement).getStatements());
+        }
+
+        if (statements.size() == 0) return;
+
+        BlockStatement rewrittenMethodCode = new BlockStatement();
+
+        rewrittenMethodCode.addStatement(tryCatchAssertionFailedError(annotationNode, methodNode, statements));
+        rewrittenMethodCode.addStatement(throwAssertionFailedError(annotationNode));
+
+        methodNode.setCode(rewrittenMethodCode);
+    }
+
+    private TryCatchStatement tryCatchAssertionFailedError(AnnotationNode annotationNode, MethodNode methodNode, ArrayList<Statement> statements) {
+        TryCatchStatement tryCatchStatement = new TryCatchStatement(new BlockStatement(statements, methodNode.getVariableScope()), EmptyStatement.INSTANCE);
+        tryCatchStatement.addCatch(new CatchStatement(new Parameter(CATCHED_THROWABLE_TYPE, "ex"), ReturnStatement.RETURN_NULL_OR_VOID));
+        return tryCatchStatement;
+    }
+
+    private Statement throwAssertionFailedError(AnnotationNode annotationNode) {
+        ThrowStatement throwStatement = new ThrowStatement(
+                new ConstructorCallExpression(ASSERTION_FAILED_ERROR_TYPE,
+                        new ArgumentListExpression(
+                                new ConstantExpression("Method is marked with @NotYetImplemented but passes unexpectedly"))));
+
+        throwStatement.setSourcePosition(annotationNode);
+
+        return throwStatement;
+    }
+}

--- a/src/test/org/codehaus/groovy/transform/NotYetImplementedTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/NotYetImplementedTransformTest.groovy
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2003-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.groovy.transform
+
+import junit.framework.AssertionFailedError
+
+/**
+ * @author Dierk König
+ * @author Andre Steingress
+ */
+class NotYetImplementedTransformTest extends GroovyShellTestCase {
+
+    void testNotYetImplemented() {
+        def output = evaluate("""
+              import groovy.transform.NotYetImplemented
+
+              class MyTests extends GroovyTestCase {
+                @NotYetImplemented void testShouldNotFail()  {
+                    assertFalse true
+                }
+              }
+
+              junit.textui.TestRunner.run(new junit.framework.TestSuite(MyTests))
+        """)
+
+        assertNotNull output
+        assertTrue "test method marked with @NotYetImplemented must NOT throw an AsssertionFailedError", output.wasSuccessful()
+    }
+
+    void testNotYetImplementedWithException() {
+            def output = evaluate("""
+                  import groovy.transform.NotYetImplemented
+
+                  class MyTests extends GroovyTestCase {
+                    @NotYetImplemented void testShouldNotFail()  {
+                        'test'.yetUnkownMethod()
+                    }
+                  }
+
+                  junit.textui.TestRunner.run(new junit.framework.TestSuite(MyTests))
+            """)
+
+            assertNotNull output
+            assertTrue "test method marked with @NotYetImplemented must NOT throw an AsssertionFailedError", output.wasSuccessful()
+        }
+
+    void testNotYetImplementedPassThrough() {
+        def output = evaluate("""
+              import groovy.transform.NotYetImplemented
+
+              class MyTests extends GroovyTestCase {
+                @NotYetImplemented void testShouldFail()  {
+                    assertTrue true
+                }
+              }
+
+              junit.textui.TestRunner.run(new junit.framework.TestSuite(MyTests))
+        """)
+
+        assertNotNull output
+
+        assertEquals "test method marked with @NotYetImplemented must throw an AssertionFailedError", 1, output.failureCount()
+        assertEquals "test method marked with @NotYetImplemented must throw an AssertionFailedError", AssertionFailedError.class, output.failures().nextElement().thrownException().class
+    }
+
+    void testEmptyTestMethod() {
+        def output = evaluate("""
+              import groovy.transform.NotYetImplemented
+
+              class MyTests extends GroovyTestCase {
+                @NotYetImplemented void testShouldNotFail()  {}
+              }
+
+              junit.textui.TestRunner.run(new junit.framework.TestSuite(MyTests))
+        """)
+
+        assertNotNull output
+
+        assertTrue "empty test method must not throw an AssertionFailedError", output.wasSuccessful()
+    }
+
+    void testNotYetImplementedJUnit4()  {
+
+        def output = evaluate("""
+        import groovy.transform.NotYetImplemented
+        import org.junit.Test
+        import org.junit.runner.JUnitCore
+
+        class MyTests {
+            @NotYetImplemented @Test void testShouldNotFail()  {
+                junit.framework.Assert.assertFalse true
+            }
+        }
+
+        new JUnitCore().run(MyTests)
+        """)
+
+        assertTrue output.wasSuccessful()
+
+    }
+
+    void testNotYetImplementedPassThroughJUnit4() {
+        def output = evaluate("""
+              import groovy.transform.NotYetImplemented
+              import org.junit.Test
+              import org.junit.runner.JUnitCore
+
+              class MyTests {
+                @NotYetImplemented @Test void shouldFail()  {
+                    junit.framework.Assert.assertTrue true
+                }
+              }
+
+              new JUnitCore().run(MyTests)
+        """)
+
+        assertNotNull output
+
+        assertEquals "test method marked with @NotYetImplemented must throw an AssertionFailedError", 1, output.failureCount
+        assertEquals "test method marked with @NotYetImplemented must throw an AssertionFailedError", AssertionFailedError.class, output.failures.first().exception.class
+    }
+}


### PR DESCRIPTION
fixes GROOVY-4835 for JUnit test methods. Compared to GroovyTestCase.notYetImplemented the AST transformation does not need to add code that re-executes the actual test method, as it can wrap the test method statements into a local try-catch block.
