### PR TITLE
Added check for /usr/libexec/java_home to startGroovy darwin section

### DIFF
--- a/src/bin/startGroovy
+++ b/src/bin/startGroovy
@@ -68,6 +68,7 @@ fi
 # Attempt to set JAVA_HOME if it's not already set.
 if [ -z "$JAVA_HOME" ] ; then
     if $darwin ; then 
+        [ -z "$JAVA_HOME" -a -f "/usr/libexec/java_home" ] && export JAVA_HOME=`/usr/libexec/java_home`
         [ -z "$JAVA_HOME" -a -d "/Library/Java/Home" ] && export JAVA_HOME="/Library/Java/Home"
         [ -z "$JAVA_HOME" -a -d "/System/Library/Frameworks/JavaVM.framework/Home" ] && export JAVA_HOME="/System/Library/Frameworks/JavaVM.framework/Home"
     else


### PR DESCRIPTION
This is the preferred way of choosing a JVM on OS X

http://developer.apple.com/library/mac/#qa/qa1170/_index.html
