### PR TITLE
Fix 2 problems with Filename completion:

### DIFF
--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/InteractiveShellRunner.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/InteractiveShellRunner.groovy
@@ -18,7 +18,7 @@ package org.codehaus.groovy.tools.shell
 
 import jline.console.ConsoleReader
 import jline.console.completer.AggregateCompleter
-import jline.console.completer.FileNameCompleter
+
 import jline.console.history.FileHistory
 import org.codehaus.groovy.tools.shell.completion.*
 import org.codehaus.groovy.tools.shell.util.Logger
@@ -62,7 +62,7 @@ class InteractiveShellRunner
                         new VariableSyntaxCompletor(shell),
                         new CustomClassSyntaxCompletor(shell),
                         new ImportsSyntaxCompletor(shell)],
-                new FileNameCompleter()))
+                new FileNameCompleter(false)))
     }
     
     void run() {

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/completion/FileNameCompleter.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/completion/FileNameCompleter.groovy
@@ -1,0 +1,159 @@
+package org.codehaus.groovy.tools.shell.completion
+
+import jline.console.completer.Completer
+
+/*
+ * Copyright (c) 2002-2012, the original author or authors.
+ *
+ * This software is distributable under the BSD license. See the terms of the
+ * BSD license in the documentation provided with this software.
+ *
+ * http://www.opensource.org/licenses/bsd-license.php
+ */
+
+
+import jline.internal.Configuration;
+
+import java.io.File;
+import java.util.List;
+
+import static jline.internal.Preconditions.checkNotNull;
+
+/**
+ * PATCHED copy from jline2.10, included
+ * https://github.com/jline/jline2/pull/88
+ * https://github.com/jline/jline2/issues/90
+ *
+ * A file name completer takes the buffer and issues a list of
+ * potential completions.
+ * <p/>
+ * This completer tries to behave as similar as possible to
+ * <i>bash</i>'s file name completion (using GNU readline)
+ * with the following exceptions:
+ * <p/>
+ * <ul>
+ * <li>Candidates that are directories will end with "/"</li>
+ * <li>Wildcard regular expressions are not evaluated or replaced</li>
+ * <li>The "~" character can be used to represent the user's home,
+ * but it cannot complete to other users' homes, since java does
+ * not provide any way of determining that easily</li>
+ * </ul>
+ *
+ * @author <a href="mailto:mwp1@cornell.edu">Marc Prud'hommeaux</a>
+ * @author <a href="mailto:jason@planet57.com">Jason Dillon</a>
+ * @since 2.3
+ */
+public class FileNameCompleter
+implements Completer
+{
+    // TODO: Handle files with spaces in them
+
+    private static final boolean OS_IS_WINDOWS;
+
+    private final boolean blankSuffix = true;
+
+    static {
+        String os = Configuration.getOsName();
+        OS_IS_WINDOWS = os.contains("windows");
+    }
+
+    public FileNameCompleter() {
+    }
+
+    public FileNameCompleter(boolean blankSuffix) {
+        this.blankSuffix = blankSuffix;
+    }
+
+    public int complete(String buffer, final int cursor, final List<CharSequence> candidates) {
+        // buffer can be null
+        checkNotNull(candidates);
+
+        if (buffer == null) {
+            buffer = "";
+        }
+
+        if (OS_IS_WINDOWS) {
+            buffer = buffer.replace('/', '\\');
+        }
+
+        String translated = buffer;
+
+        File homeDir = getUserHome();
+
+        // Special character: ~ maps to the user's home directory
+        if (translated.startsWith("~" + separator())) {
+            translated = homeDir.getPath() + translated.substring(1);
+        }
+        else if (translated.startsWith("~")) {
+            translated = homeDir.getParentFile().getAbsolutePath();
+        }
+        else if (!(new File(translated).isAbsolute())) {
+            String cwd = getUserDir().getAbsolutePath();
+            translated = cwd + separator() + translated;
+        }
+
+        File file = new File(translated);
+        final File dir;
+
+        if (translated.endsWith(separator())) {
+            dir = file;
+        }
+        else {
+            dir = file.getParentFile();
+        }
+
+        File[] entries = dir == null ? new File[0] : dir.listFiles();
+
+        return matchFiles(buffer, translated, entries, candidates);
+    }
+
+    protected String separator() {
+        return File.separator;
+    }
+
+    protected File getUserHome() {
+        return Configuration.getUserHome();
+    }
+
+    protected File getUserDir() {
+        return new File(".");
+    }
+
+    protected int matchFiles(final String buffer, final String translated, final File[] files, final List<CharSequence> candidates) {
+        if (files == null) {
+            return -1;
+        }
+
+        int matches = 0;
+
+        // first pass: just count the matches
+        for (File file : files) {
+            if (file.getAbsolutePath().startsWith(translated)) {
+                matches++;
+            }
+        }
+        for (File file : files) {
+            if (file.getAbsolutePath().startsWith(translated)) {
+                CharSequence name = file.getName()
+                if (matches == 1) {
+                    if (file.isDirectory()) {
+                        name += separator();
+                    } else {
+                        if (blankSuffix) {
+                            name += ' ';
+                        }
+                    }
+                }
+                candidates.add(render(file, name).toString());
+            }
+        }
+
+        final int index = buffer.lastIndexOf(separator());
+
+        return index + separator().length();
+    }
+
+    protected CharSequence render(final File file, final CharSequence name) {
+        return name;
+    }
+}

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/completion/GroovySyntaxCompletor.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/completion/GroovySyntaxCompletor.groovy
@@ -18,7 +18,6 @@ package org.codehaus.groovy.tools.shell.completion
 
 import antlr.TokenStreamException
 import jline.console.completer.Completer
-import jline.console.completer.FileNameCompleter
 import org.codehaus.groovy.antlr.GroovySourceToken
 import org.codehaus.groovy.antlr.SourceBuffer
 import org.codehaus.groovy.antlr.UnicodeEscapingReader
@@ -54,7 +53,7 @@ class GroovySyntaxCompletor implements Completer {
     GroovySyntaxCompletor(Groovysh shell,
                           ReflectionCompletor reflectionCompletor,
                           List<IdentifierCompletor> identifierCompletors,
-                          FileNameCompleter filenameCompletor) {
+                          Completer filenameCompletor) {
         this.shell = shell
         this.identifierCompletors = identifierCompletors
         this.reflectionCompletor = reflectionCompletor


### PR DESCRIPTION
Absolute path completion broken on Windows
path completion adds blank at the end of filenames, which is annoying in groovysh

This copies FileNameCompleter from JLine2.10, possibly one day in the future,
JLine might provided fixes on its own. However having a Groovy-maintained
FileNameCompleter does not hurt.
