### PR TITLE
intersect() refactor

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -7893,7 +7893,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @since 1.5.6
      */
     public static <T> Collection<T> intersect(Collection<T> left, Collection<T> right) {
-        if (left.isEmpty())
+        if (left.isEmpty() || right.isEmpty())
             return createSimilarCollection(left, 0);
 
         if (left.size() < right.size()) {


### PR DESCRIPTION
Added a check for right.isEmpty() to prevent a new TreeSet from being created and left elements from being added if right is empty and left is non-empty.
