### PR TITLE
Fix GROOVY-6143: Groovysh vulnerable to instances with custom getProperty()

### DIFF
--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/Groovysh.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/Groovysh.groovy
@@ -344,8 +344,9 @@ class Groovysh extends Shell {
         boolean showLastResult = !io.quiet && (io.verbose || Preferences.showLastResult)
         if (showLastResult) {
             // Need to use String.valueOf() here to avoid icky exceptions causes by GString coercion
-            if (result != null && result.class && result.class.isArray()) {
-                Class typeClass = result.class.getComponentType()
+
+            if (result != null && result.getClass() && result.getClass().isArray()) {
+                Class typeClass = result.getClass().getComponentType()
                 StringBuilder output = new StringBuilder()
                 if (result.length > 0) {
                     output.append(String.valueOf(Arrays.toString(result)))
@@ -382,7 +383,7 @@ class Groovysh extends Shell {
     final Closure defaultErrorHook = { Throwable cause ->
         assert cause != null
 
-        io.err.println("@|bold,red ERROR|@ ${cause.class.name}:")
+        io.err.println("@|bold,red ERROR|@ ${cause.getClass().name}:")
         io.err.println("@|bold,red ${cause.message}|@")
 
         maybeRecordError(cause)

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/GroovyshTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/GroovyshTest.groovy
@@ -55,6 +55,13 @@ class GroovyshTest extends GroovyTestCase {
         }
     }
 
+    void testMissingPropertyExpr() {
+        Groovysh groovysh = new Groovysh(testio)
+        // this is a special case, e.g. happens for Gradle DefaultExtraPropertiesExtension
+        // assert no fail
+        groovysh.execute("x = new Object() {public Object getProperty(String name) {throw new MissingPropertyException('From test', name, null)}}")
+    }
+
     void testDisplayBuffer() {
         Groovysh groovysh = new Groovysh(testio)
         groovysh.displayBuffer(["foo", "bar"])


### PR DESCRIPTION
Also adds tab completion for properties.

See http://jira.codehaus.org/browse/GROOVY-6143
