### PR TITLE
GROOVY-4670: groovy.ui.Console cannot be extended

### DIFF
--- a/subprojects/groovy-console/src/main/groovy/groovy/ui/Console.groovy
+++ b/subprojects/groovy-console/src/main/groovy/groovy/ui/Console.groovy
@@ -176,9 +176,9 @@ class Console implements CaretListener, HyperlinkListener, ComponentListener, Fo
     public static URL ICON_PATH = Console.class.classLoader.getResource('groovy/ui/ConsoleIcon.png') // used by ObjectBrowser and AST Viewer
     public static URL NODE_ICON_PATH = Console.class.classLoader.getResource('groovy/ui/icons/bullet_green.png') // used by AST Viewer
 
-    private static groovyFileFilter = new GroovyFileFilter()
-    private boolean scriptRunning = false
-    private boolean stackOverFlowError = false
+    static groovyFileFilter = new GroovyFileFilter()
+    boolean scriptRunning = false
+    boolean stackOverFlowError = false
     Action interruptAction
     
     static void main(args) {


### PR DESCRIPTION
https://jira.codehaus.org/browse/GROOVY-4670
