### PR TITLE
GROOVY-6283: ProxyMetaClass doesn't invoke afterInvoke when an error occurs in the method call

### DIFF
--- a/src/main/groovy/lang/ProxyMetaClass.java
+++ b/src/main/groovy/lang/ProxyMetaClass.java
@@ -217,10 +217,13 @@ public class ProxyMetaClass extends MetaClassImpl implements AdaptingMetaClass {
             return howToInvoke.call();
         }
         Object result = interceptor.beforeInvoke(object, methodName, arguments);
-        if (interceptor.doInvoke()) {
-            result = howToInvoke.call();
+        try {
+            if (interceptor.doInvoke()) {
+                result = howToInvoke.call();
+            }
+        } finally {
+            result = interceptor.afterInvoke(object, methodName, arguments, result);
         }
-        result = interceptor.afterInvoke(object, methodName, arguments, result);
         return result;
     }
 }


### PR DESCRIPTION
afterInvoke should be called whenever.
