### PR TITLE
GROOVY-3388: GroovyASTTransformation phase must be SEMANTIC_ANALYSIS or ...

### DIFF
--- a/src/test/org/codehaus/groovy/transform/LocalASTTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/LocalASTTransformTest.groovy
@@ -1,0 +1,98 @@
+package org.codehaus.groovy.transform
+
+import org.codehaus.groovy.control.CompilationFailedException
+
+/**
+ * @author Andre Steingress
+ */
+class LocalASTTransformTest extends GroovyShellTestCase {
+
+    void testVerifyCompilePhaseBeforeSemanticAnalysisWithStringClassName()  {
+        def gcl = new GroovyClassLoader()
+
+        gcl.parseClass """
+            package org.codehaus.groovy.transform
+
+            import java.lang.annotation.Retention
+            import java.lang.annotation.RetentionPolicy
+            import java.lang.annotation.Target
+            import java.lang.annotation.ElementType
+
+            @Retention(RetentionPolicy.RUNTIME)
+            @Target([ElementType.TYPE])
+            @GroovyASTTransformationClass("org.codehaus.groovy.transform.LocalTransformASTTransformation")
+            public @interface LocalTransform {}
+        """
+
+        gcl.parseClass """
+            package org.codehaus.groovy.transform
+
+            import org.codehaus.groovy.control.CompilePhase
+
+            @GroovyASTTransformation(phase = CompilePhase.CONVERSION)
+            public class LocalTransformASTTransformation extends AbstractASTTransformation {
+                void visit(org.codehaus.groovy.ast.ASTNode[] nodes, org.codehaus.groovy.control.SourceUnit source) {}
+            }
+        """
+
+        shouldFail CompilationFailedException, {
+            gcl.parseClass """
+                import org.codehaus.groovy.transform.*
+
+                @LocalTransform class Test {}
+            """
+        }
+    }
+
+    void testVerifyCompilePhaseBeforeSemanticAnalysisWithClassReference()  {
+        def gcl = new GroovyClassLoader()
+
+        gcl.parseClass """
+                package org.codehaus.groovy.transform
+
+                import org.codehaus.groovy.control.CompilePhase
+
+                @GroovyASTTransformation(phase = CompilePhase.CONVERSION)
+                public class LocalTransformASTTransformation1 extends AbstractASTTransformation {
+                    void visit(org.codehaus.groovy.ast.ASTNode[] nodes, org.codehaus.groovy.control.SourceUnit source) {}
+                }
+            """
+
+        gcl.parseClass """
+                        package org.codehaus.groovy.transform
+
+                        import org.codehaus.groovy.control.CompilePhase
+
+                        @GroovyASTTransformation(phase = CompilePhase.CONVERSION)
+                        public class LocalTransformASTTransformation2 extends AbstractASTTransformation {
+                            void visit(org.codehaus.groovy.ast.ASTNode[] nodes, org.codehaus.groovy.control.SourceUnit source) {}
+                        }
+                    """
+
+        gcl.parseClass """
+                package org.codehaus.groovy.transform
+
+                import java.lang.annotation.Retention
+                import java.lang.annotation.RetentionPolicy
+                import java.lang.annotation.Target
+                import java.lang.annotation.ElementType
+
+                @Retention(RetentionPolicy.RUNTIME)
+                @Target([ElementType.TYPE])
+                @GroovyASTTransformationClass(classes = [org.codehaus.groovy.transform.LocalTransformASTTransformation1, org.codehaus.groovy.transform.LocalTransformASTTransformation2])
+                public @interface LocalTransform {}
+            """
+
+        shouldFail CompilationFailedException, {
+            gcl.parseClass """
+                    import org.codehaus.groovy.transform.*
+
+                    @LocalTransform class Test {}
+                """
+        }
+    }
+}
+
+
+
+


### PR DESCRIPTION
...later for usage

The ASTTransformationCollectorCodeVisitor already does some basic verification of the supplied GroovyASTTransformationClass class(es). This patch extends that check as it triggers a compiler error whenever a local AST transformation with a phase < SEMANTIC_ANALYSIS is specified. 

Up to now, this error has simply been ignored and the AST transformation has not been applied.
