### PR TITLE
GROOVY-6395: Complete navigable properties for Map and Node instances

### DIFF
--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/completion/NavigablePropertiesCompleter.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/completion/NavigablePropertiesCompleter.groovy
@@ -1,0 +1,64 @@
+package org.codehaus.groovy.tools.shell.completion
+
+public class NavigablePropertiesCompleter {
+
+    /**
+     * Adds navigable properties to the list of candidates if they match the prefix
+     */
+    public void addCompletions(Object instance, final String prefix, final Set<CharSequence> candidates) {
+        if (instance == null) {
+            return;
+        }
+        this.addIndirectObjectMembers(instance, prefix, candidates)
+    }
+
+
+    void addIndirectObjectMembers(Object instance, String prefix, final Set<CharSequence> candidates) {
+        if (instance instanceof Map) {
+            Map map = (Map) instance;
+            addMapProperties(map, prefix, candidates)
+        }
+        if (instance instanceof Node) {
+            Node node = (Node) instance;
+            addNodeChildren(node, prefix, candidates)
+        }
+        if (instance instanceof NodeList) {
+            NodeList nodeList = (NodeList) instance;
+            addNodeListEntries(nodeList, prefix, candidates)
+        }
+    }
+
+    void addMapProperties(Map instance, String prefix, final Set<CharSequence> candidates) {
+        for (String member in instance.keySet()) {
+            if (member.startsWith(prefix)) {
+                candidates.add(member)
+            }
+        }
+    }
+
+    void addNodeListEntries(NodeList instance, String prefix, final Set<CharSequence> candidates) {
+        for (Object member in instance) {
+            addIndirectObjectMembers(member, prefix, candidates)
+        }
+    }
+
+    void addNodeChildren(Node instance, String prefix, final Set<CharSequence> candidates) {
+        for (Object child in instance.children()) {
+            String member = ''
+            if (child instanceof String) {
+                member = (String) child;
+            } else if (child instanceof Node) {
+                member = ((Node) child).name();
+            } else if (child instanceof NodeList) {
+                for (node in ((NodeList)child)) {
+                    addNodeChildren(node, prefix, candidates)
+                }
+            } else {
+                continue;
+            }
+            if (member.startsWith(prefix)) {
+                candidates.add(member);
+            }
+        }
+    }
+}

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/completion/ReflectionCompletor.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/completion/ReflectionCompletor.groovy
@@ -35,6 +35,7 @@ import static org.codehaus.groovy.antlr.parser.GroovyTokenTypes.*
 class ReflectionCompletor {
 
     Groovysh shell
+    static NavigablePropertiesCompleter propertiesCompleter = new NavigablePropertiesCompleter()
     int metaclass_completion_prefix_length
 
     ReflectionCompletor(Groovysh shell) {
@@ -312,9 +313,9 @@ class ReflectionCompletor {
         if (clazz == null) {
             return rv;
         }
-        boolean isClass = false
-        if (clazz == Class) {
-            isClass = true
+
+        boolean isClass = (clazz == Class)
+        if (isClass) {
             clazz = instance as Class
         }
 
@@ -331,6 +332,12 @@ class ReflectionCompletor {
                 }
             }
         }
+
+        // other completions that are commonly possible with properties
+        if (!isClass) {
+            propertiesCompleter.addCompletions(instance, prefix, rv)
+        }
+
         return rv.sort()
     }
 
@@ -347,6 +354,10 @@ class ReflectionCompletor {
             candidates.remove(defaultMethod)
         }
     }
+
+
+
+
 
     private static Collection<String> addClassFieldsAndMethods(final Class clazz, final boolean staticOnly, final String prefix, Collection rv) {
         Field[] fields = staticOnly ? clazz.fields : clazz.getDeclaredFields()

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/completion/NavigablePropertiesCompleterTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/completion/NavigablePropertiesCompleterTest.groovy
@@ -1,0 +1,39 @@
+package org.codehaus.groovy.tools.shell.completion
+
+import org.codehaus.groovy.antlr.GroovySourceToken
+import org.codehaus.groovy.tools.shell.util.CurlyCountingGroovyLexer
+
+/**
+ * Defines method tokenList for other Unit tests and tests it
+ */
+class NavigablePropertiesCompleterTest extends GroovyTestCase {
+
+    void testMap() {
+        NavigablePropertiesCompleter completer = new NavigablePropertiesCompleter()
+        completer.addCompletions(null, '', [] as Set)
+
+        Set candidates = [] as Set
+        completer.addCompletions(['aaa': 1, 'bbb': 2], '', candidates)
+        assert ['aaa', 'bbb'] as Set == candidates
+
+        candidates = [] as Set
+        completer.addCompletions(['aaa': 1, 'bbb': 2], 'a', candidates)
+        assert ['aaa'] as Set == candidates
+
+        candidates = [] as Set
+        completer.addCompletions(['aaa': 1, 'bbb': 2], 'a', candidates)
+        assert ['aaa'] as Set == candidates
+    }
+
+    void testNodeList() {
+        NavigablePropertiesCompleter completer = new NavigablePropertiesCompleter()
+        completer.addCompletions(null, '', [] as Set)
+        NodeBuilder someBuilder = new NodeBuilder()
+        Node node = someBuilder.foo(){[bar(){[bam(7)]}, baz()]}
+
+        Set candidates = [] as Set
+        completer.addCompletions(node, 'ba', candidates)
+        assert ['bar', 'baz'] as Set == candidates
+
+    }
+}

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/completion/ReflectionCompletorTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/completion/ReflectionCompletorTest.groovy
@@ -43,10 +43,12 @@ class ReflectionCompletorTest extends GroovyTestCase {
         assert 'containsKey(' in result
         assert 'clear()' in result
         // 'class' as key can cause bugs where .class is used instead of getClass()
-        result = ReflectionCompletor.getPublicFieldsAndMethods(['class': '42'], "")
+        result = ReflectionCompletor.getPublicFieldsAndMethods(['class': '42', 'club': 53], "")
         assert 'clear()' in result
         assert 'containsKey(' in result
         assert 'clear()' in result
+        assert 'class' in result
+        assert 'club' in result
         result = ReflectionCompletor.getPublicFieldsAndMethods(['id': '42'], "size")
         // e.g. don't show non-public inherited size field
         assert ["size()"] == result


### PR DESCRIPTION
E.g.

```
groovy:000> x = ['aaaaa': 1, 'bbbbb':2]
===> [aaaaa:1, bbbbb:2]
groovy:000> x.a <tab>
```

will now complete to x.aaaaa

Node support is intended for e.g. XmlSlurper and ConfigSlurper
