### PR TITLE
GROOVY-5434

### DIFF
--- a/subprojects/groovy-xml/src/main/java/groovy/util/slurpersupport/Node.java
+++ b/subprojects/groovy-xml/src/main/java/groovy/util/slurpersupport/Node.java
@@ -285,4 +285,9 @@ public class Node implements Writable {
             }
         }
     }
+
+    @Override
+    public String toString() {
+        return text();
+    }
 }


### PR DESCRIPTION
redirect toString() to text() as in GPathResult instead of using java.lang.Object.toString()
