### PR TITLE
Groovy6499

### DIFF
--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/Groovysh.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/Groovysh.groovy
@@ -48,6 +48,7 @@ class Groovysh extends Shell {
     final List<String> imports = []
 
     public static final String AUTOINDENT_PREFERENCE_KEY = "autoindent"
+    public static final String METACLASS_COMPLETION_PREFIX_LENGTH_PREFERENCE_KEY = "metacompletionprefixlength"
     int indentSize = 2
     
     InteractiveShellRunner runner
@@ -473,7 +474,10 @@ class Groovysh extends Shell {
                 loadUserScript('groovysh.rc')
 
                 // Setup the interactive runner
-                runner = new InteractiveShellRunner(this, this.&renderPrompt as Closure)
+                runner = new InteractiveShellRunner(
+                        this,
+                        this.&renderPrompt as Closure,
+                        Integer.valueOf(Preferences.get(METACLASS_COMPLETION_PREFIX_LENGTH_PREFERENCE_KEY, '3')))
 
                 // Setup the history
                 File histFile = new File(userStateDirectory, 'groovysh.history')

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/InteractiveShellRunner.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/InteractiveShellRunner.groovy
@@ -43,6 +43,10 @@ class InteractiveShellRunner
     WrappedInputStream wrappedInputStream
 
     InteractiveShellRunner(final Groovysh shell, final Closure prompt) {
+        this(shell, prompt, 0)
+    }
+
+    InteractiveShellRunner(final Groovysh shell, final Closure prompt, int metaclass_completion_prefix_length) {
         super(shell)
         
         this.prompt = prompt
@@ -57,7 +61,8 @@ class InteractiveShellRunner
         reader.addCompleter(this.completer)
 
         reader.addCompleter(new GroovySyntaxCompletor(shell,
-                new ReflectionCompletor(shell),
+                new ReflectionCompletor(shell,
+                        metaclass_completion_prefix_length),
                 [new KeywordSyntaxCompletor(),
                         new VariableSyntaxCompletor(shell),
                         new CustomClassSyntaxCompletor(shell),

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/GroovyshTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/GroovyshTest.groovy
@@ -299,7 +299,7 @@ int compareTo(Object) {0}; int priv; static int priv2; public int foo; public st
         IO testio = new IO()
         Groovysh groovysh = new Groovysh(new URLClassLoader(), new Binding(), testio)
         groovysh.run("import " + GroovyException.name)
-        ReflectionCompletor compl = new ReflectionCompletor(groovysh)
+        ReflectionCompletor compl = new ReflectionCompletor(groovysh, 0)
         def candidates = []
         compl.complete(TokenUtilTest.tokenList("GroovyException."), candidates)
         assert candidates.size() > 0

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/completion/GroovySyntaxCompletorTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/completion/GroovySyntaxCompletorTest.groovy
@@ -26,9 +26,9 @@ class GroovySyntaxCompletorTest extends CompletorTestSupport {
 
     void testEmpty() {
         IdentifierCompletor mockIdCompletor = idCompletorMocker.proxyDelegateInstance()
-        ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance()
         groovyshMocker.use {
             Groovysh groovyshMock = new Groovysh()
+            ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance(groovyshMock)
             GroovySyntaxCompletor completor = new GroovySyntaxCompletor(groovyshMock, mockReflComp, [mockIdCompletor], null)
             assert -1 == completor.complete("", 0, [])
         }
@@ -38,9 +38,9 @@ class GroovySyntaxCompletorTest extends CompletorTestSupport {
         idCompletorMocker.demand.complete(1) { tokens, candidates ->
             assert(tokens.collect{it.getText()} == ["jav"]); candidates << "javup"; candidates << "java.lang.String" ; true}
         IdentifierCompletor mockIdCompletor = idCompletorMocker.proxyDelegateInstance()
-        ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance()
         groovyshMocker.use {
             Groovysh groovyshMock = new Groovysh()
+            ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance(groovyshMock)
             GroovySyntaxCompletor completor = new GroovySyntaxCompletor(groovyshMock, mockReflComp, [mockIdCompletor], null)
             def candidates = []
             String buffer = "jav"
@@ -54,9 +54,9 @@ class GroovySyntaxCompletorTest extends CompletorTestSupport {
         idCompletorMocker.demand.complete(1) { tokens, candidates ->
             assert(tokens.collect{it.getText()} == ["{", "jav"]); candidates << "javup"; candidates << "java.lang.String" ; true}
         IdentifierCompletor mockIdCompletor = idCompletorMocker.proxyDelegateInstance()
-        ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance()
         groovyshMocker.use {
             Groovysh groovyshMock = new Groovysh()
+            ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance(groovyshMock)
             GroovySyntaxCompletor completor = new GroovySyntaxCompletor(groovyshMock, mockReflComp, [mockIdCompletor], null)
             def candidates = []
             String buffer = "{jav"
@@ -70,9 +70,9 @@ class GroovySyntaxCompletorTest extends CompletorTestSupport {
         reflectionCompletorMocker.demand.complete(1) { tokens, candidates ->
             assert(tokens.collect{it.getText()} == ["Math", ".", "ma"]); candidates << "max("; 5}
         IdentifierCompletor mockIdCompletor = idCompletorMocker.proxyDelegateInstance()
-        ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance()
         groovyshMocker.use {
             Groovysh groovyshMock = new Groovysh()
+            ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance(groovyshMock)
             GroovySyntaxCompletor completor = new GroovySyntaxCompletor(groovyshMock, mockReflComp, [mockIdCompletor], null)
             def candidates = []
             String buffer = "Math.ma"
@@ -85,9 +85,9 @@ class GroovySyntaxCompletorTest extends CompletorTestSupport {
         reflectionCompletorMocker.demand.complete(1) { tokens, candidates ->
             assert(tokens.collect{it.getText()} == ["Fo", ".", "ba", "(", ")", ".", "xyz"]); candidates << "xyzabc"; 0}
         IdentifierCompletor mockIdCompletor = idCompletorMocker.proxyDelegateInstance()
-        ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance()
         groovyshMocker.use {
             Groovysh groovyshMock = new Groovysh()
+            ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance(groovyshMock)
             GroovySyntaxCompletor completor = new GroovySyntaxCompletor(groovyshMock, mockReflComp, [mockIdCompletor], null)
             def candidates = []
             String buffer = "Fo.ba().xyz"
@@ -101,9 +101,9 @@ class GroovySyntaxCompletorTest extends CompletorTestSupport {
         idCompletorMocker.demand.complete(1) { tokens, candidates ->
             assert(tokens.collect{it.getText()} == ["Foo", ".", "bar", "(", "xyz"]); candidates << "xyzabc"; true}
         IdentifierCompletor mockIdCompletor = idCompletorMocker.proxyDelegateInstance()
-        ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance()
         groovyshMocker.use {
             Groovysh groovyshMock = new Groovysh()
+            ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance(groovyshMock)
             GroovySyntaxCompletor completor = new GroovySyntaxCompletor(groovyshMock, mockReflComp, [mockIdCompletor], null)
             def candidates = []
             String buffer = "Foo.bar(xyz"
@@ -116,9 +116,9 @@ class GroovySyntaxCompletorTest extends CompletorTestSupport {
         idCompletorMocker.demand.complete(1) { tokens, candidates ->
             assert(tokens.collect{it.getText()} == ["Foo", ".", "bar", "(", "xyz"]); candidates << "xyzabc"; true}
         IdentifierCompletor mockIdCompletor = idCompletorMocker.proxyDelegateInstance()
-        ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance()
         groovyshMocker.use {
             Groovysh groovyshMock = new Groovysh()
+            ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance(groovyshMock)
             GroovySyntaxCompletor completor = new GroovySyntaxCompletor(groovyshMock, mockReflComp, [mockIdCompletor], null)
             def candidates = []
             // cursor is BEFORE dot
@@ -129,9 +129,9 @@ class GroovySyntaxCompletorTest extends CompletorTestSupport {
 
     void testDoubleIdentifier() {
         IdentifierCompletor mockIdCompletor = idCompletorMocker.proxyDelegateInstance()
-        ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance()
         groovyshMocker.use {
             Groovysh groovyshMock = new Groovysh()
+            ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance(groovyshMock)
             GroovySyntaxCompletor completor = new GroovySyntaxCompletor(groovyshMock, mockReflComp, [mockIdCompletor], null)
             def candidates = []
             String buffer = "String jav"
@@ -142,9 +142,9 @@ class GroovySyntaxCompletorTest extends CompletorTestSupport {
 
     void testInfixKeyword() {
         IdentifierCompletor mockIdCompletor = idCompletorMocker.proxyDelegateInstance()
-        ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance()
         groovyshMocker.use {
             Groovysh groovyshMock = new Groovysh()
+            ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance(groovyshMock)
             GroovySyntaxCompletor completor = new GroovySyntaxCompletor(groovyshMock, mockReflComp, [mockIdCompletor], null)
             def candidates = []
             String buffer = "class Foo ext"
@@ -160,10 +160,10 @@ class GroovySyntaxCompletorTest extends CompletorTestSupport {
             assert(tokens.collect{it.getText()} == ["deletehardDisk", "(", ")", ";", "foo", ".", "subs"]); candidates << "substring("; 22}
 
         IdentifierCompletor mockIdCompletor = idCompletorMocker.proxyDelegateInstance()
-        ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance()
         // mock doing the right thing
         groovyshMocker.use {
             Groovysh groovyshMock = new Groovysh()
+            ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance(groovyshMock)
             GroovySyntaxCompletor completor = new GroovySyntaxCompletor(groovyshMock, mockReflComp, [mockIdCompletor], null)
             def candidates = []
             String buffer = "deletehardDisk(); foo.subs"
@@ -178,10 +178,10 @@ class GroovySyntaxCompletorTest extends CompletorTestSupport {
             assert(tokens.collect{it.getText()} == ["a", "=", "foo", ".", "subs"]); candidates << "substring("; 9}
 
         IdentifierCompletor mockIdCompletor = idCompletorMocker.proxyDelegateInstance()
-        ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance()
         // mock doing the right thing
         groovyshMocker.use {
             Groovysh groovyshMock = new Groovysh()
+            ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance(groovyshMock)
             GroovySyntaxCompletor completor = new GroovySyntaxCompletor(groovyshMock, mockReflComp, [mockIdCompletor], null)
             def candidates = []
             String buffer = "a = foo.subs"
@@ -193,10 +193,10 @@ class GroovySyntaxCompletorTest extends CompletorTestSupport {
     void testDontEvaluateAfterCommand() {
         CommandRegistry registry = new CommandRegistry()
         IdentifierCompletor mockIdCompletor = idCompletorMocker.proxyDelegateInstance()
-        ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance()
         // mock asserting nothing gets evaluated
         groovyshMocker.use {
             Groovysh groovyshMock = new Groovysh()
+            ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance(groovyshMock)
             // import command prevents reflection completion
             registry.register(new ImportCommand(groovyshMock))
             GroovySyntaxCompletor completor = new GroovySyntaxCompletor(groovyshMock, mockReflComp, [mockIdCompletor], null)
@@ -209,10 +209,10 @@ class GroovySyntaxCompletorTest extends CompletorTestSupport {
 
     void testAfterGString() {
         IdentifierCompletor mockIdCompletor = idCompletorMocker.proxyDelegateInstance()
-        ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance()
         // mock asserting GString is not evaluated
         groovyshMocker.use {
             Groovysh groovyshMock = new Groovysh()
+            ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance(groovyshMock)
             GroovySyntaxCompletor completor = new GroovySyntaxCompletor(groovyshMock, mockReflComp, [mockIdCompletor], null)
             def candidates = []
             String buffer = "\"\${foo.delete()}\".subs"
@@ -223,7 +223,6 @@ class GroovySyntaxCompletorTest extends CompletorTestSupport {
 
     void testInStringFilename() {
         IdentifierCompletor mockIdCompletor = idCompletorMocker.proxyDelegateInstance()
-        ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance()
         MockFor filenameCompletorMocker = new MockFor(FileNameCompleter)
         String linestart = "foo('" // ends with single hyphen
         String pathstart = "/usr/foobar"
@@ -235,6 +234,7 @@ class GroovySyntaxCompletorTest extends CompletorTestSupport {
         groovyshMocker.use { filenameCompletorMocker.use {
             FileNameCompleter mockFileComp = new FileNameCompleter()
             Groovysh groovyshMock = new Groovysh()
+            ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance(groovyshMock)
             GroovySyntaxCompletor completor = new GroovySyntaxCompletor(groovyshMock, mockReflComp, [mockIdCompletor], mockFileComp)
             def candidates = []
             assert "foo('/usr/".length() == completor.complete(buffer, buffer.length(), candidates)
@@ -245,7 +245,6 @@ class GroovySyntaxCompletorTest extends CompletorTestSupport {
     void testInStringFilenameBlanks() {
         // test with blanks (non-tokens) before the first hyphen
         IdentifierCompletor mockIdCompletor = idCompletorMocker.proxyDelegateInstance()
-        ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance()
         MockFor filenameCompletorMocker = new MockFor(FileNameCompleter)
         String linestart = "x = '" // ends with single hyphen
         String pathstart = "/usr/foobar"
@@ -257,6 +256,7 @@ class GroovySyntaxCompletorTest extends CompletorTestSupport {
         groovyshMocker.use { filenameCompletorMocker.use {
             FileNameCompleter mockFileComp = new FileNameCompleter()
             Groovysh groovyshMock = new Groovysh()
+            ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance(groovyshMock)
             GroovySyntaxCompletor completor = new GroovySyntaxCompletor(groovyshMock, mockReflComp, [mockIdCompletor], mockFileComp)
             def candidates = []
             assert "x = '/usr/".length() == completor.complete(buffer, buffer.length(), candidates)
@@ -268,10 +268,10 @@ class GroovySyntaxCompletorTest extends CompletorTestSupport {
         idCompletorMocker.demand.complete(1) { tokens, candidates ->
             assert(tokens.collect{it.getText()} == ["", "{", "foo"]); candidates << "foobar"; true}
         IdentifierCompletor mockIdCompletor = idCompletorMocker.proxyDelegateInstance()
-        ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance()
         // mock asserting GString is not evaluated
         groovyshMocker.use {
             Groovysh groovyshMock = new Groovysh()
+            ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance(groovyshMock)
             GroovySyntaxCompletor completor = new GroovySyntaxCompletor(groovyshMock, mockReflComp, [mockIdCompletor], null)
             def candidates = []
             String buffer = "\"\${foo"
@@ -286,9 +286,9 @@ class GroovySyntaxCompletorTest extends CompletorTestSupport {
         bufferManager.buffers.add(["\"\"\"xyz"])
         bufferManager.setSelected(1)
         IdentifierCompletor mockIdCompletor = idCompletorMocker.proxyDelegateInstance()
-        ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance()
         groovyshMocker.use {
             Groovysh groovyshMock = new Groovysh()
+            ReflectionCompletor mockReflComp = reflectionCompletorMocker.proxyInstance(groovyshMock)
             GroovySyntaxCompletor completor = new GroovySyntaxCompletor(groovyshMock, mockReflComp, [mockIdCompletor], null)
             def candidates = []
             String buffer = "abc\"\"\".subs"

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/completion/ReflectionCompletorTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/completion/ReflectionCompletorTest.groovy
@@ -28,9 +28,10 @@ class ReflectionCompletorTest extends GroovyTestCase {
         Collection<String> result = ReflectionCompletor.getPublicFieldsAndMethods(([] as String[]), "")
         assert 'length' in result
         assert 'clone()' in result
+        result = ReflectionCompletor.getMetaclassMethods(([] as String[]), "", true)
         assert 'size()' in result
         assert 'any()' in result
-        result = ReflectionCompletor.getPublicFieldsAndMethods([] as String[], "size")
+        result = ReflectionCompletor.getMetaclassMethods([] as String[], "size", true)
         assert ["size()"] == result
         result = ReflectionCompletor.getPublicFieldsAndMethods([] as String[], "le")
         assert ["length"] == result
@@ -54,14 +55,16 @@ class ReflectionCompletorTest extends GroovyTestCase {
     void testGetFieldsAndMethodsString() {
         Collection<String> result = ReflectionCompletor.getPublicFieldsAndMethods("foo", "")
         assert 'charAt(' in result
-        assert 'normalize()' in result
+        assert 'contains(' in result
         assert 'format(' in result
+        result = ReflectionCompletor.getMetaclassMethods("foo", "", true)
+        assert 'normalize()' in result
         int foo = 3
         result = ReflectionCompletor.getPublicFieldsAndMethods("$foo", "")
         assert 'build(' in result
-        result = ReflectionCompletor.getPublicFieldsAndMethods("foo", "tok")
+        result = ReflectionCompletor.getMetaclassMethods("foo", "tok", true)
         assert ["tokenize(", "tokenize()"] == result
-        result = ReflectionCompletor.getPublicFieldsAndMethods(String, "tok")
+        result = ReflectionCompletor.getMetaclassMethods(String, "tok", true)
         assert ["tokenize(", "tokenize()"] == result
     }
 
@@ -69,12 +72,13 @@ class ReflectionCompletorTest extends GroovyTestCase {
         Collection<String> result = ReflectionCompletor.getPublicFieldsAndMethods(3, "")
         assert "byteValue()" in result
         assert "MAX_VALUE" in result
-        assert "abs()" in result
-        assert "notify()" in result
+        assert "valueOf(" in result
         assert "bitCount(" in result
-        result = ReflectionCompletor.getPublicFieldsAndMethods(3, "una")
+        result = ReflectionCompletor.getMetaclassMethods(3, "", true)
+        assert "abs()" in result
+        result = ReflectionCompletor.getMetaclassMethods(3, "una", true)
         assert ["unaryMinus()", "unaryPlus()"] == result
-        result = ReflectionCompletor.getPublicFieldsAndMethods(Integer, "una")
+        result = ReflectionCompletor.getMetaclassMethods(Integer, "una", true)
         assert ["unaryMinus()", "unaryPlus()"] == result
         result = ReflectionCompletor.getPublicFieldsAndMethods(Integer, "MA")
         assert ["MAX_VALUE"] == result
@@ -125,12 +129,14 @@ class ReflectionCompletorTest extends GroovyTestCase {
     void testGetAbstractClassFields() {
         Collection<String> result = ReflectionCompletor.getPublicFieldsAndMethods(GroovyLexer, "")
         assert 'ABSTRACT' in result
-        assert 'isCase(' in result
         assert 'tracing' in result
+        result = ReflectionCompletor.getMetaclassMethods(GroovyLexer, "", true)
+        assert 'collect()' in result
         result = ReflectionCompletor.getPublicFieldsAndMethods(new GroovyLexer(new ByteArrayInputStream()), "")
         assert 'ABSTRACT' in result
-        assert 'isCase(' in result
         assert 'tracing' in result
+        result = ReflectionCompletor.getMetaclassMethods(new GroovyLexer(new ByteArrayInputStream()), "", true)
+        assert 'isCase(' in result
         result = ReflectionCompletor.getPublicFieldsAndMethods(GroovyLexer, "LITERAL_as")
         assert ["LITERAL_as", "LITERAL_assert"]== result
         GroovyLexer lexer = new GroovyLexer(new ByteArrayInputStream("".getBytes()))
@@ -147,6 +153,15 @@ class ReflectionCompletorTest extends GroovyTestCase {
         assert []== result
         result = ReflectionCompletor.getPublicFieldsAndMethods(new HashSet(), "toA")
         assert ["toArray(", "toArray()"]== result
+    }
+
+    void testSuppressMetaAndDefaultMethods() {
+        Collection<String> result = ReflectionCompletor.getMetaclassMethods("foo", "", true)
+        assert 'getMetaClass()' in result
+        assert 'asBoolean()' in result
+        result = ReflectionCompletor.getMetaclassMethods("foo", "", false)
+        assert ! ('getMetaClass()' in result)
+        assert ! ('asBoolean()' in result)
     }
 
     void testGetFieldsAndMethodsCustomClass() {


### PR DESCRIPTION
See https://jira.codehaus.org/browse/GROOVY-6499
So what I removed from AutoCompletion were metaclass Methods and Methods inherited from java.lang.Object or groovy.lang.GroovyObject, unless the user had already typed the first 3 letters (configurable in Preferences).

before:

```
groovy:000> class Foo{def foo(){}; def bar(){}}
===> true
groovy:000> f = new Foo()
===> Foo@48c95aa2
groovy:000> f.<tab>
addShutdownHook(          any(                      any()                     asBoolean() ....
```

After:

```
groovy:000> f.<tab>
bar()   foo()
```

This is supposed to help programmers see business logic methods without obfuscation by standard methods.
