### PR TITLE
GROOVY-6056 Fix for Lazy soft=true

### DIFF
--- a/src/main/org/codehaus/groovy/transform/LazyASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/LazyASTTransformation.java
@@ -81,9 +81,10 @@ public class LazyASTTransformation implements ASTTransformation, Opcodes {
 
             fieldNode.rename("$" + fieldNode.getName());
             fieldNode.setModifiers(ACC_PRIVATE | (fieldNode.getModifiers() & (~(ACC_PUBLIC | ACC_PROTECTED))));
-            
-            if (soft instanceof ConstantExpression && ((ConstantExpression) soft).getValue().equals(true))
+
+            if (soft instanceof ConstantExpression && ((ConstantExpression) soft).getValue().equals(true)) {
                 createSoft(fieldNode, init);
+            }
             else {
                 create(fieldNode, init);
                 // @Lazy not meaningful with primitive so convert to wrapper if needed
@@ -176,10 +177,13 @@ public class LazyASTTransformation implements ASTTransformation, Opcodes {
         final Statement mainIf = new IfStatement(notNullExpr(resExpr), new ExpressionStatement(resExpr), elseBlock);
 
         if (fieldNode.isVolatile()) {
+            final BlockStatement mainIfBlock = new BlockStatement();
+            mainIfBlock.addStatement( assignStatement(resExpr, callExpression) );
+            mainIfBlock.addStatement( mainIf );
             body.addStatement(new IfStatement(
                     notNullExpr(resExpr),
                     new ExpressionStatement(resExpr),
-                    new SynchronizedStatement(syncTarget(fieldNode), mainIf)
+                    new SynchronizedStatement(syncTarget(fieldNode), mainIfBlock)
             ));
         } else {
             body.addStatement(mainIf);

--- a/src/test/groovy/transform/LazyTest.groovy
+++ b/src/test/groovy/transform/LazyTest.groovy
@@ -1,0 +1,71 @@
+package groovy.transform
+
+import java.lang.ref.SoftReference
+import java.lang.reflect.Modifier
+
+/**
+ * Unit tests for the Lazy annotation
+ *
+ * @author Tim Yates
+ */
+class LazyTest extends GroovyTestCase {
+    public void testLazyPrimitiveWrapping() {
+        def tester = new GroovyClassLoader().parseClass( 
+          '''class MyClass {
+            |    @Lazy int index = { ->
+            |        1
+            |    }
+            |}'''.stripMargin() )
+        // Should be a private non-volatile Integer
+        def field = tester.getDeclaredField( '$index' )
+        assert field
+        assert Modifier.isPrivate(field.modifiers)
+        assert !Modifier.isVolatile(field.modifiers)
+        assert field.type == Integer
+    }
+
+    public void testLazyVolatilePrimitiveWrapping() {
+        def tester = new GroovyClassLoader().parseClass( 
+          '''class MyClass {
+            |    @Lazy volatile int index = { ->
+            |        1
+            |    }
+            |}'''.stripMargin() )
+        // Should be a private volatile Integer
+        def field = tester.getDeclaredField( '$index' )
+        assert field
+        assert Modifier.isPrivate(field.modifiers)
+        assert Modifier.isVolatile(field.modifiers)
+        assert field.type == Integer
+    }
+
+    public void testLazySoftPrimitiveWrapping() {
+        def tester = new GroovyClassLoader().parseClass( 
+          '''class MyClass {
+            |    @Lazy(soft=true) int index = { ->
+            |        1
+            |    }
+            |}'''.stripMargin() )
+        // Should be a private non-volatile SoftReference
+        def field = tester.getDeclaredField( '$index' )
+        assert field
+        assert Modifier.isPrivate(field.modifiers)
+        assert !Modifier.isVolatile(field.modifiers)
+        assert field.type == SoftReference
+    }
+
+    public void testLazyVolatileSoftPrimitiveWrapping() {
+        def tester = new GroovyClassLoader().parseClass( 
+          '''class MyClass {
+            |    @Lazy(soft=true) volatile int index = { ->
+            |        1
+            |    }
+            |}'''.stripMargin() )
+        // Should be a private volatile SoftReference
+        def field = tester.getDeclaredField( '$index' )
+        assert field
+        assert Modifier.isPrivate(field.modifiers)
+        assert Modifier.isVolatile(field.modifiers)
+        assert field.type == SoftReference
+    }
+}


### PR DESCRIPTION
http://jira.codehaus.org/browse/GROOVY-6056

Adds `res = $var?.get()` before testing for `null` inside the `synchronized` block of DCL
