### PR TITLE
Add StringGroovyMethods#mod() for Python-like String formatting

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/StringGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/StringGroovyMethods.java
@@ -2157,6 +2157,24 @@ public class StringGroovyMethods extends DefaultGroovyMethodsSupport {
     }
 
     /**
+     * Use a String as a format string, by given the argument, return a formatted string.
+     * <p/>
+     * <p>This allows formatting String in a Python-like style:
+     * <pre>
+     * assert 'one: 1' == 'one: %d' % 1
+     * </pre>
+     * </p>
+     *
+     * @param self a format string
+     * @param arg argument referenced by the format specifiers in the format string
+     * @see String#format(String, Object...)
+     * @return a formatted string
+     */
+    public static String mod(String self, Object arg) {
+        return mod(self, new Object[] {arg});
+    }
+
+    /**
      * Use a String as a format string, by given the arguments, return a formatted string.
      * <p/>
      * <p>This allows formatting String in a Python-like style:

--- a/src/test/org/codehaus/groovy/runtime/StringGroovyMethodsTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/StringGroovyMethodsTest.groovy
@@ -20,6 +20,7 @@ import groovy.util.GroovyTestCase;
 class StringGroovyMethodsTest extends GroovyTestCase {
 
     void testModFormatString() {
+        assert 'one: 1' == 'one: %d' % 1
         assert 'one: 1' == '%s: %d' % ['one', 1]
         assert 'two: 2' == '%s: %d' % (['two', 2] as Object[])
     }


### PR DESCRIPTION
In Python, we format String like:

```
print '%s: %d' % ('one', 1)
```

We can also do it in Groovy by adding a mod() method to String:

```
println '%s: %d' % ['one', 1]
```
