### PR TITLE
workaround for bug in Gradle 1.8

### DIFF
--- a/gradle/assemble.gradle
+++ b/gradle/assemble.gradle
@@ -30,7 +30,7 @@ ext.licenseSpec = copySpec {
     from 'config/build'
     from(zipTree(configurations.compile.fileCollection { it.name.startsWith 'commons-cli' }.singleFile).matching {
         include 'META-INF/LICENSE.txt'
-    }) {
+    }.filter{ it.isFile() }) { // TODO: remove filter when GRADLE-2900 is fixed
         eachFile { details ->
             details.path = details.path - 'META-INF'
             details.name = 'CLI-LICENSE.txt'


### PR DESCRIPTION
- FileTree.matching() is broken in Gradle 1.8
  - see http://forums.gradle.org/gradle/topics/is_filetree_matching_broken_in_gradle_1_8
  - see http://issues.gradle.org/browse/GRADLE-2900
- withtout this workaround 'gradle jarAll' fails with:

```
> Could not expand ZIP
> '~/.gradle/caches/.../commons-cli-1.2.jar'
```
