### PR TITLE
groovysh: fix bad method name createCompleto/ers

### DIFF
--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/CommandAlias.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/CommandAlias.groovy
@@ -46,12 +46,16 @@ class CommandAlias
         return command
     }
     
-    protected List<Completer> createCompletors() {
+    protected List<Completer> createCompleters() {
         try {
-            // TODO: Use interface with createCompletors()
-            return target.createCompletors()
+            // TODO: Use interface with createCompleters()
+            if (target instanceof CommandSupport) {
+                CommandSupport support = (CommandSupport) target;
+                return support.createCompleters()
+            }
+
         } catch (MissingMethodException) {
-            log.warn("Aliased Command without createCompletors Method")
+            log.warn("Aliased Command without createCompleters Method")
         }
     }
     

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/HelpCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/HelpCommand.groovy
@@ -38,7 +38,7 @@ class HelpCommand
         alias('?', '\\?')
     }
 
-    protected List createCompletors() {
+    protected List createCompleters() {
         return [
             new HelpCommandCompletor(registry),
             null

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/HistoryCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/HistoryCommand.groovy
@@ -34,7 +34,7 @@ class HistoryCommand
         super(shell, 'history', '\\H', [ 'show', 'clear', 'flush', 'recall' ], 'show')
     }
 
-    protected List createCompletors() {
+    protected List createCompleters() {
         def loader = {
             def list = []
 

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/InspectCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/InspectCommand.groovy
@@ -41,7 +41,7 @@ class InspectCommand
     def lafInitialized = false
     def headless
     
-    protected List createCompletors() {
+    protected List createCompleters() {
         return [
             new InspectCommandCompletor(binding),
             null

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/SaveCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/SaveCommand.groovy
@@ -33,7 +33,7 @@ class SaveCommand
         super(shell, 'save', '\\s')
     }
 
-    protected List createCompletors() {
+    protected List createCompleters() {
         return [
             new FileNameCompleter(),
             null

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/ComplexCommandSupportTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/ComplexCommandSupportTest.groovy
@@ -64,7 +64,7 @@ class ComplexCommandSupportTest
         }
     }
 
-    void testCreateCompletors() {
+    void testCreateCompleters() {
         ComplexCommandSupport com = new ComplexCommandSupport(shell, "fcom", "f", ["foo", "bar", "baz"]) {}
         List<Completer> completors = com.createCompleters()
         assertEquals(2, completors.size())


### PR DESCRIPTION
To reproduce, start groovysh:

type save
press tab

Result: nothing happens
should offer filenames

This is due to another typo after migrating to Jline 2

I can open JIRA issue if you need
