### PR TITLE
Updated groovy.lang.Tuple javadoc

### DIFF
--- a/src/main/groovy/lang/Tuple.java
+++ b/src/main/groovy/lang/Tuple.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2003-2007 the original author or authors.
+ * Copyright 2003-2013 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,8 +21,7 @@ import java.util.List;
 import org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation;
 
 /**
- * Represents a list of Integer objects from a specified int up to but not including
- * a given and to.
+ * Represents a list of Objects.
  * 
  * @author <a href="mailto:james@coredevelopers.net">James Strachan</a>
  * @version $Revision$


### PR DESCRIPTION
Original seems to have been mistakenly copied from IntRange
