### PR TITLE
 GROOVY-5695 - jarsigner fails because two duplicate objects exists in groovy-2.0.1.jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,22 +75,6 @@ allprojects {
 
 }
 
-// todo: use the conventional "resources" directory for classpath resources
-task(copyResources, type: Copy) {
-    destinationDir = file("$buildDir/classes")
-    // text files requiring filtering
-    into("main") {
-        from('src/main')
-        include('**/*.txt', '**/*.xml', '**/*.properties', '**/*.html')
-        filter(rootProject.propertiesFilter, org.apache.tools.ant.filters.ReplaceTokens)
-    }
-    // other resources
-    into("main") {
-        from 'src/main'
-        include('**/*.png', '**/*.gif', '**/*.ico', '**/*.css')
-    }
-}
-compileJava.dependsOn(copyResources)
 task(copyTestResources, type: Copy)
         .from('src/test')
         .into("$buildDir/classes/test")
@@ -306,7 +290,7 @@ sourceSets {
                     "org/codehaus/groovy/tools/shell/**/*.xml",
                     "org/codehaus/groovy/antlib.xml",
                     "org/codehaus/groovy/tools/groovydoc/gstringTemplates/**/*.*",
-                    "org/codehaus/groovy/tools/groovy.ico"
+                    "org/codehaus/groovy/tools/groovy.ico", "**/*.html"
         }
     }
     test {
@@ -345,6 +329,10 @@ sourceSets {
         compileClasspath = configurations.examplesRuntime + sourceSets.main.output
         output.classesDir = "$buildDir/examples-classes" as File
     }
+}
+
+processResources {
+    filter(rootProject.propertiesFilter, org.apache.tools.ant.filters.ReplaceTokens)
 }
 
 // remove this from config once GRADLE-854 is fixed.


### PR DESCRIPTION
Hello,

this fixes the defect, but I'm not sure that it has no side effects. I ran the test, compared the build output by hand and using the comparebuild feature of gradle, but it would be good if somebody took a critical look at the fix.

Thanks and regards,
Pascal
