### PR TITLE
GROOVY-6397: Prefix '\' to all commands

### DIFF
--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/CommandRegistry.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/CommandRegistry.groovy
@@ -73,7 +73,7 @@ class CommandRegistry
             if (name in [ c.name, c.shortcut ]) {
                 return c
             }
-            if (name.equals('\\' + c.name)) {
+            if (name.equals(':' + c.name)) {
                 return c
             }
         }

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/AliasCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/AliasCommand.groovy
@@ -30,7 +30,7 @@ class AliasCommand
     extends CommandSupport
 {
     AliasCommand(final Groovysh shell) {
-        super(shell, '\\alias', '\\a')
+        super(shell, ':alias', ':a')
     }
 
     Object execute(final List args) {
@@ -83,7 +83,7 @@ class AliasTargetProxyCommand
     final List args
     
     AliasTargetProxyCommand(final Groovysh shell, final String name, final List args) {
-        super(shell, name, '\\a' + counter++)
+        super(shell, name, ':a' + counter++)
         
         assert args
         

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/ClearCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/ClearCommand.groovy
@@ -29,7 +29,7 @@ class ClearCommand
     extends CommandSupport
 {
     ClearCommand(final Groovysh shell) {
-        super(shell, '\\clear', '\\c')
+        super(shell, ':clear', ':c')
     }
     
     Object execute(final List<String> args) {

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/DisplayCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/DisplayCommand.groovy
@@ -29,7 +29,7 @@ class DisplayCommand
     extends CommandSupport
 {
     DisplayCommand(final Groovysh shell) {
-        super(shell, '\\display', '\\d')
+        super(shell, ':display', ':d')
     }
 
     Object execute(final List<String> args) {

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/DocCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/DocCommand.groovy
@@ -65,7 +65,7 @@ class DocCommand extends CommandSupport {
     }
 
     DocCommand(final Groovysh shell) {
-        super(shell, '\\doc', '\\D')
+        super(shell, ':doc', ':D')
     }
 
     @Override

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/EditCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/EditCommand.groovy
@@ -30,7 +30,7 @@ class EditCommand
     extends CommandSupport
 {
     EditCommand(final Groovysh shell) {
-        super(shell, '\\edit', '\\e')
+        super(shell, ':edit', ':e')
     }
 
     ProcessBuilder getEditorProcessBuilder(String editCommand, String tempFilename) {

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/ExitCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/ExitCommand.groovy
@@ -30,9 +30,9 @@ class ExitCommand
     extends CommandSupport
 {
     ExitCommand(final Groovysh shell) {
-        super(shell, '\\exit', '\\x')
+        super(shell, ':exit', ':x')
 
-        alias('\\quit', '\\q')
+        alias(':quit', ':q')
     }
 
     Object execute(final List<String> args) {

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/HelpCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/HelpCommand.groovy
@@ -32,9 +32,9 @@ class HelpCommand
     extends CommandSupport
 {
     HelpCommand(final Groovysh shell) {
-        super(shell, '\\help', '\\h')
+        super(shell, ':help', ':h')
 
-        alias('?', '\\?')
+        alias('?', ':?')
     }
 
     protected List createCompleters() {
@@ -120,7 +120,7 @@ class HelpCommand
         
         io.out.println()
         io.out.println('For help on a specific command type:') // TODO: i18n
-        io.out.println('    \\help @|bold command|@ ')
+        io.out.println('    :help @|bold command|@ ')
         io.out.println()
     }
 }

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/HistoryCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/HistoryCommand.groovy
@@ -31,7 +31,7 @@ class HistoryCommand
     extends ComplexCommandSupport
 {
     HistoryCommand(final Groovysh shell) {
-        super(shell, '\\history', '\\H', [ 'show', 'clear', 'flush', 'recall' ], 'show')
+        super(shell, ':history', ':H', [ 'show', 'clear', 'flush', 'recall' ], 'show')
     }
 
     protected List createCompleters() {

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/ImportCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/ImportCommand.groovy
@@ -39,7 +39,7 @@ class ImportCommand
     extends CommandSupport
 {
     ImportCommand(final Groovysh shell) {
-        super(shell, 'import', '\\i')
+        super(shell, 'import', ':i')
     }
 
     @Override

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/InspectCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/InspectCommand.groovy
@@ -35,7 +35,7 @@ class InspectCommand
     extends CommandSupport
 {
     InspectCommand(final Groovysh shell) {
-        super(shell, '\\inspect', '\\n')
+        super(shell, ':inspect', ':n')
     }
     
     def lafInitialized = false

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/LoadCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/LoadCommand.groovy
@@ -30,9 +30,9 @@ class LoadCommand
     extends CommandSupport
 {
     LoadCommand(final Groovysh shell) {
-        super(shell, '\\load', '\\l')
+        super(shell, ':load', ':l')
 
-        alias('.', '\\.')
+        alias('.', ':.')
     }
 
     protected List createCompleters() {

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/PurgeCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/PurgeCommand.groovy
@@ -30,7 +30,7 @@ class PurgeCommand
     extends ComplexCommandSupport
 {
     PurgeCommand(final Groovysh shell) {
-        super(shell, '\\purge', '\\p', [ 'variables', 'classes', 'imports', 'preferences', 'all' ])
+        super(shell, ':purge', ':p', [ 'variables', 'classes', 'imports', 'preferences', 'all' ])
     }
     
     def do_variables = {

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/RecordCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/RecordCommand.groovy
@@ -30,7 +30,7 @@ class RecordCommand
     extends ComplexCommandSupport
 {
     RecordCommand(final Groovysh shell) {
-        super(shell, '\\record', '\\r', [ 'start', 'stop', 'status' ], 'status')
+        super(shell, ':record', ':r', [ 'start', 'stop', 'status' ], 'status')
 
         addShutdownHook {
             if (isRecording()) {

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/RegisterCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/RegisterCommand.groovy
@@ -32,7 +32,7 @@ class RegisterCommand
     extends CommandSupport
 {
     RegisterCommand(final Groovysh shell) {
-        super(shell, "\\register", "\\rc")
+        super(shell, ":register", ":rc")
     }
 
     public Object execute(List<String> args) {

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/SaveCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/SaveCommand.groovy
@@ -30,7 +30,7 @@ class SaveCommand
     extends CommandSupport
 {
     SaveCommand(final Groovysh shell) {
-        super(shell, '\\save', '\\s')
+        super(shell, ':save', ':s')
     }
 
     protected List createCompleters() {

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/SetCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/SetCommand.groovy
@@ -32,7 +32,7 @@ class SetCommand
     extends CommandSupport
 {
     SetCommand(final Groovysh shell) {
-        super(shell, '\\set', '\\=')
+        super(shell, ':set', ':=')
     }
 
     protected List createCompleters() {

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/ShadowCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/ShadowCommand.groovy
@@ -31,7 +31,7 @@ class ShadowCommand
     extends ComplexCommandSupport
 {
     ShadowCommand(final Groovysh shell) {
-        super(shell, '\\shadow', '\\&', [ 'debug', 'verbose', 'info', 'this' ])
+        super(shell, ':shadow', ':&', [ 'debug', 'verbose', 'info', 'this' ])
         
         this.hidden = true
     }

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/ShowCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/ShowCommand.groovy
@@ -33,7 +33,7 @@ class ShowCommand
     extends ComplexCommandSupport
 {
     ShowCommand(final Groovysh shell) {
-        super(shell, '\\show', '\\S', [ 'variables', 'classes', 'imports', 'preferences', 'all' ])
+        super(shell, ':show', ':S', [ 'variables', 'classes', 'imports', 'preferences', 'all' ])
     }
     
     def do_variables = {

--- a/subprojects/groovy-groovysh/src/main/resources/org/codehaus/groovy/tools/shell/Groovysh.properties
+++ b/subprojects/groovy-groovysh/src/main/resources/org/codehaus/groovy/tools/shell/Groovysh.properties
@@ -32,4 +32,4 @@ info.fatal=FATAL: {0}
 
 startup_banner.0=@|green Groovy Shell|@ ({0}, JVM: {1})
 
-startup_banner.1=Type '@|bold \\help|@' or '@|bold \\h|@' for help.
+startup_banner.1=Type '@|bold :help|@' or '@|bold :h|@' for help.

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/AllCompletorsTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/AllCompletorsTest.groovy
@@ -94,32 +94,32 @@ class AllCompletorsTest extends GroovyTestCase {
 
     void testEmpty() {
         def result = complete("", 0)
-        assertTrue('\\help' in result[0])
-        assertTrue('\\exit' in result[0])
+        assertTrue(':help' in result[0])
+        assertTrue(':exit' in result[0])
         assertTrue('import' in result[0])
-        assertTrue('\\show' in result[0])
-        assertTrue('\\set' in result[0])
-        assertTrue('\\inspect' in result[0])
-        assertTrue('\\doc' in result[0])
+        assertTrue(':show' in result[0])
+        assertTrue(':set' in result[0])
+        assertTrue(':inspect' in result[0])
+        assertTrue(':doc' in result[0])
         assert 0 == result[1]
     }
 
     void testExitEdit() {
-        assert [["\\exit ", "\\e", "\\edit"], 0] == complete("\\e", 0)
+        assert [[":exit ", ":e", ":edit"], 0] == complete(":e", 0)
     }
 
     void testShow() {
-        String prompt = "\\show "
+        String prompt = ":show "
         assert [["all", "classes", "imports", "preferences", "variables"], prompt.length()] == complete(prompt, prompt.length())
     }
 
     void testShowV() {
-        String prompt = "\\show v"
+        String prompt = ":show v"
         assert [["variables "], prompt.length() - 1] == complete(prompt, prompt.length())
     }
 
     void testShowVariables() {
-        String prompt = "\\show variables "
+        String prompt = ":show variables "
         assertNull(complete(prompt, prompt.length()))
     }
 
@@ -146,12 +146,12 @@ class AllCompletorsTest extends GroovyTestCase {
 
     void testCommandAndKeyword() {
         // tests against interaction with ReflectionCompleter
-        String prompt = "\\pu" // purge, public
-        assert [["\\purge "], 0] == complete(prompt, prompt.length())
+        String prompt = ":pu" // purge, public
+        assert [[":purge "], 0] == complete(prompt, prompt.length())
     }
 
     void testDoc() {
-        String prompt = "\\doc j"
+        String prompt = ":doc j"
         def result = complete(prompt, prompt.length())
         assert result
         assert prompt.length() - 1 == result[1]

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/ImportCompletorTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/ImportCompletorTest.groovy
@@ -296,7 +296,7 @@ extends CompletorTestSupport {
             def candidates = []
             assertEquals(0, completer.complete("", 0, candidates))
             // order changed by sort
-            assertEquals(["\\i", "\\i", "import", "import"], candidates.sort())
+            assertEquals([":i", ":i", "import", "import"], candidates.sort())
         }
     }
 

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/AliasCommandTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/AliasCommandTest.groovy
@@ -25,8 +25,8 @@ class AliasCommandTest
     extends CommandTestSupport
 {
     void testAlias() {
-        shell.execute('\\alias')
-        shell.execute('\\alias foo bar')
-        shell.execute('\\alias history foo') // cannot rebind
+        shell.execute(':alias')
+        shell.execute(':alias foo bar')
+        shell.execute(':alias history foo') // cannot rebind
     }
 }

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/ClearCommandTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/ClearCommandTest.groovy
@@ -25,10 +25,10 @@ class ClearCommandTest
     extends CommandTestSupport
 {
     void testClear() {
-        shell << '\\clear'
+        shell << ':clear'
     }
 
     void testClearWithArgs() {
-        shell << '\\clear foo'
+        shell << ':clear foo'
     }
 }

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/DisplayCommandTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/DisplayCommandTest.groovy
@@ -25,10 +25,10 @@ class DisplayCommandTest
     extends CommandTestSupport
 {
     void testDisplay() {
-        shell << '\\display'
+        shell << ':display'
     }
 
     void testDisplayWithArgs() {
-        shell << '\\display foo'
+        shell << ':display foo'
     }
 }

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/ExitCommandTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/ExitCommandTest.groovy
@@ -28,7 +28,7 @@ class ExitCommandTest
 {
     void testWithNoArgs() {
         try {
-            shell << '\\exit'
+            shell << ':exit'
             fail()
         }
         catch (ExitNotification e) {

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/HelpCommandTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/HelpCommandTest.groovy
@@ -25,14 +25,14 @@ class HelpCommandTest
     extends CommandTestSupport
 {
     void testList() {
-        shell << '\\help'
+        shell << ':help'
     }
     
     void testCommandHelp() {
-        shell << '\\help exit'
+        shell << ':help exit'
     }
     
     void testCommandHelpInvalidCommand() {
-        shell << '\\help no-such-command'
+        shell << ':help no-such-command'
     }
 }

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/HistoryCommandTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/HistoryCommandTest.groovy
@@ -28,11 +28,11 @@ import org.codehaus.groovy.tools.shell.Groovysh
 class HistoryCommandTest extends CommandTestSupport
 {
     void testHistory() {
-        shell << '\\history nocommandhere'
+        shell << ':history nocommandhere'
     }
 
     void testHistoryNoArg() {
-        shell << '\\history'
+        shell << ':history'
     }
 }
 

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/InspectCommandTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/InspectCommandTest.groovy
@@ -25,6 +25,6 @@ class InspectCommandTest
     extends CommandTestSupport
 {
     void testInspect() {
-        shell << '\\inspect'
+        shell << ':inspect'
     }
 }

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/LoadCommandTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/LoadCommandTest.groovy
@@ -25,6 +25,6 @@ class LoadCommandTest
     extends CommandTestSupport
 {
     void testLoad() {
-        shell << '\\load'
+        shell << ':load'
     }
 }

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/PurgeCommandTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/PurgeCommandTest.groovy
@@ -25,22 +25,22 @@ class PurgeCommandTest
     extends CommandTestSupport
 {
     void testPurgeVariables() {
-        shell << '\\purge variables'
+        shell << ':purge variables'
     }
 
     void testPurgeClasses() {
-        shell << '\\purge classes'
+        shell << ':purge classes'
     }
 
     void testPurgeImports() {
-        shell << '\\purge imports'
+        shell << ':purge imports'
     }
 
     void testPurgePreferences() {
-        shell << '\\purge preferences'
+        shell << ':purge preferences'
     }
 
     void testPurgeAll() {
-        shell << '\\purge all'
+        shell << ':purge all'
     }
 }

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/RecordCommandTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/RecordCommandTest.groovy
@@ -27,15 +27,15 @@ class RecordCommandTest
     extends CommandTestSupport
 {
     void testStopNotStarted() {
-        shell << '\\record stop'
+        shell << ':record stop'
     }
 
     void testStartAlreadyStarted() {
-        shell << '\\record start'
+        shell << ':record start'
 
-        shell << '\\record start'
+        shell << ':record start'
 
-        File file = shell << '\\record stop'
+        File file = shell << ':record stop'
 
         file.delete()
     }

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/RegisterCommandTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/RegisterCommandTest.groovy
@@ -28,21 +28,21 @@ class RegisterCommandTest
     extends CommandTestSupport
 {
     void testRegister() {
-        shell << '\\register org.codehaus.groovy.tools.shell.commands.EchoCommand'
+        shell << ':register org.codehaus.groovy.tools.shell.commands.EchoCommand'
     }
 
     void testRegisterDupes() {
-        shell << '\\register org.codehaus.groovy.tools.shell.commands.EchoCommand'
-        shell << '\\register org.codehaus.groovy.tools.shell.commands.EchoCommand echo2 \\e2'
+        shell << ':register org.codehaus.groovy.tools.shell.commands.EchoCommand'
+        shell << ':register org.codehaus.groovy.tools.shell.commands.EchoCommand echo2 \\e2'
     }
 
     void testRegisterDupesFail() {
-        shell << '\\register org.codehaus.groovy.tools.shell.commands.EchoCommand'
-        shell << '\\register org.codehaus.groovy.tools.shell.commands.EchoCommand'
+        shell << ':register org.codehaus.groovy.tools.shell.commands.EchoCommand'
+        shell << ':register org.codehaus.groovy.tools.shell.commands.EchoCommand'
     }
 
     void testRegisterFail() {
-            shell << '\\register'
+            shell << ':register'
         }
 }
 
@@ -54,7 +54,7 @@ class EchoCommand
     }
 
     EchoCommand(final Shell shell) {
-        super(shell, 'echo', '\\ec')
+        super(shell, ':echo', ':ec')
     }
 
     Object execute(final List args) {

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/SaveCommandTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/SaveCommandTest.groovy
@@ -25,7 +25,7 @@ class SaveCommandTest
     extends CommandTestSupport
 {
     void testSave() {
-        shell << '\\save'
+        shell << ':save'
 
     }
 }

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/SetCommandTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/SetCommandTest.groovy
@@ -30,7 +30,7 @@ class SetCommandTest
     extends CommandTestSupport
 {
     void testSet() {
-        shell << '\\set'
+        shell << ':set'
     }
 
     void testComplete() {

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/ShowCommandTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/ShowCommandTest.groovy
@@ -25,6 +25,6 @@ class ShowCommandTest
     extends CommandTestSupport
 {
     void testShow() {
-        shell << '\\show nocommandhere'
+        shell << ':show nocommandhere'
     }
 }


### PR DESCRIPTION
See https://jira.codehaus.org/browse/GROOVY-6397
Using backslash as command prefix because it is also used for single-letter commands. I don't like that choice too much, because on german keyboards the backslash is difficult to reach. But commands are probably not used that much anyway.
