### PR TITLE
Add includePackage flag to @ToString annotation.

### DIFF
--- a/src/main/groovy/transform/ToString.java
+++ b/src/main/groovy/transform/ToString.java
@@ -90,6 +90,25 @@ import java.lang.annotation.Target;
  * <pre>
  * NamedThing()
  * </pre>
+ * <p/>
+ * If you want to exclude package, you can use the includePackage flag:
+ * <pre>
+ * package my.company
+ * import groovy.transform.ToString
+ * {@code @ToString(includePackage = false)} class NamedThing {
+ *     String name
+ * }
+ * println new NamedThing(name: "Lassie")
+ * </pre>
+ * Which results in:
+ * <pre>
+ * NamedThing(name: Lassie)
+ * </pre>
+ * If you change the includePackage flag to {@code true}, then the output will be:
+ * <pre>
+ * my.company.NamedThing(name: Lassie)
+ * </pre> 
+ * By default the includePackage flag is {@code true}.
  *
  * @author Paul King
  * @author Andre Steingress
@@ -135,4 +154,9 @@ public @interface ToString {
      * Don't display any fields or properties with value <tt>null</tt>.
      */
     boolean ignoreNulls() default false;
+    
+    /**
+     * Whether to include of package in generated toString.
+     */
+    boolean includePackage() default true;
 }

--- a/src/test/org/codehaus/groovy/transform/ToStringTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/ToStringTransformTest.groovy
@@ -19,7 +19,7 @@ package org.codehaus.groovy.transform
  * @author Andre Steingress
  */
 class ToStringTransformTest extends GroovyShellTestCase {
-
+    
     void testSimpleToString() {
         def toString = evaluate("""
             import groovy.transform.ToString
@@ -239,5 +239,46 @@ class ToStringTransformTest extends GroovyShellTestCase {
         """)
 
         assert toString == 'Tree(val:foo, left:(this), right:(this))'
+    }
+    
+    void testIncludePackage() {
+        def toString = evaluate("""
+                package my.company
+
+                import groovy.transform.ToString
+
+                @ToString
+                class Person {}
+
+                new Person().toString()
+            """)
+
+        assertEquals("my.company.Person()", toString)
+        
+        toString = evaluate("""
+                package my.company
+
+                import groovy.transform.ToString
+
+                @ToString(includePackage = true)
+                class Person {}
+
+                new Person().toString()
+            """)
+
+        assertEquals("my.company.Person()", toString)
+        
+        toString = evaluate("""
+                package my.company
+                
+                import groovy.transform.ToString
+                
+                @ToString(includePackage = false)
+                class Person {}
+                
+                new Person().toString()
+            """)
+                
+        assertEquals("Person()", toString)
     }
 }


### PR DESCRIPTION
I use a toString method for logging variable values and the message obtained contain redundant information. For example:

<pre>
/* Bean file */
package my.company.data.mongo.schema

@ToString
class Bean {...}

/* Bean repo file */
package my.company.data.mongo.repo

class BeanRepo {
    Logger log = LoggerFactory.getLogger(BeanRepo)
    ...
    if (log.isDebug()) {
        log.debug("Result of 'findBean' is '${result}'")
    }
}
</pre>


<pre>
/* Log output */
...
12.12.14 17:40:40.625 DEBUG my.company.data.mongo.repo.BeanRepo - Result of 'findBean' is 'my.company.data.mongo.schema.Bean(id: 789ac8d3)'
...
</pre>


But may be is:

<pre>
12.12.14 17:40:40.625 DEBUG my.company.data.mongo.repo.BeanRepo - Result of 'findBean' is 'Bean(id: 789ac8d3)'
</pre>
