### PR TITLE
Made JsonOutput thread safe by moving SimpleDateFormat to a ThreadLocal

### DIFF
--- a/subprojects/groovy-json/src/main/groovy/groovy/json/JsonOutput.groovy
+++ b/subprojects/groovy-json/src/main/groovy/groovy/json/JsonOutput.groovy
@@ -35,10 +35,13 @@ class JsonOutput {
      * that can be parsed back from JavaScript with:
      * <code>Date.parse(stringRepresentation)</code>
      */
-    private static final DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US)
-
-    static {
-        dateFormat.timeZone = TimeZone.getTimeZone('GMT')
+    private static final ThreadLocal<SimpleDateFormat> dateFormatter = new ThreadLocal<SimpleDateFormat>() {
+        @Override
+        protected SimpleDateFormat initialValue() {
+            DateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.US)
+            formatter.timeZone = TimeZone.getTimeZone('GMT')
+            formatter
+        }
     }
 
     /**
@@ -80,7 +83,7 @@ class JsonOutput {
      * @return a formatted date in the form of a string
      */
     static String toJson(Date date) {
-        "\"${dateFormat.format(date)}\""
+        "\"${dateFormatter.get().format(date)}\""
     }
 
     /**
@@ -90,7 +93,7 @@ class JsonOutput {
      * @return a formatted date in the form of a string
      */
     static String toJson(Calendar cal) {
-        "\"${dateFormat.format(cal.time)}\""
+        "\"${dateFormatter.get().format(cal.time)}\""
     }
 
     /**


### PR DESCRIPTION
This will safely allow the use of the SimpleDateFormat class in a multi-threaded environment. I would typically add a test for this, but duplicating a large amount of concurrent calls typically does not result in a great unit test. 

I did, however, create a **very** crude failing script at https://gist.github.com/3279736 which does demonstrate the problem.

Thanks!
