### PR TITLE
GROOVY-6012: Source encoding is not used when scripts are reloaded

### DIFF
--- a/src/main/groovy/util/GroovyScriptEngine.java
+++ b/src/main/groovy/util/GroovyScriptEngine.java
@@ -90,9 +90,13 @@ public class GroovyScriptEngine implements ResourceConnector {
     private final ClassLoader parentLoader;
     private final GroovyClassLoader groovyLoader;
     private final Map<String, ScriptCacheEntry> scriptCache = new ConcurrentHashMap<String, ScriptCacheEntry>();
-    private CompilerConfiguration config = new CompilerConfiguration(CompilerConfiguration.DEFAULT) {
-        {{ setSourceEncoding("UTF-8"); }}
-    };
+    private CompilerConfiguration config;
+
+    {
+        config = new CompilerConfiguration(CompilerConfiguration.DEFAULT);
+        config.setSourceEncoding("UTF-8");
+    }
+
 
     //TODO: more finals?
 


### PR DESCRIPTION
Any suggestion on how to add a system-independent unit test is welcome
