### PR TITLE
GROOVY-5494

### DIFF
--- a/src/main/groovy/json/JsonOutput.groovy
+++ b/src/main/groovy/json/JsonOutput.groovy
@@ -18,6 +18,7 @@ package groovy.json
 import static JsonTokenType.*
 import java.text.SimpleDateFormat
 import java.text.DateFormat
+import org.codehaus.groovy.runtime.DefaultGroovyMethods
 
 /**
  * Class responsible for the actual String serialization of the possible values of a JSON structure.
@@ -127,7 +128,7 @@ class JsonOutput {
         } else if (object instanceof Enum) {
             '"' + object.name() + '"'
         } else {
-            def properties = object.properties
+            def properties = DefaultGroovyMethods.getProperties(object)
             properties.remove('class')
             properties.remove('declaringClass')
             properties.remove('metaClass')

--- a/src/test/groovy/json/JsonOutputTest.groovy
+++ b/src/test/groovy/json/JsonOutputTest.groovy
@@ -306,6 +306,17 @@ class JsonOutputTest extends GroovyTestCase {
         m.a = 1
         assert toJson(m) == '{"a":1}'
     }
+
+	void testObjectWithDeclaredPropertiesField() {
+		def person = new JsonObject(name: "pillow", properties: [state: "fluffy", color: "white"])
+		def json = toJson(person)
+		assert json == '{"properties":{"state":"fluffy","color":"white"},"name":"pillow"}'
+	}
+	
+	void testGROOVY5494() {
+		def json = toJson(new JsonFoo(name: "foo"))
+		assert json == '{"properties":0,"name":"foo"}'
+	}
 }
 
 @Canonical
@@ -324,6 +335,16 @@ class JsonDistrict {
 class JsonStreet {
     String streetName
     JsonStreetKind kind
+}
+
+class JsonObject {
+	String name
+	Map properties
+}
+
+class JsonFoo {
+	String name
+	int getProperties() { return 0 }
 }
 
 enum JsonStreetKind {


### PR DESCRIPTION
`JsonOutput.toJson()` does not work for objects declaring `properties` field or defining `getProperties()` method.
