### PR TITLE
Numbers section

### DIFF
--- a/src/spec/doc/core-syntax.adoc
+++ b/src/spec/doc/core-syntax.adoc
@@ -221,6 +221,8 @@ include::../test/SyntaxTest.groovy[tags=underscore_in_number_example,indent=0]
 
 === Number type suffixes
 
+We can force an number (including binary, octals and hexadecimals) to have a specific type by giving a suffix (see table bellow), either uppercase or lowercase.
+
 [cols="1,2" options="header"]
 |====
 |Type

--- a/src/spec/test/SyntaxTest.groovy
+++ b/src/spec/test/SyntaxTest.groovy
@@ -86,14 +86,19 @@ class SyntaxTest extends CompilableTestSupport {
 
     void testNumberTypeSuffixes() {
         // tag::number_type_suffixes_example[]
-        assert 42I == new Integer("42")
-        assert 123L == new Long("123")
-        assert 2147483648 == new Long("2147483648") //Long type used, value too large for an Integer
-        assert 456G == new java.math.BigInteger("456")
-        assert 123.45 == new java.math.BigDecimal("123.45") //default BigDecimal type used
-        assert 1.200065D == new Double("1.200065")
-        assert 1.234F == new Float("1.234")
-        assert 1.23E23D == new Double("1.23E23")
+        assert 42I == new Integer('42')
+        assert 42i == new Integer('42') //lowercase i more readable
+        assert 123L == new Long("123") //uppercase L more readable
+        assert 2147483648 == new Long('2147483648') //Long type used, value too large for an Integer
+        assert 456G == new java.math.BigInteger('456')
+        assert 456g == new java.math.BigInteger('456')
+        assert 123.45 == new java.math.BigDecimal('123.45') //default BigDecimal type used
+        assert 1.200065D == new Double('1.200065')
+        assert 1.234F == new Float('1.234')
+        assert 1.23E23D == new Double('1.23E23')
+        assert 0b1111L.class == Long // binary
+        assert 0xFFi.class == Integer // hexadecimal
+        assert 034G.class == BigInteger // ocatal
         // end::number_type_suffixes_example[]
     }
 


### PR DESCRIPTION
I added a few sub-sections.
- Numbers
  - Binary literal
  - Octal literal
  - Hexadecimal literal
  - Underscore in literal
  - Number type suffixes

I want to draw attention to the fact that pieces of code in "Binary literal" and "Underscore in literal" sections will compile only with Groovy 2 and above.
