### PR TITLE
GROOVY-5853: wasted work in "DefaultGrailsDomainClassInjector.implementsMethod"

### DIFF
--- a/src/examples/org/codehaus/groovy/grails/compiler/injection/DefaultGrailsDomainClassInjector.java
+++ b/src/examples/org/codehaus/groovy/grails/compiler/injection/DefaultGrailsDomainClassInjector.java
@@ -242,7 +242,7 @@ public class DefaultGrailsDomainClassInjector implements ASTTransformation {
         for (Iterator i = methods.iterator(); i.hasNext();) {
             MethodNode mn = (MethodNode) i.next();
             final boolean isZeroArg = (argTypes == null || argTypes.length ==0);
-            boolean methodMatch = mn.getName().equals(methodName) && isZeroArg;
+            boolean methodMatch = isZeroArg && mn.getName().equals(methodName);
             if(methodMatch)return true;
             // TODO Implement further parameter analysis
         }


### PR DESCRIPTION
Pull request for http://jira.codehaus.org/browse/GROOVY-5853

The problem appears in version 2.0.5 and in revision 4cf5263..

In method "DefaultGrailsDomainClassInjector.implementsMethod", in the
loop over "methods", the statement
"boolean methodMatch = mn.getName().equals(methodName) && isZeroArg"
should be
"boolean methodMatch = isZeroArg && mn.getName().equals(methodName)".
The second statement avoids comparing strings when "isZeroArg" is
"false".

The code can be made even shorter and faster by having a fast exit (by
pulling "isZeroArg" out of the loop) at the beginning of the method
body; this avoids the entire method computation.  While the resulting
code is more compact than the original, the patch itself is a bit
larger (deletes 3 lines, adds 2).  I attached this patch
(patchFull.diff) in the GROOVY-5853 JIRA report.
