### PR TITLE
GROOVY-6393: groovysh: load command without parsing xml 

### DIFF
--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/Groovysh.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/Groovysh.groovy
@@ -21,12 +21,28 @@ import jline.Terminal
 import jline.TerminalFactory
 import jline.console.history.FileHistory
 import org.codehaus.groovy.runtime.InvokerHelper
+import org.codehaus.groovy.tools.shell.commands.AliasCommand
+import org.codehaus.groovy.tools.shell.commands.ClearCommand
+import org.codehaus.groovy.tools.shell.commands.DisplayCommand
+import org.codehaus.groovy.tools.shell.commands.DocCommand
+import org.codehaus.groovy.tools.shell.commands.EditCommand
+import org.codehaus.groovy.tools.shell.commands.ExitCommand
+import org.codehaus.groovy.tools.shell.commands.HelpCommand
+import org.codehaus.groovy.tools.shell.commands.HistoryCommand
+import org.codehaus.groovy.tools.shell.commands.ImportCommand
+import org.codehaus.groovy.tools.shell.commands.InspectCommand
+import org.codehaus.groovy.tools.shell.commands.LoadCommand
+import org.codehaus.groovy.tools.shell.commands.PurgeCommand
+import org.codehaus.groovy.tools.shell.commands.RecordCommand
+import org.codehaus.groovy.tools.shell.commands.RegisterCommand
+import org.codehaus.groovy.tools.shell.commands.SaveCommand
+import org.codehaus.groovy.tools.shell.commands.SetCommand
+import org.codehaus.groovy.tools.shell.commands.ShowCommand
 import org.codehaus.groovy.tools.shell.util.PackageHelper
 import org.codehaus.groovy.runtime.StackTraceUtils
 import org.codehaus.groovy.tools.shell.util.CurlyCountingGroovyLexer
 import org.codehaus.groovy.tools.shell.util.MessageSource
 import org.codehaus.groovy.tools.shell.util.Preferences
-import org.codehaus.groovy.tools.shell.util.XmlCommandRegistrar
 import org.fusesource.jansi.Ansi
 import org.fusesource.jansi.AnsiConsole
 import org.fusesource.jansi.AnsiRenderer
@@ -75,7 +91,7 @@ class Groovysh extends Shell {
         assert registrar
 
         parser = new Parser()
-        
+
         interp = new Interpreter(classLoader, binding)
 
         registrar.call(this)
@@ -84,9 +100,34 @@ class Groovysh extends Shell {
     }
 
     private static Closure createDefaultRegistrar(final ClassLoader classLoader) {
-        return {Shell shell ->
-            def r = new XmlCommandRegistrar(shell, classLoader)
-            r.register(getClass().getResource('commands.xml'))
+
+        return {Groovysh shell ->
+            // Not sure why parsing some xml file would help with anything
+//            def r = new XmlCommandRegistrar(shell, classLoader)
+//            r.register(getClass().getResource('commands.xml'))
+            for (Command classname in [
+                    new HelpCommand(shell),
+                    new ExitCommand(shell),
+                    new ImportCommand(shell),
+                    new DisplayCommand(shell),
+                    new ClearCommand(shell),
+                    new ShowCommand(shell),
+                    new InspectCommand(shell),
+                    new PurgeCommand(shell),
+                    new EditCommand(shell),
+                    new LoadCommand(shell),
+                    new SaveCommand(shell),
+                    new RecordCommand(shell),
+                    new HistoryCommand(shell),
+                    new AliasCommand(shell),
+                    new SetCommand(shell),
+                    // does not do anything
+                    //new ShadowCommand(shell),
+                    new RegisterCommand(shell),
+                    new DocCommand(shell)
+            ]) {
+                shell.register(classname)
+            }
         }
     }
 


### PR DESCRIPTION
See https://jira.codehaus.org/browse/GROOVY-6391#comment-334200

To be discussed.

A nicer implementation is possible, and better code comments to explain the purpose of the XmlCommandRegistrar class, if we find out.
