### PR TITLE
GROOVY-5875: Cannot use DELEGATE_FIRST and delegates that are inner clas...

### DIFF
--- a/src/main/groovy/lang/Closure.java
+++ b/src/main/groovy/lang/Closure.java
@@ -319,6 +319,7 @@ public abstract class Closure<V> extends GroovyObjectSupport implements Cloneabl
         try {
             // let's try getting the property on the first object
             return InvokerHelper.getProperty(firstTry, property);
+
         } catch (MissingPropertyException e1) {
             if (secondTry != null && firstTry != this && firstTry != secondTry) {
                 try {
@@ -329,6 +330,17 @@ public abstract class Closure<V> extends GroovyObjectSupport implements Cloneabl
                 }
             }
             throw e1;
+
+        } catch (MissingFieldException e2)  { // see GROOVY-5875
+            if (secondTry != null && firstTry != this && firstTry != secondTry) {
+                try {
+                    // let's try getting the property on the second object
+                    return InvokerHelper.getProperty(secondTry, property);
+                } catch (GroovyRuntimeException e3) {
+                    // ignore, we'll throw e2
+                }
+            }
+            throw e2;
         }
     }
 

--- a/src/test/groovy/ClosureTest.groovy
+++ b/src/test/groovy/ClosureTest.groovy
@@ -390,6 +390,65 @@ class ClosureTest extends GroovyTestCase {
             '''
         }
     }
+
+    // GROOVY-5875
+    void testStaticInnerClassDelegateFirstAccess() {
+        assertScript '''
+             class Owner {
+                 Object delegate
+                 String ownerProp = "owner"
+
+                 void run() {
+                     def c = {
+                         delegateProp = ownerProp
+                     }
+                     c.delegate = delegate
+                     c.resolveStrategy = Closure.DELEGATE_FIRST
+                     c()
+                     assert c.delegate.delegateProp == ownerProp
+                 }
+             }
+
+             class Container {
+                 static class Delegate {
+                      String delegateProp = "delegate"
+                 }
+             }
+
+             def owner = new Owner()
+             owner.delegate = new Container.Delegate()
+             owner.run()
+        '''
+    }
+
+    void testStaticInnerClassOwnerFirstAccess() {
+        assertScript '''
+             class Owner {
+                 Object delegate
+                 String ownerProp = "owner"
+
+                 void run() {
+                     def c = {
+                         delegateProp = ownerProp
+                     }
+                     c.delegate = delegate
+                     c.resolveStrategy = Closure.OWNER_FIRST
+                     c()
+                     assert c.delegate.delegateProp == ownerProp
+                 }
+             }
+
+             class Container {
+                 static class Delegate {
+                      String delegateProp = "delegate"
+                 }
+             }
+
+             def owner = new Owner()
+             owner.delegate = new Container.Delegate()
+             owner.run()
+        '''
+    }
 }
 
 public class TinyAgent {


### PR DESCRIPTION
...ses.

http://jira.codehaus.org/browse/GROOVY-5875

As described in GROOVY-5875, this patch fixes an edge-case where a static inner class is used as delegate object on a closure. As the accessed property is not found in the inner class, the propertyMissing implementation from the inner class jumps in (it is added by InnerClassCompletionVisitor#addDefaultMethods) and triggers a MissingFieldException and the resolve mechanism breaks.

Please review this pull request carefully, as it patches the behaviour of Closure#getPropertyTryThese.
