### PR TITLE
Fixed that 'Allowed Interruption' menu item is missing at GroovyConsole on MacOSX

### DIFF
--- a/subprojects/groovy-console/src/main/groovy/groovy/ui/view/MacOSXMenuBar.groovy
+++ b/subprojects/groovy-console/src/main/groovy/groovy/ui/view/MacOSXMenuBar.groovy
@@ -106,6 +106,7 @@ menuBar {
     menu(text: 'Script', mnemonic: 'S') {
         menuItem(runAction, icon:null)
         menuItem(runSelectionAction, icon:null)
+        checkBoxMenuItem(threadInterruptAction, selected: controller.threadInterrupt)
         menuItem(interruptAction, icon:null)
         menuItem(compileAction, icon:null)
         separator()


### PR DESCRIPTION
http://jira.codehaus.org/browse/GROOVY-5958
