### PR TITLE
Fix typo in method name.

### DIFF
--- a/src/main/groovy/util/FactoryBuilderSupport.java
+++ b/src/main/groovy/util/FactoryBuilderSupport.java
@@ -806,7 +806,7 @@ public abstract class FactoryBuilderSupport extends Binding {
      */
     @Deprecated
     protected Object dispathNodeCall(Object name, Object args) {
-        return dispathNodeCall(name, args);
+        return dispatchNodeCall(name, args);
     }
 
     protected Object dispatchNodeCall(Object name, Object args) {


### PR DESCRIPTION
dispathNodeCall -> dispatchNodeCall

Let me know if I need to submit this to a different branch, if I missed anything.

I probably missed an invocation (or two) of the method, because I'm committing from github's web interface.
