### PR TITLE
GROOVY-5134: @ToString optionally exclude fields with null values

### DIFF
--- a/src/main/groovy/transform/ToString.java
+++ b/src/main/groovy/transform/ToString.java
@@ -76,8 +76,22 @@ import java.lang.annotation.Target;
  * <pre>
  * AgedThing(age:5, super:NamedThing(Lassie))
  * </pre>
+ * If you want to omit fields or properties referring to <tt>null</tt> you can use:
+ * <pre>
+ * import groovy.transform.ToString
+ * {@code @ToString(ignoreNullValues = true)} class NamedThing {
+ *     String name
+ * }
+ * println new NamedThing(name: null)
+ * </pre>
+ * Which results in:
+ * <pre>
+ * NamedThing()
+ * </pre>
  *
  * @author Paul King
+ * @author Andre Steingress
+ *
  * @since 1.8.0
  */
 @java.lang.annotation.Documented
@@ -111,4 +125,9 @@ public @interface ToString {
      * Include fields as well as properties in generated toString
      */
     boolean includeFields() default false;
+
+    /**
+     * Ignore fields as well as properties referring to <tt>null</tt>
+     */
+    boolean ignoreNullValues() default false;
 }

--- a/src/main/org/codehaus/groovy/transform/ToStringASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/ToStringASTTransformation.java
@@ -16,29 +16,9 @@
 package org.codehaus.groovy.transform;
 
 import groovy.transform.ToString;
-import org.codehaus.groovy.ast.ASTNode;
-import org.codehaus.groovy.ast.AnnotatedNode;
-import org.codehaus.groovy.ast.AnnotationNode;
-import org.codehaus.groovy.ast.ClassHelper;
-import org.codehaus.groovy.ast.ClassNode;
-import org.codehaus.groovy.ast.FieldNode;
-import org.codehaus.groovy.ast.MethodNode;
-import org.codehaus.groovy.ast.Parameter;
-import org.codehaus.groovy.ast.PropertyNode;
-import org.codehaus.groovy.ast.expr.BooleanExpression;
-import org.codehaus.groovy.ast.expr.ConstantExpression;
-import org.codehaus.groovy.ast.expr.ConstructorCallExpression;
-import org.codehaus.groovy.ast.expr.DeclarationExpression;
-import org.codehaus.groovy.ast.expr.Expression;
-import org.codehaus.groovy.ast.expr.MethodCallExpression;
-import org.codehaus.groovy.ast.expr.StaticMethodCallExpression;
-import org.codehaus.groovy.ast.expr.VariableExpression;
-import org.codehaus.groovy.ast.stmt.BlockStatement;
-import org.codehaus.groovy.ast.stmt.EmptyStatement;
-import org.codehaus.groovy.ast.stmt.ExpressionStatement;
-import org.codehaus.groovy.ast.stmt.IfStatement;
-import org.codehaus.groovy.ast.stmt.ReturnStatement;
-import org.codehaus.groovy.ast.stmt.Statement;
+import org.codehaus.groovy.ast.*;
+import org.codehaus.groovy.ast.expr.*;
+import org.codehaus.groovy.ast.stmt.*;
 import org.codehaus.groovy.classgen.Verifier;
 import org.codehaus.groovy.control.CompilePhase;
 import org.codehaus.groovy.control.SourceUnit;
@@ -49,24 +29,28 @@ import org.codehaus.groovy.syntax.Types;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.codehaus.groovy.transform.AbstractASTTransformUtil.getInstanceNonPropertyFields;
-import static org.codehaus.groovy.transform.AbstractASTTransformUtil.getInstanceProperties;
-import static org.codehaus.groovy.transform.AbstractASTTransformUtil.hasDeclaredMethod;
+import static org.codehaus.groovy.transform.AbstractASTTransformUtil.*;
 
 /**
  * Handles generation of code for the @ToString annotation.
  *
  * @author Paul King
+ * @author Andre Steingress
  */
 @GroovyASTTransformation(phase = CompilePhase.CANONICALIZATION)
 public class ToStringASTTransformation extends AbstractASTTransformation {
 
     static final Class MY_CLASS = ToString.class;
+
     static final ClassNode MY_TYPE = ClassHelper.make(MY_CLASS);
     static final String MY_TYPE_NAME = "@" + MY_TYPE.getNameWithoutPackage();
+
     private static final ClassNode STRINGBUFFER_TYPE = ClassHelper.make(StringBuffer.class);
     private static final ClassNode INVOKER_TYPE = ClassHelper.make(InvokerHelper.class);
+
     private static final Token ASSIGN = Token.newSymbol(Types.ASSIGN, -1, -1);
+    private static final Token LOGICAL_OR = Token.newSymbol(Types.LOGICAL_OR, -1, -1);
+    private static final Token COMPARE_NOT_EQUAL = Token.newSymbol(Types.COMPARE_NOT_EQUAL, -1, -1);
 
     public void visit(ASTNode[] nodes, SourceUnit source) {
         init(nodes, source);
@@ -85,6 +69,8 @@ public class ToStringASTTransformation extends AbstractASTTransformation {
             boolean includeFields = memberHasValue(anno, "includeFields", true);
             List<String> excludes = tokenize((String) getMemberValue(anno, "excludes"));
             List<String> includes = tokenize((String) getMemberValue(anno, "includes"));
+            boolean ignoreNullValues = memberHasValue(anno, "ignoreNullValues", true);
+
             if (hasAnnotation(cNode, CanonicalASTTransformation.MY_TYPE)) {
                 AnnotationNode canonical = cNode.getAnnotations(CanonicalASTTransformation.MY_TYPE).get(0);
                 if (excludes == null || excludes.isEmpty()) excludes = tokenize((String) getMemberValue(canonical, "excludes"));
@@ -94,70 +80,115 @@ public class ToStringASTTransformation extends AbstractASTTransformation {
                 addError("Error during " + MY_TYPE_NAME + " processing: Only one of 'includes' and 'excludes' should be supplied not both.", anno);
             }
             toStringInit(cNode, new ConstantExpression(includeNames));
-            createToString(cNode, includeSuper, includeFields, excludes, includes);
+            createToString(cNode, includeSuper, includeFields, excludes, includes, ignoreNullValues);
         }
     }
 
     public static void createToString(ClassNode cNode, boolean includeSuper, boolean includeFields, List<String> excludes, List<String> includes) {
+        createToString(cNode, includeSuper, includeFields, excludes, includes, false);
+    }
+
+    public static void createToString(ClassNode cNode, boolean includeSuper, boolean includeFields, List<String> excludes, List<String> includes, boolean ignoreNullValues) {
         // make a public method if none exists otherwise try a private method with leading underscore
         boolean hasExistingToString = hasDeclaredMethod(cNode, "toString", 0);
         if (hasExistingToString && hasDeclaredMethod(cNode, "_toString", 0)) return;
 
         final BlockStatement body = new BlockStatement();
+
+        // def $toStringLocalVar = null
+        final VariableExpression localVar = new VariableExpression("$toStringLocalVar");
+        body.addStatement(new ExpressionStatement(new DeclarationExpression(localVar, ASSIGN, ConstantExpression.NULL)));
+
+        // def $toStringLocalVarFirst = true
+        final VariableExpression localVarFirst = new VariableExpression("$toStringLocalVarFirst");
+        body.addStatement(new ExpressionStatement(new DeclarationExpression(localVarFirst, ASSIGN, ConstantExpression.TRUE)));
+
         // def _result = new StringBuffer()
         final Expression result = new VariableExpression("_result");
         final Expression init = new ConstructorCallExpression(STRINGBUFFER_TYPE, MethodCallExpression.NO_ARGUMENTS);
         body.addStatement(new ExpressionStatement(new DeclarationExpression(result, ASSIGN, init)));
 
+        // <class_name>(
         body.addStatement(append(result, new ConstantExpression(cNode.getName())));
         body.addStatement(append(result, new ConstantExpression("(")));
-        boolean first = true;
+
+        // append properties, append fields, append super
         List<PropertyNode> pList = getInstanceProperties(cNode);
         for (PropertyNode pNode : pList) {
             if (shouldSkip(pNode.getName(), excludes, includes)) continue;
-            first = appendPrefix(cNode, body, result, first, pNode.getName());
             String getterName = "get" + Verifier.capitalize(pNode.getName());
             Expression getter = new MethodCallExpression(VariableExpression.THIS_EXPRESSION, getterName, MethodCallExpression.NO_ARGUMENTS);
-            body.addStatement(append(result, new StaticMethodCallExpression(INVOKER_TYPE, "toString", getter)));
+
+            assignExpressionToVar(body, localVar, getter);
+            appendValue(cNode, body, localVar, result, pNode.getName(), localVarFirst, ignoreNullValues);
         }
+
         List<FieldNode> fList = new ArrayList<FieldNode>();
         if (includeFields) {
             fList.addAll(getInstanceNonPropertyFields(cNode));
         }
         for (FieldNode fNode : fList) {
             if (shouldSkip(fNode.getName(), excludes, includes)) continue;
-            first = appendPrefix(cNode, body, result, first, fNode.getName());
-            body.addStatement(append(result, new StaticMethodCallExpression(INVOKER_TYPE, "toString", new VariableExpression(fNode))));
+
+            assignExpressionToVar(body, localVar, new VariableExpression(fNode));
+            appendValue(cNode, body, localVar, result, fNode.getName(), localVarFirst, ignoreNullValues);
         }
+
         if (includeSuper) {
-            appendPrefix(cNode, body, result, first, "super");
+            appendCommaIfNotFirst(result, localVarFirst, body);
+            appendPrefix(cNode, body, result, "super");
             // not through MOP to avoid infinite recursion
             body.addStatement(append(result, new MethodCallExpression(VariableExpression.SUPER_EXPRESSION, "toString", MethodCallExpression.NO_ARGUMENTS)));
         }
+
+        // )
         body.addStatement(append(result, new ConstantExpression(")")));
-        body.addStatement(new ReturnStatement(new MethodCallExpression(result, "toString", MethodCallExpression.NO_ARGUMENTS)));
+
+        // return result.toString()
+        body.addStatement(new ReturnStatement(new MethodCallExpression(result, "toString", ArgumentListExpression.EMPTY_ARGUMENTS)));
         cNode.addMethod(new MethodNode(hasExistingToString ? "_toString" : "toString", hasExistingToString ? ACC_PRIVATE : ACC_PUBLIC,
                 ClassHelper.STRING_TYPE, Parameter.EMPTY_ARRAY, ClassNode.EMPTY_ARRAY, body));
     }
 
-    private static boolean appendPrefix(ClassNode cNode, BlockStatement body, Expression result, boolean first, String name) {
-        if (first) {
-            first = false;
-        } else {
-            body.addStatement(append(result, new ConstantExpression(", ")));
-        }
+    private static void appendValue(ClassNode cNode, BlockStatement body, VariableExpression localVar, Expression memberList, String nodeName, VariableExpression localVarFirst, boolean ignoreNullValues) {
+        final BlockStatement ifBlock = new BlockStatement();
+        
+        final IfStatement ifNotNull = new IfStatement(
+                // if (!ignoreValues || (value != null))
+                new BooleanExpression(new BinaryExpression(new NotExpression(new ConstantExpression(ignoreNullValues)), LOGICAL_OR, new BinaryExpression(localVar, COMPARE_NOT_EQUAL, ConstantExpression.NULL))),
+                ifBlock, 
+                EmptyStatement.INSTANCE
+        );
+
+        appendCommaIfNotFirst(memberList, localVarFirst, ifBlock);
+        appendPrefix(cNode, ifBlock, memberList, nodeName);
+
+        ifBlock.addStatement(append(memberList, new StaticMethodCallExpression(INVOKER_TYPE, "toString", localVar)));
+        ifBlock.addStatement(new IfStatement(new BooleanExpression(localVarFirst), assignStatement(localVarFirst, ConstantExpression.FALSE), EmptyStatement.INSTANCE));
+
+        body.addStatement(ifNotNull);
+    }
+
+    private static void appendCommaIfNotFirst(Expression memberList, VariableExpression localVarFirst, BlockStatement statements) {
+        // if (!$toStringLocalVarFirst) result.append(", ");
+        statements.addStatement(new IfStatement(new NotExpression(localVarFirst), append(memberList, new ConstantExpression(", ")), EmptyStatement.INSTANCE));
+    }
+
+    private static void assignExpressionToVar(BlockStatement body, VariableExpression localVar, Expression expression) {
+        body.addStatement(assignStatement(localVar, expression));
+    }
+
+    private static void appendPrefix(ClassNode cNode, BlockStatement body, Expression result, String name) {
         body.addStatement(new IfStatement(
                 new BooleanExpression(new VariableExpression(cNode.getField("$print$names"))),
                 toStringPropertyName(result, name),
                 new EmptyStatement()
         ));
-        return first;
     }
 
     private static Statement toStringPropertyName(Expression result, String fName) {
         final BlockStatement body = new BlockStatement();
-        body.addStatement(append(result, new ConstantExpression(fName)));
-        body.addStatement(append(result, new ConstantExpression(":")));
+        body.addStatement(append(result, new ConstantExpression(fName + ":")));
         return body;
     }
 

--- a/src/test/groovy/inspect/swingui/AstNodeToScriptAdapterTest.groovy
+++ b/src/test/groovy/inspect/swingui/AstNodeToScriptAdapterTest.groovy
@@ -556,7 +556,7 @@ public class AstNodeToScriptAdapterTest extends GroovyTestCase {
 
         String result = compileToScript(script, CompilePhase.CANONICALIZATION)
         // we had problems with the ast transform passing a VariableExpression as StateMethodCallExpression arguments
-        assert result.contains('_result.append(org.codehaus.groovy.runtime.InvokerHelper.toStringthis.getWhen())')
+        assert result.contains('_result.append(org.codehaus.groovy.runtime.InvokerHelper.toString( $toStringLocalVar ))')
     }
 
     public void testAtImmutableClassWithProperties() {

--- a/src/test/org/codehaus/groovy/transform/ToStringTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/ToStringTransformTest.groovy
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2008-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.groovy.transform
+
+/**
+ * @author Andre Steingress
+ */
+class ToStringTransformTest extends GroovyShellTestCase {
+
+    void testSimpleToString() {
+        def toString = evaluate("""
+            import groovy.transform.ToString
+
+            @ToString
+            class Person {
+                String firstName
+                String surName
+            }
+
+            new Person(firstName: 'John', surName: 'Doe').toString()
+        """)
+
+        assertEquals("Person(John, Doe)", toString)
+    }
+
+    void testIgnoreNullValues() {
+        def toString = evaluate("""
+                import groovy.transform.ToString
+
+                @ToString(ignoreNullValues = true)
+                class Person {
+                    String firstName
+                    String surName
+                }
+
+                new Person(firstName: null, surName: 'Doe').toString()
+            """)
+
+        assertEquals("Person(Doe)", toString)
+
+        toString = evaluate("""
+                import groovy.transform.ToString
+
+                @ToString(ignoreNullValues = true)
+                class Person {
+                    String firstName
+                    String surName
+                }
+
+                new Person(firstName: null, surName: null).toString()
+            """)
+
+        assertEquals("Person()", toString)
+    }
+
+    void testIncludeFieldNamesAndIgnoreNullValues() {
+        def toString = evaluate("""
+                    import groovy.transform.ToString
+
+                    @ToString(includeNames = true, ignoreNullValues = true)
+                    class Person {
+                        String firstName
+                        String surName
+                    }
+
+                    new Person(firstName: null, surName: 'Doe').toString()
+                """)
+
+        assertEquals("Person(surName:Doe)", toString)
+    }
+
+    void testIncludeFieldNamesAndDoNotIgnoreNullValues() {
+        def toString = evaluate("""
+                        import groovy.transform.ToString
+
+                        @ToString(includeNames = true, ignoreNullValues = false)
+                        class Person {
+                            String firstName
+                            String surName
+                        }
+
+                        new Person(firstName:null, surName: 'Doe').toString()
+                    """)
+
+        assertEquals("Person(firstName:null, surName:Doe)", toString)
+    }
+
+    void testIncludeFieldsAndIgnoreNullValues() {
+        def toString = evaluate("""
+                            import groovy.transform.ToString
+
+                            @ToString(includeFields = true, includeNames = true, ignoreNullValues = true)
+                            class Person {
+                                String firstName
+                                String surName
+
+                                private age = 50
+                            }
+
+                            new Person(firstName:null, surName: 'Doe').toString()
+                        """)
+
+        assertEquals("Person(surName:Doe, age:50)", toString)
+    }
+
+    void testSuper()  {
+
+        def toString = evaluate("""
+            import groovy.transform.ToString
+
+            @ToString(ignoreNullValues = true, includeNames = true)
+            class HumanBeing {
+                Boolean female = null
+            }
+
+            @ToString(includeSuper=true)
+            class Person extends HumanBeing {
+                String firstName
+                String surName
+
+                private age = 50
+            }
+
+            new Person(firstName:null, surName: 'Doe').toString()
+        """)
+
+        assertEquals("Person(null, Doe, HumanBeing())", toString)
+    }
+
+    void testIgnoreStaticProperties()  {
+
+        def toString = evaluate("""
+                import groovy.transform.ToString
+
+                @ToString
+                class Person {
+                    static int humanBeings = 0
+                }
+
+                new Person().toString()
+            """)
+
+        assertEquals("Person()", toString)
+    }
+
+    void testWithCollection()  {
+
+        def toString = evaluate("""
+                    import groovy.transform.ToString
+
+                    @ToString(includeNames = true)
+                    class Person {
+                        def relatives = []
+                        def mates = [:]
+                    }
+
+                    new Person(relatives: ['a', 'b', 'c'], mates: [friends: ['c', 'd', 'e']]).toString()
+                """)
+
+        assertEquals("Person(relatives:[a, b, c], mates:[friends:[c, d, e]])", toString)
+    }
+
+    void testExcludesAndIgnoreNullValues()  {
+
+        def toString = evaluate("""
+                        import groovy.transform.ToString
+
+                        @ToString(excludes = 'surName', ignoreNullValues = true)
+                        class Person {
+                            String surName
+                        }
+
+                        new Person(surName: 'Doe').toString()
+                    """)
+
+        assertEquals("Person()", toString)
+    }
+
+    void testIncludesAndIgnoreNullValues()  {
+
+        def toString = evaluate("""
+                            import groovy.transform.ToString
+
+                            @ToString(includes = 'surName', ignoreNullValues = true)
+                            class Person {
+                                String surName
+                            }
+
+                            new Person(surName: null).toString()
+                        """)
+
+        assertEquals("Person()", toString)
+    }
+
+    void testSkipInternalProperties()  {
+
+        def toString = evaluate("""
+                            import groovy.transform.ToString
+
+                            @ToString(includeFields = true)
+                            class Person {
+                                private String \$surName = 'Doe'
+                            }
+
+                            new Person().toString()
+                            """)
+
+        assertEquals("Person()", toString)
+    }
+}


### PR DESCRIPTION
this patch adds the "ignoreNullValues" annotation parameter to @ToString. In order to check properties and/or fields for null values, another (hidden) local variable had to be introduced. In addition, I added a test case for testing @ToString in general, not restricted to ignoreNullValues.
