### PR TITLE
added missing AnnotationConstantExpression#toString()

### DIFF
--- a/src/main/org/codehaus/groovy/ast/expr/AnnotationConstantExpression.java
+++ b/src/main/org/codehaus/groovy/ast/expr/AnnotationConstantExpression.java
@@ -41,4 +41,8 @@ public class AnnotationConstantExpression extends ConstantExpression {
         }
         super.visit(visitor);
     }
+
+    public String toString() {
+        return "AnnotationConstantExpression[" + getValue() + "]";
+    }
 }


### PR DESCRIPTION
this patch implements toString() for AnnotationConstantExpression. I just got into that trap when AST browser showed an annotation's argument list expression types of being ConstantExpressions, where it should have shown AnnotationConstantExpressions.
