### PR TITLE
compare Boolean compiler optimization flags with equals() rather than ==

### DIFF
--- a/src/main/org/codehaus/groovy/classgen/asm/WriterController.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/WriterController.java
@@ -76,12 +76,12 @@ public class WriterController {
         boolean invokedynamic=false;
         if (optOptions.isEmpty()) {
             // IGNORE
-        } else if (optOptions.get("all")==Boolean.FALSE) {
+        } else if (Boolean.FALSE.equals(optOptions.get("all"))) {
             optimizeForInt=false;
             // set other optimizations options to false here
         } else {
-            if (optOptions.get("indy")==Boolean.TRUE) invokedynamic=true;
-            if (optOptions.get("int")==Boolean.FALSE) optimizeForInt=false;
+            if (Boolean.TRUE.equals(optOptions.get("indy"))) invokedynamic=true;
+            if (Boolean.FALSE.equals(optOptions.get("int"))) optimizeForInt=false;
             // set other optimizations options to false here
         }
         this.classNode = cn;

--- a/src/main/org/codehaus/groovy/control/CompilationUnit.java
+++ b/src/main/org/codehaus/groovy/control/CompilationUnit.java
@@ -805,7 +805,7 @@ public class CompilationUnit extends ProcessingUnit {
     protected ClassVisitor createClassVisitor() {
         CompilerConfiguration config = getConfiguration();
         int computeMaxStackAndFrames = ClassWriter.COMPUTE_MAXS;
-        if (config.getOptimizationOptions().get("indy")==Boolean.TRUE) {
+        if (Boolean.TRUE.equals(config.getOptimizationOptions().get("indy"))) {
             computeMaxStackAndFrames += ClassWriter.COMPUTE_FRAMES;
         }
         return new ClassWriter(computeMaxStackAndFrames) {


### PR DESCRIPTION
- otherwise the comparisons might not work, for example when optimizationOptions map is serialized/deserialized (this happened in Gradle and took me a long time to find)
