### PR TITLE
Removed test dependency on Sql#preCheckForNamedParams(String) and deprecated method

### DIFF
--- a/subprojects/groovy-sql/src/main/java/groovy/sql/Sql.java
+++ b/subprojects/groovy-sql/src/main/java/groovy/sql/Sql.java
@@ -3900,7 +3900,25 @@ public class Sql {
         return new SqlWithParams(preCheck.getSql(), getUpdatedParams(params, indexPropList));
     }
 
+    /**
+     * @deprecated Use {@link #buildSqlWithIndexedProps(String)} instead
+     */
+    @Deprecated
     public SqlWithParams preCheckForNamedParams(String sql) {
+        return buildSqlWithIndexedProps(sql);
+    }
+
+    /**
+     * Hook to allow derived classes to override behavior associated with the
+     * parsing and indexing of parameters from a given sql statement.
+     *
+     * @param sql the sql statement to process
+     * @return a {@link SqlWithParams} instance containing the parsed sql
+     *         and parameters containing the indexed location and property
+     *         name of parameters or {@code null} if no parsing of
+     *         the sql was performed.
+     */
+    protected SqlWithParams buildSqlWithIndexedProps(String sql) {
         // look for quick exit
         if (!enableNamedQueries || !ExtractIndexAndSql.hasNamedParameters(sql)) {
             return null;

--- a/subprojects/groovy-sql/src/test/groovy/groovy/sql/ExtractIndexAndSqlTest.groovy
+++ b/subprojects/groovy-sql/src/test/groovy/groovy/sql/ExtractIndexAndSqlTest.groovy
@@ -170,7 +170,7 @@ and 3 = (12 / 4)
         String query = "select * from PERSON where name=:name and location=:location and building=:building"
         String expected = "select * from PERSON where name=? and location=? and building=?"
 
-        ExtractIndexAndSql extracter = new ExtractIndexAndSql(query).invoke()
+        ExtractIndexAndSql extracter = ExtractIndexAndSql.from(query)
 
         assert expected == extracter.newSql
 
@@ -204,6 +204,10 @@ and 3 = (12 / 4)
 
         assert 2 == extracter.indexPropList.get(2)[0]
         assert 'building' == extracter.indexPropList.get(2)[1]
+    }
+
+    void testCastingNotConfusedWithNamedParameters_5111() {
+        assert !ExtractIndexAndSql.hasNamedParameters("select * from TABLE where TEXTFIELD::integer = 3")
     }
 
 }

--- a/subprojects/groovy-sql/src/test/groovy/groovy/sql/SqlCompleteTest.groovy
+++ b/subprojects/groovy-sql/src/test/groovy/groovy/sql/SqlCompleteTest.groovy
@@ -128,10 +128,6 @@ class SqlCompleteTest extends SqlHelperTestCase {
         assert results == ["Bob": "Mcwhirter"]
     }
 
-    void testCastingNotConfusedWithNamedParameters_5111() {
-        assert !sql.preCheckForNamedParams("select * from TABLE where TEXTFIELD::integer = 3")
-    }
-
     void testEachRowWithNamedOrdinalParams() {
         def lastPatHolder = new Expando()
         lastPatHolder.lastPat = '%a%'


### PR DESCRIPTION
Only reference I could find to `Sql#preCheckForNamedParams(String)` was in a test.  With commit 69c7e47a9cb0957ee0cbb5125a2a137c642a009f this test no longer needs to rely on access to that method, so seemed like a good opportunity to move the test and deprecate the public method.
