### PR TITLE
added failure if catched exception does not have a cause in shouldFailWi...

### DIFF
--- a/subprojects/groovy-test/src/main/java/groovy/util/GroovyTestCase.java
+++ b/subprojects/groovy-test/src/main/java/groovy/util/GroovyTestCase.java
@@ -288,6 +288,8 @@ public class GroovyTestCase extends TestCase {
             orig = e;
             th = orig.getCause();
         }
+        
+        if (orig != null && th == null) fail("Catched exception does not have a cause (indicates that the cause is nonexistent or unknown). Maybe you should use 'shouldFail' instead?");
 
         while (th != null && !clazz.isInstance(th) && th != th.getCause() && level < MAX_NESTED_EXCEPTIONS) {
             th = th.getCause();

--- a/subprojects/groovy-test/src/test/groovy/GroovyTestCaseTest.groovy
+++ b/subprojects/groovy-test/src/test/groovy/GroovyTestCaseTest.groovy
@@ -1,10 +1,10 @@
-
+import junit.framework.AssertionFailedError
 
 /**
-    Testing the notYetImplemented feature of GroovyTestCase.
-    Todo: testing all other features.
-    @author Dierk Koenig
-*/
+ Testing the notYetImplemented feature of GroovyTestCase.
+ Todo: testing all other features.
+ @author Dierk Koenig
+ */
 
 class GroovyTestCaseTest extends GroovyTestCase {
 
@@ -50,6 +50,16 @@ class GroovyTestCaseTest extends GroovyTestCase {
         shouldFail(MyException) {
             new Foo().createBarWithNestedException()
         }
+    }
+
+    void testShouldFailWithCause() {
+        def msg = shouldFail(AssertionFailedError) {
+            shouldFailWithCause(Exception) {
+                throw new Exception()
+            }
+        }
+
+        assertEquals "Catched exception does not have a cause (indicates that the cause is nonexistent or unknown). Maybe you should use 'shouldFail' instead?", msg
     }
 }
 


### PR DESCRIPTION
...thCause

as discussed in the mailing list:

http://groovy.329449.n5.nabble.com/Question-regarding-GroovyTestCase-shouldFailWithCause-tt5507648.html

adds a more concrete AssertionFailed message when an exception occurs with an empty clause.
