### PR TITLE
GROOVY-4791: SimpleTemplateEngine class has side effects

### DIFF
--- a/subprojects/groovy-templates/src/main/java/groovy/text/SimpleTemplateEngine.java
+++ b/subprojects/groovy-templates/src/main/java/groovy/text/SimpleTemplateEngine.java
@@ -24,6 +24,7 @@ import java.io.Reader;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Map;
+import java.util.LinkedHashMap;
 
 import org.codehaus.groovy.control.CompilationFailedException;
 import org.codehaus.groovy.runtime.InvokerHelper;
@@ -155,10 +156,12 @@ public class SimpleTemplateEngine extends TemplateEngine {
                  */
                 public Writer writeTo(Writer writer) {
                     Binding binding;
-                    if (map == null)
+                    if (map == null) {
                         binding = new Binding();
-                    else
-                        binding = new Binding(map);
+                    } else {
+                        // Binding modifies the Map object so a copy is made to avoid polluting the caller's instance
+                        binding = new Binding(new LinkedHashMap(map));
+                    }
                     Script scriptObject = InvokerHelper.createScript(script.getClass(), binding);
                     PrintWriter pw = new PrintWriter(writer);
                     scriptObject.setProperty("out", pw);

--- a/subprojects/groovy-templates/src/test/groovy/groovy/text/SimpleTemplateTest.groovy
+++ b/subprojects/groovy-templates/src/test/groovy/groovy/text/SimpleTemplateTest.groovy
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2003-2012 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package groovy.text
 
 class SimpleTemplateTest extends GroovyTestCase {
@@ -53,6 +68,13 @@ class SimpleTemplateTest extends GroovyTestCase {
         }
     %>'''
     assertEquals('123', simpleCall(text))
+    }
+
+    void testGROOVY4791(){
+        def text = '''<%=key1%> <%=key2%>'''
+        def map1 = [key1: 'value1', key2: 'value2']
+        assert 'value1 value2' == bindingCall(map1, text)
+        assert [key1: 'value1', key2: 'value2'] == map1
     }
 
     String simpleCall(input){

--- a/subprojects/groovy-templates/src/test/java/groovy/text/TemplateTest.java
+++ b/subprojects/groovy-templates/src/test/java/groovy/text/TemplateTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2003-2011 the original author or authors.
+ * Copyright 2003-2012 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,6 +39,7 @@ public class TemplateTest extends TestCase {
     public void testBinding() throws CompilationFailedException, ClassNotFoundException, IOException {
         Map binding = new HashMap();
         binding.put("sam", "pullara");
+        Map bindingForCompare = new HashMap(binding);
 
         Template template1 = new SimpleTemplateEngine().createTemplate("<%= sam %><% print sam %>");
         assertEquals("pullarapullara", template1.make(binding).toString());
@@ -48,6 +49,8 @@ public class TemplateTest extends TestCase {
 
         Template template3 = new GStringTemplateEngine().createTemplate("<%= sam + \" \" + sam %><% out << sam %>");
         assertEquals("pullara pullarapullara", template3.make(binding).toString());
+
+        assertEquals(bindingForCompare, binding);
     }
 
 }


### PR DESCRIPTION
Change to make a copy of the Map passed to the Binding constructor so it doesn't modify the caller's instance.
