### PR TITLE
Inefficient method DefaultGrailsDomainClassInjector.implementsMethod

### DIFF
--- a/src/examples/org/codehaus/groovy/grails/compiler/injection/DefaultGrailsDomainClassInjector.java
+++ b/src/examples/org/codehaus/groovy/grails/compiler/injection/DefaultGrailsDomainClassInjector.java
@@ -239,12 +239,13 @@ public class DefaultGrailsDomainClassInjector implements ASTTransformation {
      */
     private static boolean implementsMethod(ClassNode classNode, String methodName, Class[] argTypes) {
         List methods = classNode.getMethods();
-        for (Iterator i = methods.iterator(); i.hasNext();) {
-            MethodNode mn = (MethodNode) i.next();
-            final boolean isZeroArg = (argTypes == null || argTypes.length ==0);
-            boolean methodMatch = isZeroArg && mn.getName().equals(methodName);
-            if(methodMatch)return true;
-            // TODO Implement further parameter analysis
+        if (argTypes == null || argTypes.length ==0) {
+            for (Iterator i = methods.iterator(); i.hasNext();) {
+                MethodNode mn = (MethodNode) i.next();
+                boolean methodMatch = mn.getName().equals(methodName);
+                if(methodMatch)return true;
+                // TODO Implement further parameter analysis
+            }
         }
         return false;
     }


### PR DESCRIPTION
The problem appears in versions 2.1.6, 2.2.0-beta-1 and in revision
ca83beb.  This is a simple patch to fix it.  The patch moves only one
line, but it looks larger because I indented the loop to preserve
formatting.  I also reported this problem and sent a patch at
http://jira.codehaus.org/browse/GROOVY-6261.

In method "DefaultGrailsDomainClassInjector.implementsMethod", the
loop over "methods" should not be executed when 
"(argTypes == null || argTypes.length ==0)" is false.  When 
"(argTypes == null || argTypes.length ==0)" is false, "isZeroArg" is
false, which makes "methodMatch" false, which means the loop will not
execute "return true".  "return true" is the loop's only side effect,
so when "return true" cannot be executed, the loop is not necessary.
Note that "argTypes" and "argTypes.length" are never modified in the
loop, so the value of "(argTypes == null || argTypes.length ==0)" does
not change during the loop execution.
