### PR TITLE
GROOVY-5508: enable generated property methods to be checked for covaria...

### DIFF
--- a/src/main/org/codehaus/groovy/classgen/Verifier.java
+++ b/src/main/org/codehaus/groovy/classgen/Verifier.java
@@ -169,8 +169,8 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
         addInitialization(node);
         checkReturnInObjectInitializer(node.getObjectInitializerStatements());
         node.getObjectInitializerStatements().clear();
-        addCovariantMethods(node);
         node.visitContents(this);
+        addCovariantMethods(node);
     }
 
     private FieldNode checkFieldDoesNotExist(ClassNode node, String fieldName) {

--- a/src/test/groovy/sql/SqlTest.groovy
+++ b/src/test/groovy/sql/SqlTest.groovy
@@ -172,7 +172,7 @@ class SqlTest extends GroovyTestCase {
 }
 
 class SqlSubclass extends Sql {
-    def connection
+    Connection connection
 
     SqlSubclass(Sql base) {
         super(base)


### PR DESCRIPTION
To fix the issue in GROOVY-5508 achange of the order of the methods for checking covariants and visiting the fields and properties of the class in the Verifier has to be done. This change is intended for after Groovy 2.0
