### PR TITLE
fixed GROOVY-5408: JavaAwareCompilationUnit should have a constructor th...

### DIFF
--- a/src/main/org/codehaus/groovy/tools/javac/JavaAwareCompilationUnit.java
+++ b/src/main/org/codehaus/groovy/tools/javac/JavaAwareCompilationUnit.java
@@ -47,11 +47,16 @@ public class JavaAwareCompilationUnit extends CompilationUnit {
     private boolean keepStubs;
 
     public JavaAwareCompilationUnit(CompilerConfiguration configuration) {
-        this(configuration,null);
+        this(configuration,null,null);
     }
 
     public JavaAwareCompilationUnit(CompilerConfiguration configuration, GroovyClassLoader groovyClassLoader) {
-        super(configuration,null,groovyClassLoader);
+        this(configuration,groovyClassLoader,null);
+    }
+
+    public JavaAwareCompilationUnit(CompilerConfiguration configuration, GroovyClassLoader groovyClassLoader,
+                                    GroovyClassLoader transformClassLoader) {
+        super(configuration,null,groovyClassLoader,transformClassLoader);
         javaSources = new LinkedList<String>();
         Map options = configuration.getJointCompilationOptions();
         generationGoal = (File) options.get("stubDir");


### PR DESCRIPTION
...at allows to set transformLoader
