### PR TITLE
GROOVY-5918 Remove metaPropertyValues from Expando before calling toJson

### DIFF
--- a/subprojects/groovy-json/src/main/groovy/groovy/json/JsonOutput.groovy
+++ b/subprojects/groovy-json/src/main/groovy/groovy/json/JsonOutput.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2003-2012 the original author or authors.
+ * Copyright 2003-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonOutputTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonOutputTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2003-2011 the original author or authors.
+ * Copyright 2003-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Since https://github.com/groovy/groovy-core/commit/ecfe0f06efc2293fac5310caec9c501f50e597de calling `JsonBuilder` on an `Expando` seems to have thrown a Stack Overflow exception

Fingers crossed this fixes it, by specifically handling `Expando` in the `toJson` overloaded methods (Inside JsonOutput)
