### PR TITLE
GROOVY-3332: The groovy.time.*Duration classes make use of java.sql.Date

### DIFF
--- a/src/main/groovy/time/DatumDependentDuration.java
+++ b/src/main/groovy/time/DatumDependentDuration.java
@@ -105,16 +105,12 @@ public class DatumDependentDuration extends BaseDuration {
         cal.add(Calendar.SECOND, -this.getSeconds());
         cal.add(Calendar.MILLISECOND, -this.getMillis());
 
-        //
-        // SqlDate should not really care about these values but it seems to "remember" them
-        // so we clear them. We do the adds first in case we get carry into the day field.
-        //
         cal.set(Calendar.HOUR_OF_DAY, 0);
         cal.set(Calendar.MINUTE, 0);
         cal.set(Calendar.SECOND, 0);
         cal.set(Calendar.MILLISECOND, 0);
 
-        return new java.sql.Date(cal.getTimeInMillis());
+        return new Date(cal.getTimeInMillis());
     }
 
     public From getFrom() {
@@ -130,16 +126,12 @@ public class DatumDependentDuration extends BaseDuration {
                 cal.add(Calendar.SECOND, DatumDependentDuration.this.getSeconds());
                 cal.add(Calendar.MILLISECOND, DatumDependentDuration.this.getMillis());
 
-                //
-                // SqlDate should not really care about these values but it seems to "remember" them
-                // so we clear them. We do the adds first in case we get carry into the day field.
-                //
                 cal.set(Calendar.HOUR_OF_DAY, 0);
                 cal.set(Calendar.MINUTE, 0);
                 cal.set(Calendar.SECOND, 0);
                 cal.set(Calendar.MILLISECOND, 0);
 
-                return new java.sql.Date(cal.getTimeInMillis());
+                return new Date(cal.getTimeInMillis());
             }
         };
     }

--- a/src/main/groovy/time/Duration.java
+++ b/src/main/groovy/time/Duration.java
@@ -88,19 +88,13 @@ public class Duration extends BaseDuration {
         cal.add(Calendar.MINUTE, -this.getMinutes());
         cal.add(Calendar.SECOND, -this.getSeconds());
         cal.add(Calendar.MILLISECOND, -this.getMillis());
-        
-        
-        //
-        // SqlDate should not really care about these values but it seems to "remember" them
-        // so we clear them.
-        // We do the adds first incase we get carry into the day field
-        //
+
         cal.set(Calendar.HOUR_OF_DAY, 0);
         cal.set(Calendar.MINUTE, 0);
         cal.set(Calendar.SECOND, 0);
         cal.set(Calendar.MILLISECOND, 0);
         
-        return new java.sql.Date(cal.getTimeInMillis());
+        return new Date(cal.getTimeInMillis());
     }
      
     public From getFrom() {
@@ -109,18 +103,13 @@ public class Duration extends BaseDuration {
             final Calendar cal = Calendar.getInstance();
 
                 cal.add(Calendar.DAY_OF_YEAR, Duration.this.getDays());
-                
-                //
-                // SqlDate should not really care about these values but it seems to "remember" them
-                // so we clear them.
-                // We do the adds first incase we get carry into the day field
-                //
+
                 cal.set(Calendar.HOUR_OF_DAY, 0);
                 cal.set(Calendar.MINUTE, 0);
                 cal.set(Calendar.SECOND, 0);
                 cal.set(Calendar.MILLISECOND, 0);
-                
-                return new java.sql.Date(cal.getTimeInMillis());
+
+                return new Date(cal.getTimeInMillis());
             }
         };
     }

--- a/src/test/groovy/time/TimeCategoryTest.groovy
+++ b/src/test/groovy/time/TimeCategoryTest.groovy
@@ -225,4 +225,13 @@ class TimeCategoryTest extends GroovyTestCase {
         }
     }
 
+    void testDateEquality() {
+        use (TimeCategory) {
+            Date dt1 = 0.days.from.now
+            Date dt2 = new Date(0.days.from.now.time)
+
+            assert dt1 == dt2
+            assert dt1.toString() == dt2.toString()
+        }
+    }
 }


### PR DESCRIPTION
Patch supplied by Brad Long.

see: https://jira.codehaus.org/browse/GROOVY-3332
