### PR TITLE
GROOVY-5925 Casting map as Random results in java.lang.VerifyError (mino...

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/ProxyGeneratorAdapter.java
+++ b/src/main/org/codehaus/groovy/runtime/ProxyGeneratorAdapter.java
@@ -572,8 +572,7 @@ public class ProxyGeneratorAdapter extends ClassVisitor implements Opcodes {
     }
 
     private void initializeDelegateClosure(final MethodVisitor mv, Type[] args) {
-        int idx = 1;
-        for (Type type : args)  { idx += registerLen(type); }
+        int idx = 1 + getTypeArgsRegisterLength(args);
 
         mv.visitIntInsn(ALOAD, 0); // this
         mv.visitIntInsn(ALOAD, idx); // constructor arg n is the closure map
@@ -582,12 +581,17 @@ public class ProxyGeneratorAdapter extends ClassVisitor implements Opcodes {
     }
 
     private void initializeDelegateObject(final MethodVisitor mv, Type[] args) {
-        int idx = 2;
-        for (Type type : args)  { idx += registerLen(type); }
+        int idx = 2 + getTypeArgsRegisterLength(args);
 
         mv.visitIntInsn(ALOAD, 0); // this
         mv.visitIntInsn(ALOAD, idx); // constructor arg n is the closure map
         mv.visitFieldInsn(PUTFIELD, proxyName, DELEGATE_OBJECT_FIELD, BytecodeHelper.getTypeDescription(delegateClass));
+    }
+
+    private int getTypeArgsRegisterLength(Type[] args)  {
+        int length = 0;
+        for (Type type : args)  { length += registerLen(type); }
+        return length;
     }
 
     /**

--- a/src/test/groovy/util/ProxyGeneratorAdapterTest.groovy
+++ b/src/test/groovy/util/ProxyGeneratorAdapterTest.groovy
@@ -138,6 +138,26 @@ class ProxyGeneratorAdapterTest extends GroovyTestCase {
         '''
     }
 
+    void testGetTypeArgsRegisterLength() {
+        def types = { list -> list as org.objectweb.asm.Type[] }
+        def proxyGeneratorAdapter = new ProxyGeneratorAdapter([:], Object, [] as Class[], null, false, Object)
+
+        assert 2 == proxyGeneratorAdapter.getTypeArgsRegisterLength(types([org.objectweb.asm.Type.LONG_TYPE]))
+        assert 2 == proxyGeneratorAdapter.getTypeArgsRegisterLength(types([org.objectweb.asm.Type.DOUBLE_TYPE]))
+
+        assert 1 == proxyGeneratorAdapter.getTypeArgsRegisterLength(types([org.objectweb.asm.Type.BYTE_TYPE]))
+        assert 1 == proxyGeneratorAdapter.getTypeArgsRegisterLength(types([org.objectweb.asm.Type.CHAR_TYPE]))
+        assert 1 == proxyGeneratorAdapter.getTypeArgsRegisterLength(types([org.objectweb.asm.Type.INT_TYPE]))
+        assert 1 == proxyGeneratorAdapter.getTypeArgsRegisterLength(types([org.objectweb.asm.Type.FLOAT_TYPE]))
+
+        assert 1 == proxyGeneratorAdapter.getTypeArgsRegisterLength(types([org.objectweb.asm.Type.BOOLEAN_TYPE]))
+
+        assert 5 == proxyGeneratorAdapter.getTypeArgsRegisterLength(types([
+                org.objectweb.asm.Type.LONG_TYPE,
+                org.objectweb.asm.Type.LONG_TYPE,
+                org.objectweb.asm.Type.INT_TYPE ] as org.objectweb.asm.Type[]))
+    }
+
     abstract static class Foo {
         abstract String m()
     }


### PR DESCRIPTION
Minor refactoring: moved the register length computation to a separate method.
