### PR TITLE
GROOVY-5898: fix for empty quotes

### DIFF
--- a/subprojects/groovy-sql/src/main/java/groovy/sql/ExtractIndexAndSql.java
+++ b/subprojects/groovy-sql/src/main/java/groovy/sql/ExtractIndexAndSql.java
@@ -117,12 +117,17 @@ class ExtractIndexAndSql {
 
     private void appendToEndOfString(StringBuilder buffer) {
         buffer.append(QUOTE);
+        int startQuoteIndex = index;
         ++index;
         boolean foundClosingQuote = false;
         while (index < sql.length()) {
             char c = sql.charAt(index);
             buffer.append(c);
             if (c == QUOTE && next() != QUOTE) {
+                if (startQuoteIndex == (index - 1)) {   // empty quote ''
+                    foundClosingQuote = true;
+                    break;
+                }
                 int previousQuotes = countPreviousRepeatingChars(QUOTE);
                 if (previousQuotes == 0 || previousQuotes % 2 == 0) {
                     foundClosingQuote = true;

--- a/subprojects/groovy-sql/src/test/groovy/groovy/sql/ExtractIndexAndSqlTest.groovy
+++ b/subprojects/groovy-sql/src/test/groovy/groovy/sql/ExtractIndexAndSqlTest.groovy
@@ -25,6 +25,13 @@ class ExtractIndexAndSqlTest extends GroovyTestCase {
         assert ExtractIndexAndSql.hasNamedParameters('select * from PERSON where id=?')
     }
 
+    void testWithEmptyStringQuote() {
+        String query = """select * from FOOD where type=:foo and category='' and calories < ?2.kcal"""
+        String expected = """select * from FOOD where type=? and category='' and calories < ?"""
+
+        assert expected == ExtractIndexAndSql.from(query).newSql
+    }
+
     void testWithQuoteEmbeddedInInlineComments() {
         String query = """select *
 from FOOD


### PR DESCRIPTION
This is a fix for a previous pull request 212 to correct a bug that caused it not to handle empty quotes.  Sorry about that @paulk-asert.
