### PR TITLE
GROOVY-4946 Groovy getAt cannot be used with lazily initialized lists

### DIFF
--- a/src/main/groovy/lang/ListWithDefault.java
+++ b/src/main/groovy/lang/ListWithDefault.java
@@ -1,0 +1,201 @@
+package groovy.lang;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+
+/**
+ * A wrapper for {@link List} which automatically grows by calling {@link #get(int)} or {@link #getAt(int)} with
+ * an index greater or equal to {@code size()}.
+ *
+ * @author Andre Steingress
+ * @since TODO
+ */
+public final class ListWithDefault<T> implements List<T> {
+
+    private final List<T> delegate;
+    private final boolean lazyDefaultValues;
+
+    private final Closure initClosure;
+
+    private ListWithDefault(List<T> items, boolean lazyDefaultValues, Closure initClosure)  {
+        this.delegate = items;
+        this.lazyDefaultValues = lazyDefaultValues;
+        this.initClosure = initClosure;
+    }
+
+    public static <T> List<T> newInstance(List<T> items, boolean lazyDefaultValues, Closure initClosure) {
+        if (items == null)
+            throw new IllegalArgumentException("Parameter \"items\" must not be null");
+        if (initClosure == null)
+            throw new IllegalArgumentException("Parameter \"initClosure\" must not be null");
+
+        return new ListWithDefault<T>(items, lazyDefaultValues, initClosure);
+    }
+
+    public int size() {
+        return delegate.size();
+    }
+
+    public boolean isEmpty() {
+        return delegate.isEmpty();
+    }
+
+    public boolean contains(Object o) {
+        return delegate.contains(o);
+    }
+
+    public Iterator<T> iterator() {
+        return delegate.iterator();
+    }
+
+    public Object[] toArray() {
+        return delegate.toArray();
+    }
+
+    public <T> T[] toArray(T[] ts) {
+        return delegate.toArray(ts);
+    }
+
+    public boolean add(T t) {
+        return delegate.add(t);
+    }
+
+    public boolean remove(Object o) {
+        return delegate.remove(o);
+    }
+
+    public boolean containsAll(Collection<?> objects) {
+        return delegate.containsAll(objects);
+    }
+
+    public boolean addAll(Collection<? extends T> ts) {
+        return delegate.addAll(ts);
+    }
+
+    public boolean addAll(int i, Collection<? extends T> ts) {
+        return delegate.addAll(i, ts);
+    }
+
+    public boolean removeAll(Collection<?> objects) {
+        return delegate.removeAll(objects);
+    }
+
+    public boolean retainAll(Collection<?> objects) {
+        return delegate.retainAll(objects);
+    }
+
+    public void clear() {
+        delegate.clear();
+    }
+
+    /**
+     * Overwrites subscript operator handling by redirecting to {@link #get(int)}.
+     * 
+     * @param index an index (might be greater or equal to {@code size()}, or smaller than 0)
+     * @return the value at the given {@code index} or the default value
+     */
+    public T getAt(int index)  {
+        return get(index);
+    }
+
+    /**
+     * Implements the "lazy list" approach. If the requested {@code index} is greater or equal to {@code size()}, the
+     * list will grow to the new size. This implementation breaks
+     * the contract of {@link java.util.List#get(int)} as it a) possibly modifies the underlying list and b) does
+     * NOT throw an {@link IndexOutOfBoundsException} when {@code index < 0 || index >= size()}.
+     *
+     * @param index an index (might be greater or equal to {@code size()}, or smaller than 0)
+     * @return the value at the given {@code index} or the default value
+     */
+    public T get(int index) {
+
+        final int size = size();
+        int normalisedIndex = normaliseIndex(index, size);
+
+        // either index >= size or the normalised index is negative
+        if (normalisedIndex >= size || normalisedIndex < 0)  {
+            final boolean prepend = (normalisedIndex < 0);
+            // find out the number of gaps to fill with null/the default value
+            final int gapCount = (prepend ? ((normalisedIndex + 1) * -1) : normalisedIndex - size);
+
+            // fill all gaps
+            for (int i = 0; i < gapCount; i++)  {
+                final int idx = prepend ? 0 : size();
+
+                // if we lazily create default values, use 'null' as placeholder
+                if (lazyDefaultValues)
+                    delegate.add(idx, null);
+                else
+                    delegate.add(idx, getDefaultValue(idx));
+            }
+
+            // add the first/last element being always the default value
+            final int idx = prepend ? 0 : normalisedIndex;
+            delegate.add(idx, getDefaultValue(idx));
+
+            // normalise index again to get positive index
+            normalisedIndex = normaliseIndex(index, size());
+        }
+
+        T item = delegate.get(normalisedIndex);
+        if (item == null)  {
+            item = getDefaultValue(normalisedIndex);
+            delegate.set(normalisedIndex, item);
+        }
+
+        return item;
+    }
+
+    private T getDefaultValue(int idx) {
+        return (T) initClosure.call(new Object[] { idx });
+    }
+
+    private int normaliseIndex(int index, int size) {
+        if (index < 0) {
+            index += size;
+        }
+        return index;
+    }
+
+    public T set(int i, T t) {
+        return delegate.set(i, t);
+    }
+
+    public void add(int i, T t) {
+        delegate.add(i, t);
+    }
+
+    public T remove(int i) {
+        return delegate.remove(i);
+    }
+
+    public int indexOf(Object o) {
+        return delegate.indexOf(o);
+    }
+
+    public int lastIndexOf(Object o) {
+        return delegate.lastIndexOf(o);
+    }
+
+    public ListIterator<T> listIterator() {
+        return delegate.listIterator();
+    }
+
+    public ListIterator<T> listIterator(int i) {
+        return delegate.listIterator(i);
+    }
+
+    /**
+     * Returns a view of a portion of this list. This method returns a list with the same
+     * lazy list settings as the original list.
+     *
+     * @param fromIndex low endpoint of the subList (inclusive)
+     * @param toIndex upper endpoint of the subList (exclusive)
+     * @return a view of a specified range within this list, keeping all lazy list settings
+     */
+    public List<T> subList(int fromIndex, int toIndex) {
+        return new ListWithDefault<T>(delegate.subList(fromIndex, toIndex), lazyDefaultValues, (Closure) initClosure.clone());
+    }
+}

--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -102,6 +102,7 @@ import java.util.regex.Pattern;
  * @author Cedric Champeau
  * @author Tim Yates
  * @author Dinko Srkoc
+ * @author Andre Steingress
  */
 public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
 
@@ -5291,6 +5292,81 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      */
     public static <K, V> Map<K, V> withDefault(Map<K, V> self, Closure init) {
         return MapWithDefault.newInstance(self, init);
+    }
+
+    /**
+     * Wraps a list using the delegate pattern with a wrapper that intercepts all calls
+     * to <code>getAt(index)</code> and <code>get(index)</code>. If an index greater or equal
+     * than size is used, the list will grow automatically up to the specified index. Gaps
+     * will be filled by {@code null}.
+     *
+     * Example usage:
+     * <pre class="groovyTestCase">
+     * def list = [0,1].withDefault{ 42 }
+     * assert list[0] == 0
+     * assert list[1] == 1
+     *
+     * assert list[3] == 42   // default value
+     * assert list[2] == null // gap filled with null
+     * </pre>
+     *
+     * @param self a List
+     * @param init a Closure which generates the default value and that is passed the target index
+     * @return the wrapped List
+     * @since TODO
+     */
+    public static <T> List<T> withDefault(List<T> self, Closure init)  {
+        return withLazyDefault(self, init);
+    }
+
+    /**
+     * Wraps a list using the delegate pattern with a wrapper that intercepts all calls
+     * to <code>getAt(index)</code> and <code>get(index)</code>. If an index greater or equal
+     * than size is used, the list will grow automatically up to the specified index. Gaps
+     * will be filled by {@code null}.
+     *
+     * Example usage:
+     * <pre class="groovyTestCase">
+     * def list = [0,1].withDefault{ 42 }
+     * assert list[0] == 0
+     * assert list[1] == 1
+     *
+     * assert list[3] == 42   // default value
+     * assert list[2] == null // gap filled with null
+     * </pre>
+     *
+     * @param self a List
+     * @param init a Closure which generates the default value and that is passed the target index
+     * @return the wrapped List
+     * @since TODO
+     */
+    public static <T> List<T> withLazyDefault(List<T> self, Closure init)  {
+        return ListWithDefault.newInstance(self, true, init);
+    }
+
+    /**
+     * Wraps a list using the delegate pattern with a wrapper that intercepts all calls
+     * to <code>getAt(index)</code> and <code>get(index)</code>. If an index greater or equal
+     * than size is used, the list will grow automatically up to the specified index. Gaps
+     * will be filled by the closure generated default value.
+     *
+     * Example usage:
+     * <pre class="groovyTestCase">
+     * def list = [0,1].withDefault(false), { 42 }
+     * assert list[0] == 0
+     * assert list[1] == 1
+     *
+     * assert list[3] == 42   // default value
+     * assert list[2] == 42   // gap filled with default value
+     * </pre>
+     *
+     * @param self a List
+     * @param init a Closure which generates the default value and that is passed the target index
+     * @return the wrapped List
+     * @since TODO
+     */
+    public static <T> List<T> withEagerDefault(List<T> self, Closure init)  {
+        return ListWithDefault.newInstance(self, false, init);
     }
 
     /**

--- a/src/test/groovy/ListTest.groovy
+++ b/src/test/groovy/ListTest.groovy
@@ -432,4 +432,122 @@ class ListTest extends GroovyTestCase {
             immlist[0] = 1
         }
     }
+
+    // GROOVY-4946
+    void testWithLazyDefault() {
+        def l1 = [].withLazyDefault { 42 }
+        assert l1[0] == 42
+        assert l1[2] == 42
+        assert l1 == [42, null, 42]
+
+        assert l1[1] == 42
+
+        assert l1[-1] == 42
+        assert l1[-3] == 42
+
+        def l2 = [].withLazyDefault { 42 }
+        assert l2[-1] == 42
+        assert l2.size() == 1
+        assert l2[0]  == 42
+
+        def l3 = [].withLazyDefault { it }
+        assert l3[-1] == 0
+        assert l3[1]  == 1
+        assert l3[3]  == 3
+
+        def l5 = [0,1,null,3].withLazyDefault { 42 }
+        assert l5[0] == 0
+        assert l5[1] == 1
+        assert l5[3] == 3
+        assert l5 == [0,1,null,3]
+
+        def l8 = [].withLazyDefault { it }
+        assert l8[-1] == 0
+        assert l8[1]  == 1
+        assert l8[3]  == 3
+        assert l8[5]  == 5
+        assert l8 == [0,1,null,3,null,5]
+
+        def l9 = [].withLazyDefault { int index -> index }
+        assert l9[-1] == 0
+        assert l9[1]  == 1
+        assert l9[3]  == 3
+        assert l9[5]  == 5
+
+        assert l9[0..5] == [0, 1, null, 3, null, 5]
+    }
+
+    void testWithEagerDefault() {
+
+        def l1 = [].withEagerDefault { 42 }
+        assert l1[0] == 42
+        assert l1[2] == 42
+        assert l1 == [42, 42, 42]
+
+        assert l1[1] == 42
+        assert l1[-1] == 42
+        assert l1[-3] == 42
+
+        def l2 = [].withEagerDefault { 42 }
+        assert l2[-1] == 42
+        assert l2.size() == 1
+        assert l2[0]  == 42
+
+        def l3 = [].withEagerDefault { it }
+        assert l3[-1] == 0
+        assert l3[1]  == 1
+        assert l3[3]  == 3
+
+        assert l3 == [0,1,2,3]
+
+        def l5 = [0,1,null,3].withEagerDefault { 42 }
+        assert l5[0] == 0
+        assert l5[1] == 1
+        assert l5[3] == 3
+        assert l5 == [0,1,null,3]
+
+        def l8 = [].withEagerDefault { it }
+        assert l8[-1] == 0
+        assert l8[1]  == 1
+        assert l8[3]  == 3
+        assert l8[5]  == 5
+        assert l8 == [0,1,2,3,4,5]
+
+        def l9 = [].withEagerDefault { int index -> index }
+        assert l9[-1] == 0
+        assert l9[1]  == 1
+        assert l9[3]  == 3
+        assert l9[5]  == 5
+
+        assert l9[0..5] == [0, 1, 2, 3, 4, 5]
+
+    }
+
+    void testWithDefaultReturnWithDefaultSubList() {
+
+        def l1 = [].withLazyDefault { 42 }
+        assert l1[2] == 42
+        assert l1.size() == 3
+
+        def l2 = l1.subList(0, 2)
+        assert l2.size() == 2
+        assert l2 == [null, null]
+        assert l2[2] == 42
+        assert l2 == [null, null, 42]
+    }
+    
+    void testWithDefaultRedirectsToWithLazyDefault()  {
+        
+        def l1 = [].withDefault { 42 }
+        assert l1[2] == 42
+        assert l1 == [null, null, 42]
+        
+    }
+    
+    void testWithDefaultNullAsDefaultValue() {
+        def l1 = [].withEagerDefault { null }
+        assert l1[0] == null
+        assert l1[2] == null
+        assert l1 == [null, null, null]
+    }
 }


### PR DESCRIPTION
Hi,

This commit fixes GROOVY-4946 by adding a List.withDefault to DGM. As done by Commons LazyList a list created with 

```
[].withDefault { 42 }
```

automatically grows when get(index) or getAt(index) is called. Gaps will be filled wither either null or the default value (in the case above, 42).

Please note: `@since` has to be filled out accordingly in the javadoc 

Cheers, André 
