### PR TITLE
GROOVY-6490

### DIFF
--- a/src/main/groovy/util/GroovyScriptEngine.java
+++ b/src/main/groovy/util/GroovyScriptEngine.java
@@ -265,7 +265,13 @@ public class GroovyScriptEngine implements ResourceConnector {
                 if (entryNames.contains(entryName)) continue;
                 entryNames.add(entryName);
                 Set<String> value = convertToPaths(entry.getValue(), localData.precompiledEntries);
-                ScriptCacheEntry cacheEntry = new ScriptCacheEntry(clazz, time, time, value, false);
+                long lastModified;
+                try {
+                    lastModified = getLastModified(entryName);
+                } catch (ResourceException e) {
+                    lastModified = time;
+                }
+                ScriptCacheEntry cacheEntry = new ScriptCacheEntry(clazz, lastModified, time, value, false);
                 scriptCache.put(entryName, cacheEntry);
             }
             cache.clear();


### PR DESCRIPTION
http://jira.codehaus.org/browse/GROOVY-6490 excessive reload of dependencies in GroovyScriptEngine. Solve storing the last-modified attribute from the source file in the scriptCache.
