### PR TITLE
Add package-list file for groovy-jdk API documentation

### DIFF
--- a/src/tools/org/codehaus/groovy/tools/DocGenerator.groovy
+++ b/src/tools/org/codehaus/groovy/tools/DocGenerator.groovy
@@ -109,7 +109,13 @@ class DocGenerator {
         out.withWriter {
             it << templateOverviewFrame.make(binding)
         }
-
+        
+        // the package list
+        out = new File(outputFolder, 'package-list')
+        out.withWriter { writer ->
+            packages.keySet().findAll{ it }.each{ writer.println it }
+        }
+        
         // the allclasses-frame.html
         def templateAllClasses = createTemplate(engine, 'template.allclasses-frame.html')
         out = new File(outputFolder, 'allclasses-frame.html')


### PR DESCRIPTION
In order to allow API documentation generator to rely on this website for their external links.
See http://docs.oracle.com/javase/1.3/docs/tooldocs/win32/javadoc.html#package-list
