### PR TITLE
GROOVY-6500 expose a getter for FBS.disposalClosures. 

### DIFF
--- a/src/main/groovy/util/FactoryBuilderSupport.java
+++ b/src/main/groovy/util/FactoryBuilderSupport.java
@@ -1279,6 +1279,10 @@ public abstract class FactoryBuilderSupport extends Binding {
         disposalClosures.add(closure);
     }
 
+    public List<Closure> getDisposalClosures() {
+        return Collections.unmodifiableList(disposalClosures);
+    }
+
     public void dispose() {
         for (int i = disposalClosures.size() - 1; i >= 0; i--) {
             disposalClosures.get(i).call();


### PR DESCRIPTION
The getter returns an unmodifiable Collection, just like every other setter in FBS that exposes internal state
