### PR TITLE
removed static class reference from builtin AST transform implementation...

### DIFF
--- a/subprojects/groovy-test/src/main/java/org/codehaus/groovy/transform/NotYetImplementedASTTransformation.java
+++ b/subprojects/groovy-test/src/main/java/org/codehaus/groovy/transform/NotYetImplementedASTTransformation.java
@@ -41,7 +41,7 @@ import java.util.Arrays;
 public class NotYetImplementedASTTransformation extends AbstractASTTransformation {
 
     private static final ClassNode CATCHED_THROWABLE_TYPE = ClassHelper.make(Throwable.class);
-    private static final ClassNode ASSERTION_FAILED_ERROR_TYPE = ClassHelper.make(AssertionFailedError.class);
+    private static final ClassNode ASSERTION_FAILED_ERROR_TYPE = ClassHelper.make("junit.framework.AssertionFailedError");
 
     public void visit(ASTNode[] nodes, SourceUnit source) {
         if (nodes.length != 2 || !(nodes[0] instanceof AnnotationNode) || !(nodes[1] instanceof AnnotatedNode)) {


### PR DESCRIPTION
... class to third-party class junit.framework.AssertionFailedError
- this solves a class loading error for compiler environments (like Gradle) which separate class loading of the compiler from that of the compile class path

I reviewed all other Groovy-provided transforms and this is the only one that has this problem (at least before modularization, but probably also after). If the goal is for users not to have to think about such class loading details (which I think is a fair assumption), then Groovy-provided transform implementations shouldn't statically reference classes outside their own Jar and the JDK.
