### PR TITLE
GROOVY-5632: Closure default params can cause BUG! exception in phase 'c...

### DIFF
--- a/src/main/org/codehaus/groovy/classgen/Verifier.java
+++ b/src/main/org/codehaus/groovy/classgen/Verifier.java
@@ -674,17 +674,11 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
         List methods = new ArrayList(node.getMethods());
         addDefaultParameters(methods, new DefaultArgsAction() {
             public void call(ArgumentListExpression arguments, Parameter[] newParams, MethodNode method) {
-                MethodCallExpression expression = new MethodCallExpression(VariableExpression.THIS_EXPRESSION, method.getName(), arguments);
-                expression.setMethodTarget(method);
-                expression.setImplicitThis(true);
-                Statement code = null;
-                if (method.isVoidMethod()) {
-                    code = new ExpressionStatement(expression);
-                } else {
-                    code = new ReturnStatement(expression);
-                }
+                final BlockStatement code = new BlockStatement();
+
                 MethodNode newMethod = new MethodNode(method.getName(), method.getModifiers(), method.getReturnType(), newParams, method.getExceptions(), code);
-                // GROOVY-5681
+
+                // GROOVY-5681 and GROOVY-5632
                 for (Expression argument : arguments.getExpressions()) {
                     if (argument instanceof CastExpression) {
                         argument = ((CastExpression) argument).getExpression();
@@ -695,7 +689,43 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
                             type.setEnclosingMethod(newMethod);
                         }
                     }
+
+                    // check whether closure shared variables refer to params with default values (GROOVY-5632)
+                    if (argument instanceof ClosureExpression)  {
+                        final List<Parameter> newMethodNodeParameters = Arrays.asList(newParams);
+
+                        CodeVisitorSupport visitor = new CodeVisitorSupport() {
+                            @Override
+                            public void visitVariableExpression(VariableExpression expression) {
+                                Variable v = expression.getAccessedVariable();
+                                if (!(v instanceof Parameter)) return;
+
+                                Parameter param = (Parameter) v;
+                                if (param.hasInitialExpression() && code.getVariableScope().getDeclaredVariable(param.getName()) == null && !newMethodNodeParameters.contains(param))  {
+
+                                    VariableExpression localVariable = new VariableExpression(param.getName(), ClassHelper.makeReference());
+                                    DeclarationExpression declarationExpression = new DeclarationExpression(localVariable, Token.newSymbol(Types.EQUAL, -1, -1), new ConstructorCallExpression(ClassHelper.makeReference(), param.getInitialExpression()));
+
+                                    code.addStatement(new ExpressionStatement(declarationExpression));
+                                    code.getVariableScope().putDeclaredVariable(localVariable);
+                                }
+                            }
+                        };
+
+                        visitor.visitClosureExpression((ClosureExpression) argument);
+                    }
                 }
+
+                MethodCallExpression expression = new MethodCallExpression(VariableExpression.THIS_EXPRESSION, method.getName(), arguments);
+                expression.setMethodTarget(method);
+                expression.setImplicitThis(true);
+
+                if (method.isVoidMethod()) {
+                    code.addStatement(new ExpressionStatement(expression));
+                } else {
+                    code.addStatement(new ReturnStatement(expression));
+                }
+
                 List<AnnotationNode> annotations = method.getAnnotations();
                 if(annotations != null) {
                     newMethod.addAnnotations(annotations);

--- a/src/test/gls/invocation/DefaultParamTest.groovy
+++ b/src/test/gls/invocation/DefaultParamTest.groovy
@@ -125,5 +125,68 @@ class DefaultParamTest extends CompilableTestSupport {
             assert meth(a:1) {} == "21"
         """
     }
+
+    void testClosureSharedVariableRefersToDefaultParameter() {
+        assertScript """
+                def f1( int x = 3, fn={ -> x } ) {
+                    return fn()
+                }
+
+                assert 3 == f1()
+                assert 42 == f1(42)
+            """
+
+        assertScript """
+               def f2( int x = 3, fn={ -> def c2 = { -> x }; c2.call() } ) {
+                   return fn()
+               }
+
+               assert 42 == f2(42)
+               assert 42 == f2(42)
+               assert 84 == f2(42) { 84 }
+            """
+
+        assertScript """
+               def f3(fn={ -> 42 }, fn2={ -> def c2 = { -> fn() }; c2.call() } ) {
+                   return fn2()
+               }
+
+               assert 42 == f3()
+               assert 84 == f3({ -> 84 })
+            """
+
+        assertScript """
+               def f4(def s = [1,2,3], fn = { -> s.size() }) {
+                   fn()
+               }
+
+               assert 3 == f4()
+            """
+
+        assertScript """
+           static <T extends Number> Integer f5(List<T> s = [1,2,3], fn = { -> (s*.intValue()).sum() }) {
+               fn()
+           }
+
+           assert 6 == f5()
+           assert 6 == f5([1.1, 2.1, 3.1])
+        """
+
+        assertScript """
+           def f6(def s = [1,2,3], fn = { -> s.size() }, fn2 = { fn() + s.size() }) {
+               fn2()
+           }
+
+           assert 6 == f6()
+        """
+
+        assertScript """
+            def f7( int x = 3, int y = 39, fn={ -> x + y } ) {
+                return fn()
+            }
+
+            assert 42 == f7()
+        """
+    }
 }
 


### PR DESCRIPTION
Fixes [GROOVY-5632](https://jira.codehaus.org/browse/GROOVY-5632) by introducing local variables for initial parameter values. 

For a given function f() having two parameters carrying default expressions, the Verifier creates 2 synthetic methods whereas one of them has no parameters. Currently, the generated code for the no-arg method looks like this:  

``` groovy
def f() {
    this.f((int) 3, (Object) { -> x })
}
```

This leads to the "BUG! exception ..." during compilation as the closure shared variable x is not available in this case.

The code change patches the Verifier class and introduces local variables to bypass the need for rewriting the original closure expression:

``` groovy
def f() {
    Reference x = new Reference((int) 3)
    this.f((int) 3, (Object) { -> x })
}
```

Please investigate whether this approach is valid in terms of leaving the original VariableScope (referring to the method parameter) untouched, although referring to the local Reference variable instead of the parameter variable in the no-arg synthetic f() method. I added more advanced tests to DefaultParamTest.
