### PR TITLE
GROOVY-5854: wasted work in the "ClassNode" constructor

### DIFF
--- a/src/main/org/codehaus/groovy/ast/ClassNode.java
+++ b/src/main/org/codehaus/groovy/ast/ClassNode.java
@@ -325,6 +325,7 @@ public class ClassNode extends AnnotatedNode implements Opcodes {
         if (!usesGenerics && interfaces!=null) {
             for (ClassNode anInterface : interfaces) {
                 usesGenerics = usesGenerics || anInterface.isUsingGenerics();
+                if (usesGenerics) break;
             }
         }
         this.methods = new MapOfLists();


### PR DESCRIPTION
Pull request for http://jira.codehaus.org/browse/GROOVY-5854

The problem appears in version 2.0.5 and in revision 4cf5263..  This
problem is similar to the previously fixed GROOVY-5803, GROOVY-5823,
GROOVY-5825, and GROOVY-5827.

In the "ClassNode" constructor (the constructor with 5 parameters),
the loop over "interfaces" should break immediately after
"usesGenerics" is set to "true". All the iterations after
"usesGenerics" is set to "true" do not perform any useful work, at
best they just set "usesGenerics" again to "true".
