### PR TITLE
Removed Bundle-ActivationPolicy: lazy header.

### DIFF
--- a/gradle/assemble.gradle
+++ b/gradle/assemble.gradle
@@ -24,7 +24,6 @@ ext.allManifest = manifest {
             "Bundle-ClassPath": '.',
             "Bundle-RequiredExecutionEnvironment": 'J2SE-1.5',
             "Eclipse-BuddyPolicy": 'dependent',
-            "Bundle-ActivationPolicy": 'lazy',
             "DynamicImport-Package": '*',
             "Main-class": 'groovy.ui.GroovyMain')
 }


### PR DESCRIPTION
Lazy activation is a bad practice for general OSGi uage. It also doesn't seem to be useful, there is no activator anyway.
