### PR TITLE
@Slf4j toUpperCase fix

### DIFF
--- a/src/main/groovy/util/logging/Slf4j.java
+++ b/src/main/groovy/util/logging/Slf4j.java
@@ -19,6 +19,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
+import java.util.Locale;
 
 import groovy.lang.GroovyClassLoader;
 import org.codehaus.groovy.ast.ClassNode;
@@ -84,7 +85,7 @@ public @interface Slf4j {
         public Expression wrapLoggingMethodCall(Expression logVariable, String methodName, Expression originalExpression) {
             MethodCallExpression condition = new MethodCallExpression(
                     logVariable,
-                    "is" + methodName.substring(0, 1).toUpperCase() + methodName.substring(1, methodName.length()) + "Enabled",
+                    "is" + methodName.substring(0, 1).toUpperCase(Locale.ENGLISH) + methodName.substring(1, methodName.length()) + "Enabled",
                     ArgumentListExpression.EMPTY_ARGUMENTS);
 
             return new TernaryExpression(


### PR DESCRIPTION
Hi,

Logging annotations produce wrong method name for "info" keyword since in Turkish locale uppercase form of "i" is "İ". Please see below link for details.

http://java.sys-con.com/node/46241

Sample error message from usage :
    groovy.lang.MissingMethodException: No signature of method: ch.qos.logback.classic.Logger.isİnfoEnabled() is applicable for argument types: () values: [] Possible solutions: isInfoEnabled(), isInfoEnabled(org.slf4j.Marker), isErrorEnabled(), isWarnEnabled(), isErrorEnabled(org.slf4j.Marker), isWarnEnabled(org.slf4j.Marker)

Regards
Hakan Baykuşlar
