### PR TITLE
Added ClosureScript class

### DIFF
--- a/src/main/groovy/util/DelegatingScript.java
+++ b/src/main/groovy/util/DelegatingScript.java
@@ -1,0 +1,120 @@
+package groovy.util;
+
+import groovy.lang.Binding;
+import groovy.lang.Closure;
+import groovy.lang.MetaClass;
+import groovy.lang.MissingMethodException;
+import groovy.lang.MissingPropertyException;
+import groovy.lang.Script;
+import org.codehaus.groovy.runtime.InvokerHelper;
+
+/**
+ * {@link Script} that performs method invocations and property access like {@link Closure} does.
+ *
+ * <p>
+ * {@link DelegatingScript} is a convenient basis for loading a custom-defined DSL as a {@link Script}, then execute it.
+ * The following sample code illustrates how to do it:
+ *
+ * <pre>
+ * class MyDSL {
+ *     public void foo(int x, int y, Closure z) { ... }
+ *     public void setBar(String a) { ... }
+ * }
+ *
+ * CompilerConfiguration cc = new CompilerConfiguration();
+ * cc.setScriptBaseClass(DelegatingScript.class);
+ * GroovyShell sh = new GroovyShell(cl,new Binding(),cc);
+ * DelegatingScript script = (DelegatingScript)sh.parse(new File("my.dsl"))
+ * script.setDelegate(new MyDSL());
+ * script.run();
+ * </pre>
+ *
+ * <p>
+ * <tt>my.dsl</tt> can look like this:
+ *
+ * <pre>
+ * foo(1,2) {
+ *     ....
+ * }
+ * bar = ...;
+ * </pre>
+ *
+ * <p>
+ * {@link DelegatingScript} does this by delegating property access and method invocation to the <tt>delegate</tt> object.
+ *
+ * <p>
+ * More formally speaking, given the following script:
+ *
+ * <pre>
+ * a = 1;
+ * b(2);
+ * </pre>
+ *
+ * <p>
+ * Using {@link DelegatingScript} as the base class, the code will run as:
+ *
+ * <pre>
+ * delegate.a = 1;
+ * delegate.b(2);
+ * </pre>
+ *
+ * ... whereas in plain {@link Script}, this will be run as:
+ *
+ * <pre>
+ * binding.setProperty("a",1);
+ * ((Closure)binding.getProperty("b")).call(2);
+ * </pre>
+ *
+ * @author Kohsuke Kawaguchi
+ */
+public abstract class DelegatingScript extends Script {
+    private Object delegate;
+    private MetaClass metaClass;
+
+    protected DelegatingScript() {
+        super();
+    }
+
+    protected DelegatingScript(Binding binding) {
+        super(binding);
+    }
+
+    /**
+     * Sets the delegation target.
+     */
+    public void setDelegate(Object delegate) {
+        this.delegate = delegate;
+        this.metaClass = InvokerHelper.getMetaClass(delegate.getClass());
+    }
+
+    @Override
+    public Object invokeMethod(String name, Object args) {
+        try {
+            return metaClass.invokeMethod(delegate,name,args);
+        } catch (MissingMethodException mme) {
+            return super.invokeMethod(name, args);
+        }
+    }
+
+    @Override
+    public Object getProperty(String property) {
+        try {
+            return metaClass.getProperty(delegate,property);
+        } catch (MissingPropertyException e) {
+            return super.getProperty(property);
+        }
+    }
+
+    @Override
+    public void setProperty(String property, Object newValue) {
+        try {
+            metaClass.setProperty(delegate,property,newValue);
+        } catch (MissingPropertyException e) {
+            super.setProperty(property,newValue);
+        }
+    }
+
+    public Object getDelegate() {
+        return delegate;
+    }
+}

--- a/src/main/org/codehaus/groovy/control/CompilerConfiguration.java
+++ b/src/main/org/codehaus/groovy/control/CompilerConfiguration.java
@@ -16,6 +16,7 @@
 
 package org.codehaus.groovy.control;
 
+import groovy.lang.Script;
 import org.codehaus.groovy.control.customizers.CompilationCustomizer;
 import org.codehaus.groovy.control.io.NullWriter;
 import org.codehaus.groovy.control.messages.WarningMessage;
@@ -620,6 +621,14 @@ public class CompilerConfiguration {
      */
     public void setScriptBaseClass(String scriptBaseClass) {
         this.scriptBaseClass = scriptBaseClass;
+    }
+
+    /**
+     * Sets the name of the base class for scripts.  It must be a subclass
+     * of Script.
+     */
+    public void setScriptBase(Class<? extends Script> baseClass) {
+        setScriptBaseClass(baseClass==null ? null : baseClass.getName());
     }
 
     public ParserPluginFactory getPluginFactory() {

--- a/src/test/groovy/util/DelegatingScriptTest.groovy
+++ b/src/test/groovy/util/DelegatingScriptTest.groovy
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2003-2011 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package groovy.util
+
+import org.codehaus.groovy.control.CompilerConfiguration
+
+public class DelegatingScriptTest extends GroovyTestCase {
+    public void testDelegatingScript() throws Exception {
+        def cc = new CompilerConfiguration();
+        cc.scriptBase = DelegatingScript.class;
+        def sh = new GroovyShell(new Binding(), cc);
+        def script = (DelegatingScript)sh.parse("""
+            println DelegatingScript.class
+            foo(3,2){ a,b -> a*b };
+            bar='test';
+            assert 'testsetget'==bar
+        """)
+        def dsl = new MyDSL()
+        script.setDelegate(dsl);
+        script.run();
+        assert dsl.foo==6;
+        assert dsl.innerBar()=='testset';
+    }
+}
+
+class MyDSL {
+    protected int foo;
+    protected String bar;
+
+    public void foo(int x, int y, Closure z) { foo = z(x, y); }
+    public void setBar(String a) {
+        this.bar = a+"set";
+    }
+    public String getBar() {
+        return this.bar+"get";
+    }
+
+    String innerBar() {
+        return this.bar;
+    }
+}


### PR DESCRIPTION
This is a convenient `Script` subtype that performs method invocations and property access like `Closure` does.

For example, when the script is:

```
a = 1;
b(2);
```

Using `ClosureScript` as the base class would run it as:

```
delegate.a = 1;
delegate.b(2);
```

... whereas in plain `Script`, this will be run as:

```
binding.setProperty("a",1);
((Closure)binding.getProperty("b")).call(2);
```

This makes it a convenient basis for loading a custom-defined DSL as a `Script`, then execute it.
The following sample code illustrates how to do it:

```
class MyDSL {
    public void foo(int x, int y, Closure z) { ... }
}

CompilerConfiguration cc = new CompilerConfiguration();
cc.setScriptBaseClass(ClosureScript.class.getName());
GroovyShell sh = new GroovyShell(cl,new Binding(),cc);
ClosureScript script = (ClosureScript)sh.parse(new File("my.dsl"))
script.setDelegate(new MyDSL());
script.run();
```

<tt>my.dsl</tt> can look like this:

```
foo(1,2) {
    ....
}
```

I find this useful in a number of places (for example in Jenkins where we define several Groovy DSLs), so I'm trying to push this back to the upstream.
