### PR TITLE
Groovy 2 0 0 rc x

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -363,9 +363,10 @@ task compilerDgmConverter(type: JavaExec) {
     description = 'Generates DGM info file for the bootstrap compiler'
     classpath = files(file('target/classes/compiler')) + configurations.compilerCompile
     main = 'org.codehaus.groovy.tools.DgmConverter'
-    args = ['--info', 'target/classes/compiler']
+    ext.compilerDirPath = file('target/classes/compiler').absolutePath
+    args = ['--info', compilerDirPath]
     doFirst {
-        new File('target/classes/compiler/META-INF').mkdirs()
+        file('target/classes/compiler/META-INF').mkdirs()
     }
 }
 


### PR DESCRIPTION
The groovy + grails joint build is failing and I think this commit helps.  The problem is a relative path was being given to the DgmConverter.  That relative path works if the current working directory happens to be the top of the groovy development workspace, which is not the case in the groovy + grails joint build.
