### PR TITLE
Support class node serialization

### DIFF
--- a/src/main/org/codehaus/groovy/ast/ASTNode.java
+++ b/src/main/org/codehaus/groovy/ast/ASTNode.java
@@ -18,6 +18,8 @@ package org.codehaus.groovy.ast;
 import org.codehaus.groovy.GroovyBugError;
 import org.codehaus.groovy.util.ListHashMap;
 
+import java.io.Serializable;
+
 /**
  * Base class for any AST node. This class supports basic information used in all
  * nodes of the AST<ul>
@@ -40,13 +42,13 @@ import org.codehaus.groovy.util.ListHashMap;
  * @author <a href="maito:blackdrag@gmx.org>Jochen "blackdrag" Theodorou</a>
  * @version $Revision$
  */
-public class ASTNode {
+public class ASTNode implements Serializable {
 
     private int lineNumber = -1;
     private int columnNumber = -1;
     private int lastLineNumber = -1;
     private int lastColumnNumber = -1;
-    private ListHashMap metaDataMap = new ListHashMap();
+    private transient ListHashMap metaDataMap = new ListHashMap();
 
     public void visit(GroovyCodeVisitor visitor) {
         throw new RuntimeException("No visit() method implemented for class: " + getClass().getName());

--- a/src/main/org/codehaus/groovy/ast/ClassNode.java
+++ b/src/main/org/codehaus/groovy/ast/ClassNode.java
@@ -30,6 +30,7 @@ import org.codehaus.groovy.transform.GroovyASTTransformation;
 import org.codehaus.groovy.vmplugin.VMPluginFactory;
 import org.objectweb.asm.Opcodes;
 
+import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.util.*;
 
@@ -96,17 +97,18 @@ import java.util.*;
  * @version $Revision$
  */
 public class ClassNode extends AnnotatedNode implements Opcodes {
-    private static class MapOfLists {
-        private Map<Object, List<MethodNode>> map = new HashMap<Object, List<MethodNode>>();
-        public List<MethodNode> get(Object key) {
+
+    private static class MapOfLists implements Serializable {
+        private Map<Serializable, List<MethodNode>> map = new HashMap<Serializable, List<MethodNode>>();
+        public List<MethodNode> get(Serializable key) {
             return map.get(key);
         }
-        public List<MethodNode> getNotNull(Object key) {
+        public List<MethodNode> getNotNull(Serializable key) {
             List<MethodNode> ret = get(key);
             if (ret==null) ret = Collections.emptyList();
             return ret;
         }
-        public void put(Object key, MethodNode value) {
+        public void put(Serializable key, MethodNode value) {
             if (map.containsKey(key)) {
                 get(key).add(value);
             } else {
@@ -148,7 +150,7 @@ public class ClassNode extends AnnotatedNode implements Opcodes {
     private Map<CompilePhase, Map<Class<? extends ASTTransformation>, Set<ASTNode>>> transformInstances;
 
     // use this to synchronize access for the lazy init
-    protected Object lazyInitLock = new Object();
+    protected transient Object lazyInitLock = new Object();
 
     // clazz!=null when resolved
     protected Class clazz;

--- a/src/main/org/codehaus/groovy/ast/CompileUnit.java
+++ b/src/main/org/codehaus/groovy/ast/CompileUnit.java
@@ -17,6 +17,7 @@ package org.codehaus.groovy.ast;
 
 import groovy.lang.GroovyClassLoader;
 
+import java.io.Serializable;
 import java.security.CodeSource;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -40,12 +41,12 @@ import org.codehaus.groovy.syntax.SyntaxException;
  * @author <a href="mailto:james@coredevelopers.net">James Strachan </a>
  * @version $Revision$
  */
-public class CompileUnit {
+public class CompileUnit implements Serializable {
 
     private final List<ModuleNode> modules = new ArrayList<ModuleNode>();
     private Map<String, ClassNode> classes = new HashMap<String, ClassNode>();
-    private CompilerConfiguration config;
-    private GroovyClassLoader classLoader;
+    private transient CompilerConfiguration config;
+    private transient GroovyClassLoader classLoader;
     private CodeSource codeSource;
     private Map<String, ClassNode> classesToCompile = new HashMap<String, ClassNode>();
     private Map<String, SourceUnit> classNameToSource = new HashMap<String, SourceUnit>();

--- a/src/main/org/codehaus/groovy/ast/Variable.java
+++ b/src/main/org/codehaus/groovy/ast/Variable.java
@@ -17,13 +17,15 @@ package org.codehaus.groovy.ast;
 
 import org.codehaus.groovy.ast.expr.Expression;
 
+import java.io.Serializable;
+
 /**
  * interface to mark a AstNode as Variable. Typically these are 
  * VariableExpression, FieldNode, PropertyNode and Parameter
  * 
  * @author Jochen Theodorou
  */
-public interface Variable {
+public interface Variable extends Serializable {
     
     /**
      * the type of the variable

--- a/src/main/org/codehaus/groovy/ast/VariableScope.java
+++ b/src/main/org/codehaus/groovy/ast/VariableScope.java
@@ -15,6 +15,7 @@
  */
 package org.codehaus.groovy.ast;
 
+import java.io.Serializable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -28,7 +29,7 @@ import java.util.Map;
  * @author Jochen Theodorou
  * @version $Revision$
  */
-public class VariableScope  {
+public class VariableScope implements Serializable {
     private Map<String, Variable> declaredVariables = Collections.emptyMap();
     private Map<String, Variable> referencedLocalVariables = Collections.emptyMap();
     private Map<String, Variable> referencedClassVariables = Collections.emptyMap();

--- a/src/main/org/codehaus/groovy/classgen/BytecodeInstruction.java
+++ b/src/main/org/codehaus/groovy/classgen/BytecodeInstruction.java
@@ -18,6 +18,8 @@ package org.codehaus.groovy.classgen;
 
 import org.objectweb.asm.MethodVisitor;
 
+import java.io.Serializable;
+
 /**
  * Helper class used by the class generator. Usually
  * an inner class is produced, that contains bytecode
@@ -25,6 +27,6 @@ import org.objectweb.asm.MethodVisitor;
  *
  * @author Jochen Theodorou
  */
-public abstract class BytecodeInstruction {
+public abstract class BytecodeInstruction implements Serializable {
     public abstract void visit(MethodVisitor mv);
 }

--- a/src/main/org/codehaus/groovy/classgen/Verifier.java
+++ b/src/main/org/codehaus/groovy/classgen/Verifier.java
@@ -34,6 +34,7 @@ import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 
+import java.io.Serializable;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.*;
@@ -45,7 +46,7 @@ import java.util.*;
  * @author <a href="mailto:james@coredevelopers.net">James Strachan</a>
  * @version $Revision$
  */
-public class Verifier implements GroovyClassVisitor, Opcodes {
+public class Verifier implements GroovyClassVisitor, Opcodes, Serializable {
 
     public static final String STATIC_METACLASS_BOOL = "__$stMC";
     public static final String SWAP_INIT = "__$swapInit";
@@ -1438,7 +1439,7 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
 
     private static class SwapInitStatement extends BytecodeSequence {
 
-        private WriterController controller;
+        private transient WriterController controller;
 
         public SwapInitStatement() {
             super(new SwapInitInstruction());

--- a/src/main/org/codehaus/groovy/syntax/CSTNode.java
+++ b/src/main/org/codehaus/groovy/syntax/CSTNode.java
@@ -18,6 +18,7 @@ package org.codehaus.groovy.syntax;
 
 import org.codehaus.groovy.GroovyBugError;
 
+import java.io.Serializable;
 import java.io.StringWriter;
 import java.io.PrintWriter;
 
@@ -38,7 +39,7 @@ import java.io.PrintWriter;
  *  @version $Id$
  */
 
-public abstract class CSTNode
+public abstract class CSTNode implements Serializable
 {
 
   //---------------------------------------------------------------------------

--- a/src/test/org/codehaus/groovy/control/CompilationUnitTest.java
+++ b/src/test/org/codehaus/groovy/control/CompilationUnitTest.java
@@ -19,9 +19,16 @@
 package org.codehaus.groovy.control;
 
 import groovy.lang.GroovyClassLoader;
+import org.codehaus.groovy.ast.ClassNode;
 import org.jmock.Mock;
 import org.jmock.cglib.MockObjectTestCase;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.util.Iterator;
 
 public class CompilationUnitTest extends MockObjectTestCase {
@@ -33,11 +40,73 @@ public class CompilationUnitTest extends MockObjectTestCase {
         //new CompilationUnit(configuration, null, createGroovyClassLoaderWithExpectations(configuration));
     }
 
+    public void testClassNodeSerializationAndInjectionIntoScriptASTPriorToCompilation() throws Exception {
+        // Compile a regular class
+        CompilationUnit classUnit = new CompilationUnit();
+        classUnit.addSource("example.HelloWorld", "package example; class HelloWorld { def sayIt() { 'Hello, World!' } }");
+        classUnit.compile(Phases.CLASS_GENERATION);
+
+        // Serialize the generated class node
+        ClassNode classNode = classUnit.getClassNode("example.HelloWorld");
+        byte[] serializedClassNode = serialize(classNode);
+        assertNotNull(serializedClassNode);
+
+        // Ensure deserialization works
+        ClassNode deserializedClassNode = (ClassNode) deserialize(serializedClassNode);
+        assertNotNull(deserializedClassNode);
+        assertEquals(classNode.getName(), deserializedClassNode.getName());
+
+        // Add the deserialized class node into a script's AST so it compiles
+        CompilationUnit scriptUnit = new CompilationUnit();
+        scriptUnit.addSource("HelloWorldScript", "new example.HelloWorld().sayIt()");
+        scriptUnit.getAST().addClass(deserializedClassNode);
+        scriptUnit.compile(Phases.CLASS_GENERATION);
+    }
+
     private GroovyClassLoader createGroovyClassLoaderWithExpectations(CompilerConfiguration configuration) {
         Mock mockGroovyClassLoader = mock(GroovyClassLoader.class);
         for (Iterator iterator = configuration.getClasspath().iterator(); iterator.hasNext();) {
             mockGroovyClassLoader.expects(once()).method("addClasspath").with(eq(iterator.next()));
         }
         return (GroovyClassLoader) mockGroovyClassLoader.proxy();
+    }
+
+    private static byte[] serialize(Serializable obj) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream(512);
+        ObjectOutputStream out = null;
+        try {
+            out = new ObjectOutputStream(baos);
+            out.writeObject(obj);
+        }
+        finally {
+            try {
+              if (out != null) {
+                out.close();
+              }
+            }
+            catch (IOException ex) {
+                // ignore close exception
+            }
+        }
+        return baos.toByteArray();
+    }
+
+    public static Object deserialize(byte[] objectData) throws ClassNotFoundException, IOException {
+        ByteArrayInputStream bais = new ByteArrayInputStream(objectData);
+        ObjectInputStream in = null;
+        try {
+            in = new ObjectInputStream(bais);
+            return in.readObject();
+        }
+        finally {
+            try {
+                if (in != null) {
+                    in.close();
+                }
+            }
+            catch (IOException ex) {
+                // ignore close exception
+            }
+        }
     }
 }


### PR DESCRIPTION
Since the JSR-223 does not define a code sharing mechanism, the only option for emulating this is by adding multiple source units into a script's compilation unit before compiling it. However when a dependency is modified, all scripts referencing it need to be recompiled as well, which is far from optimal. Therefore, an option could be injecting serializable class nodes into a script's AST prior to its compilation.
