### PR TITLE
fixed template of "index-all.html" to be parsed by Dash's javadocset command

### DIFF
--- a/subprojects/groovy-docgenerator/src/main/resources/org/codehaus/groovy/tools/template.index-all.html
+++ b/subprojects/groovy-docgenerator/src/main/resources/org/codehaus/groovy/tools/template.index-all.html
@@ -64,13 +64,11 @@ function asd()
             -->
             
             <% indexMapEntry.value.each{ it -> %>
-            <DT> 
-            <% if (it.'method') { 
+            <DT><% if (it.'method') { 
             final String href1 = it.class.replaceAll('\\.','/') + '.html'
             final String href2 = href1 + 
             '#' + it.method.name + '(' + it.parametersSignature + ')'
-            %>
-            <a href="${href2}"><b>${it.method.name}(${it.parametersSignature})</b></a>  - 
+            %><a href="${href2}"><b>${it.method.name}(${it.parametersSignature})</b></a> - 
             Method in class ${it.packageName}.<a href="${href1}">${it.simpleClassName}</a>
             <% } %>
             </DT>


### PR DESCRIPTION
If you are mac user, Dash is very handy tool to look up API document.
`index-all.html` of groovy-jdk from current template can't be parsed by Dash's `javadocset` command.

After this patch is applied, you can get the groovy-jdk's docset as follows:

```
$ cd groovy-core
$ gradle docGDK
$ javadocset "Groovy JDK" target/html/groovy-jdk
$ ls "Groovy JDK.docset"
Groovy JDK.docset
```
- Dash - http://kapeli.com/dash
- javadocset - https://github.com/Kapeli/javadocset
