### PR TITLE
GROOVY-5446: Make @Delegate carry over method annotations

### DIFF
--- a/src/main/groovy/lang/Delegate.java
+++ b/src/main/groovy/lang/Delegate.java
@@ -132,4 +132,14 @@ public @interface Delegate {
      * @return true if owner class should delegate to methods annotated with @Deprecated
      */
     boolean deprecated() default false;
+
+    /**
+     * @return true if generated delegate methods should keep method annotations
+     */
+    boolean methodAnnotations() default false;
+
+    /**
+     * @return true if generated delegate methods should keep parameter annotations
+     */
+    boolean parameterAnnotations() default false;
 }


### PR DESCRIPTION
Fixes Groovy-5446. As mentioned in https://jira.codehaus.org/browse/GROOVY-5446, we need to discuss (possible) different compilation results with closure annotations.
