### PR TITLE
GROOVY-6152: LazyList does not allow range access

### DIFF
--- a/src/main/groovy/lang/ListWithDefault.java
+++ b/src/main/groovy/lang/ListWithDefault.java
@@ -15,6 +15,7 @@
  */
 package groovy.lang;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
@@ -40,13 +41,25 @@ public final class ListWithDefault<T> implements List<T> {
         this.initClosure = initClosure;
     }
 
+    public List<T> getDelegate() {
+        return delegate != null ? new ArrayList<T>(delegate) : null;
+    }
+
+    public boolean isLazyDefaultValues() {
+        return lazyDefaultValues;
+    }
+
+    public Closure getInitClosure() {
+        return initClosure != null ? (Closure) initClosure.clone() : null;
+    }
+
     public static <T> List<T> newInstance(List<T> items, boolean lazyDefaultValues, Closure initClosure) {
         if (items == null)
             throw new IllegalArgumentException("Parameter \"items\" must not be null");
         if (initClosure == null)
             throw new IllegalArgumentException("Parameter \"initClosure\" must not be null");
 
-        return new ListWithDefault<T>(items, lazyDefaultValues, initClosure);
+        return new ListWithDefault<T>(new ArrayList<T>(items), lazyDefaultValues, (Closure) initClosure.clone());
     }
 
     public int size() {
@@ -140,16 +153,18 @@ public final class ListWithDefault<T> implements List<T> {
 
         final int size = size();
         int normalisedIndex = normaliseIndex(index, size);
+        if (normalisedIndex < 0) {
+            throw new ArrayIndexOutOfBoundsException("Negative array index [" + normalisedIndex + "] too large for array size " + size);
+        }
 
         // either index >= size or the normalised index is negative
-        if (normalisedIndex >= size || normalisedIndex < 0) {
-            final boolean prepend = (normalisedIndex < 0);
+        if (normalisedIndex >= size) {
             // find out the number of gaps to fill with null/the default value
-            final int gapCount = (prepend ? ((normalisedIndex + 1) * -1) : normalisedIndex - size);
+            final int gapCount = normalisedIndex - size;
 
             // fill all gaps
             for (int i = 0; i < gapCount; i++) {
-                final int idx = prepend ? 0 : size();
+                final int idx = size();
 
                 // if we lazily create default values, use 'null' as placeholder
                 if (lazyDefaultValues)
@@ -159,7 +174,7 @@ public final class ListWithDefault<T> implements List<T> {
             }
 
             // add the first/last element being always the default value
-            final int idx = prepend ? 0 : normalisedIndex;
+            final int idx = normalisedIndex;
             delegate.add(idx, getDefaultValue(idx));
 
             // normalise index again to get positive index

--- a/src/test/groovy/ListTest.groovy
+++ b/src/test/groovy/ListTest.groovy
@@ -405,22 +405,14 @@ class ListTest extends GroovyTestCase {
     }
 
     // GROOVY-4946
-    void testWithLazyDefault() {
+    void testLazyDefault() {
         def l1 = [].withLazyDefault { 42 }
         assert l1[0] == 42
         assert l1[2] == 42
         assert l1 == [42, null, 42]
-        assert l1[-1] == 42
-        assert l1[-3] == 42
         assert l1[1] == 42
 
-        def l2 = [].withLazyDefault { 42 }
-        assert l2[-1] == 42
-        assert l2.size() == 1
-        assert l2[0] == 42
-
         def l3 = [].withLazyDefault { it }
-        assert l3[-1] == 0
         assert l3[1] == 1
         assert l3[3] == 3
 
@@ -431,21 +423,19 @@ class ListTest extends GroovyTestCase {
         assert l4 == [0, 1, null, 3]
 
         def l5 = [].withLazyDefault { it }
-        assert l5[-1] == 0
         assert l5[1] == 1
         assert l5[3] == 3
         assert l5[5] == 5
-        assert l5 == [0, 1, null, 3, null, 5]
+        assert l5 == [null, 1, null, 3, null, 5]
 
         def l6 = [].withLazyDefault { int index -> index }
-        assert l6[-1] == 0
         assert l6[1] == 1
         assert l6[3] == 3
         assert l6[5] == 5
-        assert l6[0..5] == [0, 1, null, 3, null, 5]
+        assert l6[0..5] == [null, 1, null, 3, null, 5]
     }
 
-    void testWithEagerDefault() {
+    void testEagerDefault() {
         def l1 = [].withEagerDefault { 42 }
         assert l1[0] == 42
         assert l1[2] == 42
@@ -455,12 +445,9 @@ class ListTest extends GroovyTestCase {
         assert l1[-3] == 42
 
         def l2 = [].withEagerDefault { 42 }
-        assert l2[-1] == 42
-        assert l2.size() == 1
         assert l2[0] == 42
 
         def l3 = [].withEagerDefault { it }
-        assert l3[-1] == 0
         assert l3[1] == 1
         assert l3[3] == 3
         assert l3 == [0, 1, 2, 3]
@@ -472,21 +459,19 @@ class ListTest extends GroovyTestCase {
         assert l4 == [0, 1, null, 3]
 
         def l5 = [].withEagerDefault { it }
-        assert l5[-1] == 0
         assert l5[1] == 1
         assert l5[3] == 3
         assert l5[5] == 5
         assert l5 == [0, 1, 2, 3, 4, 5]
 
         def l6 = [].withEagerDefault { int index -> index }
-        assert l6[-1] == 0
         assert l6[1] == 1
         assert l6[3] == 3
         assert l6[5] == 5
         assert l6[0..5] == [0, 1, 2, 3, 4, 5]
     }
 
-    void testWithDefaultReturnWithDefaultSubList() {
+    void testDefaultReturnWithDefaultSubList() {
         def l1 = [].withLazyDefault { 42 }
         assert l1[2] == 42
         assert l1 == [null, null, 42]
@@ -497,16 +482,191 @@ class ListTest extends GroovyTestCase {
         assert l2 == [null, null, 42]
     }
 
-    void testWithDefaultRedirectsToWithLazyDefault() {
+    void testDefaultRedirectsToWithLazyDefault() {
         def l1 = [].withDefault { 42 }
         assert l1[2] == 42
         assert l1 == [null, null, 42]
     }
 
-    void testWithDefaultNullAsDefaultValue() {
+    void testDefaultNullAsDefaultValue() {
         def l1 = [].withEagerDefault { null }
         assert l1[0] == null
         assert l1[2] == null
         assert l1 == [null, null, null]
+    }
+
+    void testLazyListAndRangeAccess() {
+        def l1 = [].withDefault { 42 }
+        assert [null, 42] == l1[1..2]
+    }
+
+    void testEagerListAndRangeAccess() {
+        def l1 = [].withEagerDefault { 42 }
+        assert [42, 42] == l1[1..2]
+    }
+
+    void testLazyListAndNegativeIndexAccess() {
+        def l1 = [].withDefault { 42 }
+        assert 42 == l1[1]
+        assert 42 == l1[-1]
+    }
+
+    void testeEagerListAndNegativeIndexAccess() {
+        def l1 = [].withEagerDefault { 42 }
+        assert 42 == l1[1]
+        assert 42 == l1[-1]
+    }
+
+    void testLazyListAndNegativeRangeAccess() {
+        def l1 = [].withDefault { 42 }
+        assert 42 == l1[0]
+        assert 42 == l1[1]
+
+        def subList = l1[0..-1]
+        assert [42, 42] == subList
+    }
+
+    void testEagerListAndNegativeRangeAccess() {
+        def l1 = [].withEagerDefault { 42 }
+        assert 42 == l1[0]
+        assert 42 == l1[1]
+
+        def subList = l1[0..-1]
+        assert [42, 42] == subList
+    }
+
+    void testLazyListAndFailingNegativeRangeAccess() {
+        def l1 = [].withDefault { 42 }
+
+        shouldFail(ArrayIndexOutOfBoundsException) {
+            l1[-42..0]
+        }
+    }
+
+    void testEagerListAndFailingNegativeRangeAccess() {
+        def l1 = [].withEagerDefault { 42 }
+
+        shouldFail(ArrayIndexOutOfBoundsException) {
+            l1[-42..0]
+        }
+    }
+
+    void testLazyListAndEmptyRangeAccess() {
+        def l1 = [].withDefault { 42 }
+        assert l1[0..<0] instanceof ListWithDefault
+    }
+
+    void testEagerListAndEmptyRangeAccess() {
+        def l1 = [].withEagerDefault { 42 }
+        assert l1[0..<0] instanceof ListWithDefault
+    }
+
+    void testLazyListAndReversedRangeAccess() {
+        def l1 = [].withDefault { 42 }
+
+        assert 42 == l1[0]
+        assert 42 == l1[1]
+        assert 42 == l1[2]
+
+        def subList = l1[2..0]
+        assert subList instanceof ListWithDefault
+    }
+
+    void testEagerListAndReversedRangeAccess() {
+        def l1 = [].withEagerDefault { 42 }
+
+        assert 42 == l1[0]
+        assert 42 == l1[1]
+        assert 42 == l1[2]
+
+        def subList = l1[2..0]
+        assert subList instanceof ListWithDefault
+    }
+
+    void testLazyListAndCollectionOfIndices() {
+        def l1 = [].withDefault { 42 }
+        assert [42, 42, 42] == l1[0,1,2]
+        assert l1.size() == 3
+    }
+
+    void testEagerListAndCollectionOfIndices() {
+        def l1 = [].withEagerDefault { 42 }
+        assert [42, 42, 42] == l1[0,1,2]
+        assert l1.size() == 3
+    }
+
+    void testLazyListAndCollectionOfCollectionIndices() {
+        def l1 = [].withDefault { 42 }
+        assert [42, 42, 42] == l1[0,[1,2]]
+        assert l1.size() == 3
+    }
+
+    void testLazyListAndCollectionOfRangeIndices() {
+        def l1 = [].withDefault { 42 }
+        assert [42, null, 42] == l1[0,[1..2]]
+        assert l1.size() == 3
+    }
+
+    void testEagerListAndCollectionOfRangeIndices() {
+        def l1 = [].withEagerDefault { 42 }
+        assert [42, 42, 42] == l1[0,[1..2]]
+        assert l1.size() == 3
+    }
+
+    void testDefaultAndCollectionOfIndicesReturnsCorrectType() {
+        def l1 = [].withDefault { 42 }
+        assert  l1[0,[1..2]] instanceof ListWithDefault
+    }
+
+    void testLazyListAndUnorderedCollectionIndices() {
+        def l1 = [].withLazyDefault { 42 }
+
+        assert [42, 42, 42] == l1[2, 0, 3]
+    }
+
+    void testLazyListAndNegativeReversedRangeAccess() {
+        def a = [1].withDefault {42}
+        assert a[2..-1] == [42, null, 1]
+    }
+
+    void testEagerListAndNegativeReversedRangeAccess() {
+        def a = [1].withEagerDefault {42}
+        assert a[2..-1] == [42, 42, 1]
+    }
+
+    void testEagerListAndNegativeCollectionIndicesAccess() {
+        def a = [1].withEagerDefault {42}
+        assert a[0,-1] == [1, 1]
+    }
+
+    void testEagerLazyListInvocation() {
+        def a = [1].withEagerDefault {42}.withEagerDefault {43}
+        assert a[0,2,-1] == [1, 43, 43]
+    }
+
+    void testEagerListWithNegativeIndex() {
+        def a = [].withEagerDefault { 42 }
+        shouldFail(ArrayIndexOutOfBoundsException) {
+            a[-2]
+        }
+    }
+
+    void testLazyListCollectionIndicesSubList() {
+        def list = [1].withDefault{42}
+        assert list[4] == 42
+        assert list == [1, null, null, null, 42]
+
+        def sub = list[0,2,4]
+        assert sub.size() == 3
+        assert sub[3] == 42
+    }
+
+    void testLazyListRangeIndexSubList() {
+        def list = [1].withDefault{42}
+        assert list[4] == 42
+        assert list == [1, null, null, null, 42]
+
+        def sub = list[0..4]
+        assert sub[5] == 42
     }
 }


### PR DESCRIPTION
Fixes the behavior described in GROOVY-6152 so that indexing negative, non-existent positions (with multiple indices, single index access and ranges) will not cause the ListWithDefault to grow, but to throw an AIOBE. In addition, whenever a sublist is returned (.e.g caused by a range index), the sublist type will be ListWithDefault with the settings from its parent list.
