### PR TITLE
Fix a bug in JsonBuilder.toPrettyString() for zero-length strings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ out
 *.ipr
 *.iws
 .idea
+.*.swp

--- a/subprojects/groovy-json/src/main/groovy/groovy/json/JsonOutput.groovy
+++ b/subprojects/groovy-json/src/main/groovy/groovy/json/JsonOutput.groovy
@@ -190,7 +190,12 @@ class JsonOutput {
             } else if (token.type == COLON) {
                 output.append(': ')
             } else if (token.type == STRING) {
-                output.append('"' + StringEscapeUtils.escapeJava(token.text[1..-2]) + '"')
+                // Cannot use a range (1..-2) here as it will reverse for a string of
+                // length 2 (i.e. textStr=/""/ ) and will not strip the leading/trailing
+                // quotes (just reverses them).
+                String textStr = token.text
+                String textWithoutQuotes = textStr.substring( 1, textStr.size()-1 )
+                output.append('"' + StringEscapeUtils.escapeJava( textWithoutQuotes ) + '"')
             } else {
                 output.append(token.text)
             }

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonOutputTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonOutputTest.groovy
@@ -236,11 +236,19 @@ class JsonOutputTest extends GroovyTestCase {
             }""".stripIndent()
     }
 
+    private stripWhiteSpace( String str ) {
+      return str.replaceAll( ~/\s/, '' )
+    }
+    void testPrettyPrintStringZeroLen() {
+      def tree = [ myStrings: [ str3:'abc', str0:'' ] ]
+      def result   = stripWhiteSpace( new JsonBuilder( tree ).toPrettyString() )
+      def expected = stripWhiteSpace( '{ "myStrings":{ "str3":"abc","str0":"" } }' )
+      assert result == expected
+    }
+
     void testPrettyPrintDoubleQuoteEscape() {
         def json = new JsonBuilder()
-
         json.text { content 'abc"def' }
-
         assert json.toPrettyString() == """\
             {
                 "text": {


### PR DESCRIPTION
Zero-length strings are represented in JSON as a pair of double-quotes
(e.g. "").  This is actually a java.lang.String of length=2.  The old
logic attempted to strip the leading & trailing quotes (either single or
double) using a range of (1..-2), which fails for length=2 strings (it
just reverses the 2 chars).  Replaced with a call to
String.substring( 1, size()-1 ).

Fixes issues in both [GROOVY-5927](http://jira.codehaus.org/browse/GROOVY-5927) and [GROOVY-5733](http://jira.codehaus.org/browse/GROOVY-5733)
