### PR TITLE
GROOVY-6457 Update eachFileMatch to behave like eachFile

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/ResourceGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/ResourceGroovyMethods.java
@@ -1296,9 +1296,9 @@ public class ResourceGroovyMethods extends DefaultGroovyMethodsSupport {
         if (files == null) return;
         BooleanReturningMethodInvoker bmi = new BooleanReturningMethodInvoker("isCase");
         for (final File currentFile : files) {
-            if ((fileType != FileType.FILES && currentFile.isDirectory()) ||
-                (fileType != FileType.DIRECTORIES && currentFile.isFile())) 
-            {
+            if (fileType == FileType.ANY ||
+                    (fileType != FileType.FILES && currentFile.isDirectory()) ||
+                    (fileType != FileType.DIRECTORIES && currentFile.isFile())) {
                 if (bmi.invoke(nameFilter, currentFile.getName()))
                     closure.call(currentFile);
             }


### PR DESCRIPTION
GROOVY-6457

[File.eachFileMatch](http://groovy.codehaus.org/groovy-jdk/java/io/File.html#eachFileMatch%28groovy.io.FileType,%20java.lang.Object,%20groovy.lang.Closure%29) is very similar to [File.eachFile](http://groovy.codehaus.org/groovy-jdk/java/io/File.html#eachFile%28groovy.io.FileType,%20groovy.lang.Closure%29) but it has one subtle difference: it doesn't shortcircuit on `FileTypes.ANY`. This means that they return different results for directory entries that aren't files or directories and that it can be significantly slower due to Java needing to invoke a `stat()` system call for every entry.

This pull request adds in that `FileTypes.ANY` shortcircuit that `eachFile` has to `eachFileMatch`, causing it to behave similar: it iterates over every directory item and it doesn't require the `isDirectory()` and `isFile()` calls on every item in the directory.

See [GROOVY-6457](http://jira.codehaus.org/browse/GROOVY-6457) for details and demos.
