### PR TITLE
Check groovy.home ant property first (#GROOVY-6102)

### DIFF
--- a/subprojects/groovy-ant/src/main/java/org/codehaus/groovy/ant/Groovy.java
+++ b/subprojects/groovy-ant/src/main/java/org/codehaus/groovy/ant/Groovy.java
@@ -105,6 +105,7 @@ public class Groovy extends Java {
     private CompilerConfiguration configuration = new CompilerConfiguration();
 
     private Commandline cmdline = new Commandline();
+    private Commandline cmdlineJava = new Commandline();
     private boolean contextClassLoader;
 
     /**
@@ -338,6 +339,10 @@ public class Groovy extends Java {
 
     public Commandline.Argument createArg() {
         return cmdline.createArgument();
+    }
+
+    public Commandline.Argument createJvmarg() {
+        return cmdlineJava.createArgument();
     }
 
     /**
@@ -590,6 +595,10 @@ public class Groovy extends Java {
         commandline[0] = tempFile.getCanonicalPath();
         System.arraycopy(args, 0, commandline, 1, args.length);
         super.clearArgs();
+        for (String jvmarg : cmdlineJava.getCommandline()) {
+            final Commandline.Argument argument = super.createJvmarg();
+            argument.setValue(jvmarg);
+        }
         for (String arg : commandline) {
             final Commandline.Argument argument = super.createArg();
             argument.setValue(arg);


### PR DESCRIPTION
Check groovy.home ant property first, so people can have their own
project specific setting for groovy home which tend to be easier to use
when multiple groovy versions are being used.
