### PR TITLE
GROOVY-5865: DefaultGroovyMethods.getAt(List, Range) delegates now to getAt(List, EmptyRange) in case of EmptyRange

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -4856,6 +4856,10 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @since 1.0
      */
     public static <T> List<T> getAt(List<T> self, Range range) {
+        if (range instanceof EmptyRange) {
+            return getAt(self, (EmptyRange) range);
+        }
+
         RangeInfo info = subListBorders(self.size(), range);
         List<T> answer = self.subList(info.from, info.to);  // sublist is always exclusive, but Ranges are not
         if (info.reverse) {

--- a/src/test/groovy/SubscriptTest.groovy
+++ b/src/test/groovy/SubscriptTest.groovy
@@ -167,6 +167,13 @@ class SubscriptTest extends GroovyTestCase {
         assert sub == [101, 103, 120, 121, 122, 123, 124, 125, 133]
     }
 
+    // GROOVY-5865
+    void testListSubscriptWithListAndEmptyRange() {
+        def list = [0, 1, 2]
+
+        assert list[0, 1..<1] == [0]
+    }
+
     void testStringWithSubscriptList() {
 
         def text = "nice cheese gromit!"


### PR DESCRIPTION
This fixes issue with inconsistent behavior of getAt(List, Collection) where element of collection is EmptyRange. For details please see the JIRA ticket.

Test case included.
