### PR TITLE
GROOVY-5816 Add an "encoding" option for Groovydoc tool and Ant task

### DIFF
--- a/subprojects/groovy-ant/src/main/java/org/codehaus/groovy/ant/Groovydoc.java
+++ b/subprojects/groovy-ant/src/main/java/org/codehaus/groovy/ant/Groovydoc.java
@@ -65,7 +65,9 @@ public class Groovydoc extends Task {
     private File styleSheetFile;
     // dev note: update javadoc comment for #setExtensions(String) if updating below
     private String extensions = ".java:.groovy:.gv:.gvy:.gsh";
+
     private String charset;
+    private String fileEncoding;
 
     public Groovydoc() {
         packageNames = new ArrayList<String>();
@@ -276,6 +278,17 @@ public class Groovydoc extends Task {
     }
 
     /**
+     * Specifies the file encoding to be used for generated files. If <em>fileEncoding</em> is missing,
+     * the <em>charset</em> encoding will be used for writing the files. If <em>fileEncoding</em> and
+     * <em>charset</em> are missing, the file encoding will default to <em>Charset.defaultCharset()</em>.
+     *
+     * @param fileEncoding the file encoding
+     */
+    public void setFileEncoding(String fileEncoding) {
+        this.fileEncoding = fileEncoding;
+    }
+
+    /**
      * Specifies a stylesheet file to use. If not specified,
      * a default one will be generated for you.
      *
@@ -409,6 +422,7 @@ public class Groovydoc extends Task {
         properties.setProperty("includeMainForScripts", includeMainForScripts.toString());
         properties.setProperty("overviewFile", overviewFile != null ? overviewFile.getAbsolutePath() : "");
         properties.setProperty("charset", charset != null ? charset : "");
+        properties.setProperty("fileEncoding", fileEncoding != null ? fileEncoding : "");
 
         if (sourcePath != null) {
             sourceDirs.addExisting(sourcePath);

--- a/subprojects/groovy-groovydoc/src/main/groovy/org/codehaus/groovy/tools/groovydoc/Main.groovy
+++ b/subprojects/groovy-groovydoc/src/main/groovy/org/codehaus/groovy/tools/groovydoc/Main.groovy
@@ -36,6 +36,7 @@ class Main {
     private static String header
     private static String footer
     private static String charset
+    private static String fileEncoding
     private static Boolean author
     private static Boolean noScripts
     private static Boolean noMainForScripts
@@ -73,6 +74,7 @@ class Main {
         cli.package(messages['cli.option.package.description'])
         cli.private(messages['cli.option.private.description'])
         cli.charset(args:1, argName: 'charset', messages['cli.option.charset.description'])
+        cli.fileEncoding(args:1, argName: 'charset', messages['cli.option.fileEncoding.description'])
         cli.windowtitle(args:1, argName: 'text', messages['cli.option.windowtitle.description'])
         cli.doctitle(args:1, argName: 'html', messages['cli.option.doctitle.description'])
         cli.header(args:1, argName: 'html', messages['cli.option.header.description'])
@@ -141,6 +143,7 @@ class Main {
         header = options.header ?: ''
         footer = options.footer ?: ''
         charset = options.charset ?: ''
+        fileEncoding = options.fileEncoding ?: ''
 
         if (options.Ds) {
             def values = options.Ds
@@ -177,6 +180,7 @@ class Main {
         properties.put("footer", footer)
         properties.put("header", header)
         properties.put("charset", charset)
+        properties.put("fileEncoding", fileEncoding)
         properties.put("privateScope", privateScope.toString())
         properties.put("protectedScope", protectedScope.toString())
         properties.put("publicScope", publicScope.toString())

--- a/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/FileOutputTool.java
+++ b/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/FileOutputTool.java
@@ -25,9 +25,9 @@ public class FileOutputTool implements OutputTool {
         dir.mkdirs();
     }
 
-    public void writeToOutput(String fileName, String text) throws Exception {
+    public void writeToOutput(String fileName, String text, String charset) throws Exception {
         File file = new File(fileName);
         file.getParentFile().mkdirs();
-        ResourceGroovyMethods.write(file, text);
+        ResourceGroovyMethods.write(file, text, charset);
     }
 }

--- a/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/GroovyDocTool.java
+++ b/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/GroovyDocTool.java
@@ -34,7 +34,8 @@ public class GroovyDocTool {
     private final Logger log = Logger.create(GroovyDocTool.class);
     private final GroovyRootDocBuilder rootDocBuilder;
     private final GroovyDocTemplateEngine templateEngine;
-    private Properties properties;
+
+    protected Properties properties;
 
     /**
      * Constructor for use by people who only want to interact with the Groovy Doclet Tree (rootDoc)
@@ -51,10 +52,19 @@ public class GroovyDocTool {
 
     public GroovyDocTool(ResourceManager resourceManager, String[] sourcepaths, String[] docTemplates, String[] packageTemplates, String[] classTemplates, List<LinkArgument> links, Properties properties) {
         rootDocBuilder = new GroovyRootDocBuilder(this, sourcepaths, links, properties);
-        String charset = properties.getProperty("charset");
-        properties.setProperty("charset", charset != null && charset.length() != 0 ? charset : Charset.defaultCharset().name());
-        this.properties = properties;
 
+        String defaultCharset = Charset.defaultCharset().name();
+
+        String fileEncoding = properties.getProperty("fileEncoding");
+        String charset = properties.getProperty("charset");
+
+        if (fileEncoding == null || fileEncoding.length() == 0) fileEncoding = charset;
+        if (charset == null || charset.length() == 0) charset = fileEncoding;
+
+        properties.setProperty("fileEncoding", fileEncoding != null && fileEncoding.length() != 0 ? fileEncoding : defaultCharset);
+        properties.setProperty("charset", charset != null && charset.length() != 0 ? charset : defaultCharset);
+
+        this.properties = properties;
 
         if (resourceManager == null) {
             templateEngine = null;

--- a/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/GroovyDocWriter.java
+++ b/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/GroovyDocWriter.java
@@ -54,7 +54,7 @@ public class GroovyDocWriter {
             String destFileName = destdir + FS + classDoc.getFullPathName() + ".html";
             log.debug("Generating " + destFileName);
             String renderedSrc = templateEngine.applyClassTemplates(classDoc);
-            output.writeToOutput(destFileName, renderedSrc);
+            output.writeToOutput(destFileName, renderedSrc, properties.getProperty("fileEncoding"));
         }
     }
 
@@ -71,7 +71,7 @@ public class GroovyDocWriter {
         }
         String destFileName = destdir + FS + "package-list";
         log.debug("Generating " + destFileName);
-        output.writeToOutput(destFileName, sb.toString());
+        output.writeToOutput(destFileName, sb.toString(), properties.getProperty("fileEncoding"));
     }
 
     public void writePackageToOutput(GroovyPackageDoc packageDoc, String destdir) throws Exception {
@@ -81,7 +81,7 @@ public class GroovyDocWriter {
             String renderedSrc = templateEngine.applyPackageTemplate(template, packageDoc);
             String destFileName = destdir + FS + packageDoc.name() + FS + tool.getFile(template);
             log.debug("Generating " + destFileName);
-            output.writeToOutput(destFileName, renderedSrc);
+            output.writeToOutput(destFileName, renderedSrc, properties.getProperty("fileEncoding"));
         }
     }
 
@@ -100,7 +100,7 @@ public class GroovyDocWriter {
                 templateEngine.copyBinaryResource(template, destFileName);
             } else {
                 String renderedSrc = templateEngine.applyRootDocTemplate(template, rootDoc);
-                output.writeToOutput(destFileName, renderedSrc);
+                output.writeToOutput(destFileName, renderedSrc, properties.getProperty("fileEncoding"));
             }
         }
     }

--- a/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/MockOutputTool.java
+++ b/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/MockOutputTool.java
@@ -33,10 +33,10 @@ public class MockOutputTool implements OutputTool {
         outputAreas.add(filename);
     }
 
-    public void writeToOutput(String fileName, String text) throws Exception {
+    public void writeToOutput(String fileName, String text, String charset) throws Exception {
         output.put(fileName, text);
     }
-    
+
     public boolean isValidOutputArea(String fileName) {
         return outputAreas.contains(fileName);
     }

--- a/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/OutputTool.java
+++ b/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/OutputTool.java
@@ -17,5 +17,5 @@ package org.codehaus.groovy.tools.groovydoc;
 
 public interface OutputTool {
     void makeOutputArea(String filename);
-    void writeToOutput(String fileName, String text) throws Exception;
+    void writeToOutput(String fileName, String text, String charset) throws Exception;
 }

--- a/subprojects/groovy-groovydoc/src/main/resources/org/codehaus/groovy/tools/groovydoc/Main.properties
+++ b/subprojects/groovy-groovydoc/src/main/resources/org/codehaus/groovy/tools/groovydoc/Main.properties
@@ -40,6 +40,8 @@ cli.option.windowtitle.description=Browser window title for the documentation
 
 cli.option.charset.description=Charset for cross-platform viewing of generated documentation
 
+cli.option.fileEncoding.description=Charset for generated documentation files
+
 cli.option.header.description=Include header text for each page
 
 cli.option.footer.description=Include footer text for each page

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocTest.java
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocTest.java
@@ -15,11 +15,14 @@
  */
 package org.codehaus.groovy.tools.groovydoc;
 
+import groovy.util.CharsetToolkit;
 import org.apache.tools.ant.BuildFileTest;
+import org.codehaus.groovy.runtime.DefaultGroovyMethods;
 import org.codehaus.groovy.runtime.ResourceGroovyMethods;
 
 import java.io.File;
 import java.io.FilenameFilter;
+import java.nio.charset.Charset;
 import java.util.List;
 
 /**
@@ -37,12 +40,12 @@ public class GroovyDocTest extends BuildFileTest {
 
     @Override
     public void setUp() throws Exception {
-        configureProject(SRC_TESTFILES + "buildWithCustomGroovyDoc.xml");
+        configureProject(SRC_TESTFILES + "groovyDocTests.xml");
         tmpDir = new File(getProject().getProperty("tmpdir"));
     }
 
     public void testCustomClassTemplate() throws Exception {
-        executeTarget("doc");
+        executeTarget("testCustomClassTemplate");
 
         final File testfilesPackageDir = new File(tmpDir, "org/codehaus/groovy/tools/groovydoc/testfiles");
         System.err.println("testfilesPackageDir = " + testfilesPackageDir);
@@ -59,5 +62,22 @@ public class GroovyDocTest extends BuildFileTest {
         List<String> lines = ResourceGroovyMethods.readLines(documentedClassHtmlDoc);
         assertTrue("\"<title>DocumentedClass</title>\" not in: " + lines, lines.contains("<title>DocumentedClass</title>"));
         assertTrue("\"This is a custom class template.\" not in: " + lines, lines.contains("This is a custom class template."));
+    }
+
+    public void testFileEncoding() throws Exception {
+        executeTarget("testFileEncoding");
+
+        final File testfilesPackageDir = new File(tmpDir, "org/codehaus/groovy/tools/groovydoc/testfiles");
+        System.err.println("testfilesPackageDir = " + testfilesPackageDir);
+        final String[] list = testfilesPackageDir.list(new FilenameFilter() {
+            public boolean accept(File file, String name) {
+                return name.equals("DocumentedClass.html");
+            }
+        });
+
+        File documentedClassHtmlDoc = new File(testfilesPackageDir, list[0]);
+        CharsetToolkit charsetToolkit = new CharsetToolkit(documentedClassHtmlDoc);
+
+        assertEquals("The generated groovydoc must be in 'UTF-16LE' file encoding.'", Charset.forName("UTF-16LE"), charsetToolkit.getCharset());
     }
 }

--- a/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
+++ b/subprojects/groovy-groovydoc/src/test/groovy/org/codehaus/groovy/tools/groovydoc/GroovyDocToolTest.java
@@ -22,6 +22,7 @@ import org.codehaus.groovy.groovydoc.GroovyClassDoc;
 import org.codehaus.groovy.groovydoc.GroovyMethodDoc;
 import org.codehaus.groovy.groovydoc.GroovyRootDoc;
 
+import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
@@ -334,5 +335,58 @@ public class GroovyDocToolTest extends GroovyTestCase {
         xmlTool.renderToOutput(output, MOCK_DIR);
         String text = output.getText(MOCK_DIR + "/org/codehaus/groovy/tools/groovydoc/SimpleGroovyRootDoc.html");
         assertTrue(text.indexOf("<parameter type=\"org.codehaus.groovy.groovydoc.GroovyPackageDoc\"") > 0);
+    }
+
+    public void testFileEncodingFallbackToCharset() throws Exception {
+        String expectedCharset = "ISO-88591";
+
+        Properties props = new Properties();
+        props.setProperty("charset", expectedCharset);
+
+        GroovyDocTool tool = new GroovyDocTool(
+                new FileSystemResourceManager("src"),
+                new String[0],
+                new String[0],
+                new String[0],
+                new String[0],
+                new ArrayList<LinkArgument>(),
+                props);
+
+        assertEquals("'fileEncoding' falls back to 'charset' if not provided", expectedCharset, tool.properties.getProperty("fileEncoding"));
+    }
+
+    public void testCharsetFallbackToFileEncoding() throws Exception {
+        String expectedCharset = "ISO-88591";
+
+        Properties props = new Properties();
+        props.setProperty("fileEncoding", expectedCharset);
+
+        GroovyDocTool tool = new GroovyDocTool(
+                new FileSystemResourceManager("src"),
+                new String[0],
+                new String[0],
+                new String[0],
+                new String[0],
+                new ArrayList<LinkArgument>(),
+                props);
+
+        assertEquals("'charset' falls back to 'fileEncoding' if not provided", expectedCharset, tool.properties.getProperty("charset"));
+
+    }
+
+    public void testFileEncodingCharsetFallbackToDefaultCharset() throws Exception {
+        String expectedCharset = Charset.defaultCharset().name();
+
+        GroovyDocTool tool = new GroovyDocTool(
+                new FileSystemResourceManager("src"),
+                new String[0],
+                new String[0],
+                new String[0],
+                new String[0],
+                new ArrayList<LinkArgument>(),
+                new Properties());
+
+        assertEquals("'charset' falls back to the default charset", expectedCharset, tool.properties.getProperty("charset"));
+        assertEquals("'fileEncoding' falls back to the default charset", expectedCharset, tool.properties.getProperty("fileEncoding"));
     }
 }

--- a/subprojects/groovy-groovydoc/src/test/resources/groovydoc/groovyDocTests.xml
+++ b/subprojects/groovy-groovydoc/src/test/resources/groovydoc/groovyDocTests.xml
@@ -9,12 +9,30 @@
     </path>
 
     <taskdef name="groovydoc" classpathref="classpath"
-            classname="org.codehaus.groovy.tools.groovydoc.CustomGroovyDoc"/>
+             classname="org.codehaus.groovy.tools.groovydoc.CustomGroovyDoc"/>
 
-    <target name="doc">
+    <target name="testCustomClassTemplate">
         <groovydoc destdir="${tmpdir}" sourcepath="${test}"
+                   packagenames="org/codehaus/groovy/tools/groovydoc/testfiles/**.*"
+                   use="true" windowtitle="GroovyDoc" private="false">
+            <link packages="java.,org.groovy.xml.,javax.,org.groovy.w3c." href="http://download.oracle.com/javase/6/docs/api"/>
+            <link packages="org.apache.tools.ant." href="http://evgeny-goldin.org/javadoc/ant/api"/>
+            <link packages="org.junit.,junit.framework." href="http://kentbeck.github.com/junit/javadoc/latest"/>
+            <link packages="groovy.,org.codehaus.groovy." href="http://groovy.codehaus.org/api/"/>
+            <link packages="org.codehaus.gmaven." href="http://evgeny-goldin.org/javadoc/gmaven"/>
+        </groovydoc>
+    </target>
+
+    <target name="testFileEncoding">
+        <groovydoc
+                destdir="${tmpdir}"
+                sourcepath="${test}"
                 packagenames="org/codehaus/groovy/tools/groovydoc/testfiles/**.*"
-                use="true" windowtitle="GroovyDoc" private="false">
+                use="true"
+                windowtitle="GroovyDoc"
+                private="false"
+                fileEncoding="UTF-16LE">
+
             <link packages="java.,org.groovy.xml.,javax.,org.groovy.w3c." href="http://download.oracle.com/javase/6/docs/api"/>
             <link packages="org.apache.tools.ant." href="http://evgeny-goldin.org/javadoc/ant/api"/>
             <link packages="org.junit.,junit.framework." href="http://kentbeck.github.com/junit/javadoc/latest"/>


### PR DESCRIPTION
The option has actually been called "fileEncoding" as there already exists a "charset" option that refers to the HTML content type charset.
