### PR TITLE
wasted work in "SimpleGroovyClassDocAssembler.extractName"

### DIFF
--- a/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/SimpleGroovyClassDocAssembler.java
+++ b/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/SimpleGroovyClassDocAssembler.java
@@ -599,9 +599,11 @@ public class SimpleGroovyClassDocAssembler extends VisitorAdapter implements Gro
         String typeName = buildName(typeNode);
         if (typeName.indexOf("/") == -1) {
             String slashName = "/" + typeName;
-            for (String name : importedClassesAndPackages) {
+            for (int i = importedClassesAndPackages.size()-1; i >=0; i--) {
+            	String name = importedClassesAndPackages.get(i);
                 if (name.endsWith(slashName)) {
                     typeName = name;
+                    break;
                 }
             }
         }


### PR DESCRIPTION
The problem appears in version 2.0.5 and in revision 4cf5263..  I
submitted the GROOVY-5851 bug report in Groovy JIRA.

In method "SimpleGroovyClassDocAssembler.extractName", the loop over
"importedClassesAndPackages" keeps overriding "typeName" with "name".
Therefore, only the last written value is visible out of the loop and
all the other writes and iterations are not necessary.  The patch
iterates from the end of "importedClassesAndPackages" and breaks the
first time when "typeName" is set.

The fix in this pull request is certainly correct (it's easy to see
through code inspection), but I think we can have an even shorter
patch (one line, in file patchShort.diff in the GROOVY-5851 report),
described below.  There is no Groovy test that touches this code
location, so I am not 100% sure this second patch (patchShort.diff) is
correct, though it should be.

patchShort.diff is based on the fact that the condition 
"if (name.endsWith(slashName))" (which decides if "typeName" is set or
not) is true at most once in the loop over
"importedClassesAndPackages".  Even if it is true more than one time,
the "name" value is still legal.  Thus, the loop can just break
immediately after "typeName" is set.
