### PR TITLE
wasted work in "ClassCompletionVerifier.checkMethodForWeakerAccessPrivileges"

### DIFF
--- a/src/main/org/codehaus/groovy/classgen/ClassCompletionVerifier.java
+++ b/src/main/org/codehaus/groovy/classgen/ClassCompletionVerifier.java
@@ -287,6 +287,7 @@ public class ClassCompletionVerifier extends ClassCodeVisitorSupport {
     }
 
     private void checkMethodForWeakerAccessPrivileges(MethodNode mn, ClassNode cn) {
+        if (mn.isPublic()) return;
         Parameter[] params = mn.getParameters();
         for (MethodNode superMethod : cn.getSuperClass().getMethods(mn.getName())) {
             Parameter[] superParams = superMethod.getParameters();


### PR DESCRIPTION
The problem appears in version 2.0.5 and in revision 4cf5263..  I
submitted the GROOVY-5849 bug report in Groovy JIRA.

The entire work performed in method
"ClassCompletionVerifier.checkMethodForWeakerAccessPrivileges"
produces no result when the parameter "MethodNode mn" represents a
public method, i.e., when "mn.isPublic()" is "true".  This condition
can be evaluated right at the beginning of the
"checkMethodForWeakerAccessPrivileges" method body, thus avoiding the
entire method execution.

We can have this fast exist because the method
"checkMethodForWeakerAccessPrivileges" produces results only when this
condition (in the method code):

if ((mn.isPrivate() && !superMethod.isPrivate()) ||
        (mn.isProtected() && superMethod.isPublic()))

evaluates to "true", which does not happen when "mn.isPublic()" is
"true" (i.e., when "!mn.isPrivate() && !mn.isProtected()" is "true").

I attached a second one-line patch (patchTwoCond.diff) where I use the
condition "!mn.isPrivate() && !mn.isProtected()" instead of
"mn.isPublic()", in case you prefer the longer condition.
