### PR TITLE
Fix binding issues

### DIFF
--- a/subprojects/groovy-swing/src/main/groovy/groovy/swing/factory/BindFactory.groovy
+++ b/subprojects/groovy-swing/src/main/groovy/groovy/swing/factory/BindFactory.groovy
@@ -351,7 +351,12 @@ public class BindFactory extends AbstractFactory {
     private def finishContextualBinding(FullBinding fb, FactoryBuilderSupport builder, bindAttrs, id) {
         bindAttrs.remove('update')
         Object bindValue = bindAttrs.remove("bind")
-        bindAttrs.each {k, v -> fb."$k" = v}
+        List propertiesToBeSkipped = ['group']
+        bindAttrs.each {k, v -> if (!(k in propertiesToBeSkipped)) fb."$k" = v}
+
+        if ((bindAttrs.group instanceof AggregateBinding) && (fb instanceof BindingUpdatable)) {
+            bindAttrs.group.addBinding(fb)
+        }
 
         if ((bindValue == null)
                 || ((bindValue instanceof Boolean) && ((Boolean) bindValue).booleanValue())) {

--- a/subprojects/groovy-swing/src/main/java/org/codehaus/groovy/binding/AggregateBinding.java
+++ b/subprojects/groovy-swing/src/main/java/org/codehaus/groovy/binding/AggregateBinding.java
@@ -31,6 +31,7 @@ public class AggregateBinding implements BindingUpdatable {
     protected Set<BindingUpdatable> bindings = new LinkedHashSet<BindingUpdatable>();
 
     public void addBinding(BindingUpdatable binding) {
+        if (binding == null || bindings.contains(binding)) return;
         if (bound) binding.bind(); // bind is idempotent, so no state checking
         bindings.add(binding);
     }

--- a/subprojects/groovy-swing/src/test/groovy/groovy/swing/SwingBuilderBindingsTest.groovy
+++ b/subprojects/groovy-swing/src/test/groovy/groovy/swing/SwingBuilderBindingsTest.groovy
@@ -1172,6 +1172,70 @@ public class SwingBuilderBindingsTest extends GroovySwingTestCase {
             assert abean.text != bbean.vetoField
         }
     }
+
+    public void testGroovy4627_source_binding() {
+        testInEDT {
+            SwingBuilder swing = new SwingBuilder()
+
+            BindableBean model = new BindableBean(text: '0')
+
+            swing.actions {
+                bindGroup(id: 'formElements')
+                textField(id: 'txt1', text: bind(source: model, sourceProperty: 'text', group: formElements))
+                textField(id: 'txt2', text: bind(source: model, sourceProperty: 'text', group: formElements))
+            }
+
+            assert model.text == '0'
+            assert swing.txt1.text == '0'
+            assert swing.txt2.text == '0'
+
+            swing.formElements.unbind()
+            model.text = '1'
+            assert swing.txt1.text == '0'
+            assert swing.txt2.text == '0'
+
+            swing.formElements.rebind()
+            swing.formElements.update()
+            assert swing.txt1.text == '1'
+            assert swing.txt2.text == '1'
+
+            model.text = '2'
+            assert swing.txt1.text == '1'
+            assert swing.txt2.text == '1'
+            swing.formElements.update()
+            assert swing.txt1.text == '2'
+            assert swing.txt2.text == '2'
+        }
+    }
+
+    public void testGroovy4627_target_binding() {
+        testInEDT {
+            SwingBuilder swing = new SwingBuilder()
+
+            BindableBean model = new BindableBean()
+
+            swing.actions {
+                bindGroup(id: 'formElements')
+                textField(id: 'txt1', text: bind(target: model, targetProperty: 'text', group: formElements, value: '0'))
+            }
+
+            assert model.text == '0'
+            assert swing.txt1.text == '0'
+
+            swing.formElements.unbind()
+            swing.txt1.text = '1'
+            assert model.text == '0'
+
+            swing.formElements.rebind()
+            swing.formElements.update()
+            assert model.text == '1'
+
+            swing.txt1.text = '2'
+            assert model.text == '1'
+            swing.formElements.update()
+            assert model.text == '2'
+        }
+    }
 }
 
 @Bindable class BindableBean {


### PR DESCRIPTION
This patch contains a fix for 3 issues found in bindings:
- setting non-string values for either sourceProperty: or targetProperty: (GROOVY-5837)
- specify sourceProperty: (or value) but leave source: out (GROOVY-5837)
- group: should not fail when target: is specified (GROOVY-4627)
