### PR TITLE
GROOVY-5922: CompileStatic: long loses type when bitwise OR applied to i...

### DIFF
--- a/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -2412,6 +2412,11 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
                 if (isPrimitiveType(right) && initialType.isDerivedFrom(Number_TYPE)) {
                     return getWrapper(right);
                 }
+
+                if (isPrimitiveType(initialType) && rightRedirect.isDerivedFrom(Number_TYPE))  {
+                    return getUnwrapper(right);
+                }
+
                 // as anything can be assigned to a String, Class or boolean, return the left type instead
                 if (STRING_TYPE.equals(initialType)
                         || CLASS_Type.equals(initialType)

--- a/src/test/groovy/transform/stc/MiscSTCTest.groovy
+++ b/src/test/groovy/transform/stc/MiscSTCTest.groovy
@@ -218,6 +218,55 @@ class MiscSTCTest extends StaticTypeCheckingTestCase {
         '''
     }
 
+    // GROOVY-5922
+    void testUnwrapPrimitiveLongType() {
+
+        assertScript '''
+            long[] data = [0] as long[]
+
+            @ASTTest(phase=INSTRUCTION_SELECTION, value={
+                assert node.getNodeMetaData(INFERRED_TYPE) == long_TYPE
+            })
+            long mask = 0 | 0x1L
+        '''
+
+        assertScript '''
+            long[] data = [0] as long[]
+            data[0] = 0x1L
+
+            @ASTTest(phase=INSTRUCTION_SELECTION, value={
+                assert node.getNodeMetaData(INFERRED_TYPE) == long_TYPE
+            })
+            def value = data[0]
+        '''
+
+        assertScript '''
+            def c = { -> 42L }
+
+            long[] data = [0] as long[]
+
+            data[0] = c()
+
+            @ASTTest(phase=INSTRUCTION_SELECTION, value={
+                assert node.getNodeMetaData(INFERRED_TYPE) == long_TYPE
+            })
+            def value = data[0]
+        '''
+
+        assertScript '''
+            def c = { -> 42L }
+
+            Long[] data = [0] as Long[]
+
+            data[0] = c()
+
+            @ASTTest(phase=INSTRUCTION_SELECTION, value={
+                assert node.getNodeMetaData(INFERRED_TYPE) == Long_TYPE
+            })
+            def value = data[0]
+        '''
+    }
+
     public static class MiscSTCTestSupport {
         static def foo() { '123' }
     }


### PR DESCRIPTION
...t
