### PR TITLE
Methods to big decimal

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -11837,7 +11837,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
     /**
      * Truncate the value
      *
-     * @param number a Double
+     * @param number a Float
      * @return the Float truncated to 0 decimal places (i.e. a synonym for floor)
      * @since 1.6.0
      */

--- a/src/test/org/codehaus/groovy/runtime/DefaultGroovyMethodsTest.java
+++ b/src/test/org/codehaus/groovy/runtime/DefaultGroovyMethodsTest.java
@@ -121,7 +121,6 @@ public class DefaultGroovyMethodsTest extends GroovyTestCase {
         assertEquals(DefaultGroovyMethods.trunc(d, 6), 1000.123456);
     }
 
-
     public void testToMethods() throws Exception {
         Number n = 7L;
         assertEquals(DefaultGroovyMethods.toInteger(n), new Integer(7));


### PR DESCRIPTION
https://jira.codehaus.org/browse/GROOVY-4847
    Include methods round and trunc for BigDecimal class.
    modified:   src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
    modified:   src/test/org/codehaus/groovy/runtime/DefaultGroovyMethodsTest.java
    steps in git:
        $ git remote add methodsToBigDecimal https://github.com/groovy/groovy-core.git
        $ git remote -v
        $ git pull methodsToBigDecimal master
        $ git checkout -b methodsToBigDecimal
        $ git status -v
        $ git commit -a -m "Added methods round and trunc to BigDecimal"
        $ git push origin methodsToBigDecimal

```
    went to https://github.com/romalopes/groovy-core
        clicked in Compare & pull request
```
