### PR TITLE
Update src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -8203,19 +8203,10 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @since 1.5.0
      */
     public static <T> Set<T> minus(Set<T> self, Collection<?> removeMe) {
-        Comparator comparator = (self instanceof SortedSet) ? ((SortedSet) self).comparator() : null;
         final Set<T> ansSet = createSimilarSet(self);
         ansSet.addAll(self);
-        if (removeMe != null) {
-            for (T o1 : self) {
-                for (Object o2 : removeMe) {
-                    boolean areEqual = (comparator != null) ? (comparator.compare(o1, o2) == 0) : coercedEquals(o1, o2);
-                    if (areEqual) {
-                        ansSet.remove(o1);
-                    }
-                }
-            }
-        }
+        for (Object o : removeMe)
+            ansSet.remove(o);
         return ansSet;
     }
 


### PR DESCRIPTION
I propose updating the implementation of the method, minus(Set<T> self, Collection<?> removeMe) per GROOVY-5513.  This should reduce the running time from O(m*n) to O(n) since we are now iterating over the Collection of objects to remove, rather than both the input Collection and Set to remove from.
There was some concern about the ordering between the input and resultant sets.  I would imagine, however, that if the input Set has an inherent order (eg. LinkedHashSet), then it's remove() method should take this ordering into account in its implementation.
