### PR TITLE
added json as implicit variable of type JsonBuilder to groovlets

### DIFF
--- a/src/main/groovy/servlet/ServletBinding.java
+++ b/src/main/groovy/servlet/ServletBinding.java
@@ -17,6 +17,7 @@ package groovy.servlet;
 
 import groovy.lang.Binding;
 import groovy.xml.MarkupBuilder;
+import groovy.json.JsonBuilder;
 
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletContext;
@@ -57,6 +58,7 @@ import java.util.Map;
  * <li><tt>"out"</tt> : <code>response.getWriter()</code></li>
  * <li><tt>"sout"</tt> : <code>response.getOutputStream()</code></li>
  * <li><tt>"html"</tt> : <code>new MarkupBuilder(response.getWriter())</code> - <code>expandEmptyElements</code> flag is set to true</li>
+ * <li><tt>"json"</tt> : <code>new JsonBuilder()</code></li>
  * </ul>
  * As per the Servlet specification, a call to <code>response.getWriter()</code> should not be
  * done if a call to <code>response.getOutputStream()</code> has already occurred or the other way
@@ -271,6 +273,7 @@ public class ServletBinding extends Binding {
         excludeReservedName(name, "out");
         excludeReservedName(name, "sout");
         excludeReservedName(name, "html");
+		excludeReservedName(name, "json");
         excludeReservedName(name, "forward");
         excludeReservedName(name, "include");
         excludeReservedName(name, "redirect");
@@ -303,7 +306,9 @@ public class ServletBinding extends Binding {
         MarkupBuilder builder = new MarkupBuilder(output.getWriter());
         builder.setExpandEmptyElements(true);
         super.setVariable("html", builder);
-        
+		JsonBuilder jsonBuilder = new JsonBuilder();
+        super.setVariable("json", jsonBuilder);
+
         // bind forward method
         MethodClosure c = new MethodClosure(this, "forward");
         super.setVariable("forward", c);

--- a/src/test/groovy/servlet/ServletBindingTest.groovy
+++ b/src/test/groovy/servlet/ServletBindingTest.groovy
@@ -137,7 +137,7 @@ class ServletBindingTest extends GroovyTestCase {
     void testGetVariables_Contract() {
 
         def expectedVariables = ["request", "response", "context", "application",
-                "session", "params", "headers", "out", "sout", "html"]
+                "session", "params", "headers", "out", "sout", "html", "json"]
         def request = makeDefaultRequest()
         def binding = makeDefaultBinding(request)
         def keys = binding.variables.keySet()
@@ -169,6 +169,7 @@ class ServletBindingTest extends GroovyTestCase {
         assert binding.getVariable("out") instanceof PrintWriter
         assert binding.getVariable("html") instanceof groovy.xml.MarkupBuilder
         assert binding.getVariable("sout") instanceof ServletOutputStream
+		assert binding.getVariable("json") instanceof groovy.json.JsonBuilder
     }
     
     void testOutSoutWriteException() {
@@ -190,6 +191,7 @@ class ServletBindingTest extends GroovyTestCase {
 
         binding.out.print("foo")
         binding.html.foo()
+		binding.out.print(binding.json.foo())
         shouldFail(IllegalStateException) {
             binding.sout.print("foo")
         }
@@ -234,6 +236,7 @@ class ServletBindingTest extends GroovyTestCase {
         shouldFail(IllegalArgumentException) { binding.setVariable("out", null) }
         shouldFail(IllegalArgumentException) { binding.setVariable("sout", null) }
         shouldFail(IllegalArgumentException) { binding.setVariable("html", null) }
+		shouldFail(IllegalArgumentException) { binding.setVariable("json", null) }
     }
 
     /**


### PR DESCRIPTION
groovlets have long had an implicit object of type MarkupBuilder called html, which is useful for writing out XML representations of objects. A similar object called json, of type groovy.json.JsonBuilder, was added to ServletBinding so that it is available in groovlets.

Unlike MarkupBuilder, JsonBuilder only serializes its output but does not write it to the output writer. Expected usage, therefore, will be to use the builder and then use "out << json" or "print json" to write the result to the response.

https://jira.codehaus.org/browse/GROOVY-5341
