### PR TITLE
wasted work in "StaticTypeCheckingVisitor.inferReturnTypeGenerics"

### DIFF
--- a/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -2917,6 +2917,7 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
                                 if (anInterface.equals(type)) {
                                     intf = true;
                                     actualType = GenericsUtils.parameterizeType(actualType, anInterface);
+                                    break;
                                 }
                             }
                             if (!intf) actualType = actualType.getUnresolvedSuperClass();


### PR DESCRIPTION
The problem appears in version 2.0.5 and in revision 4cf5263..  I
submitted the GROOVY-5850 bug report in Groovy JIRA.

There is no Groovy test that touches this code location (the entire
"else" branch that contains this code is not touched), but I think the
patch is correct.

In method "StaticTypeCheckingVisitor.inferReturnTypeGenerics", the
loop over "interfaces" should break immediately after "actualType" is
set.  All the iterations after "actualType" is set do not perform any
useful work.
