### PR TITLE
GROOVY-3048 callWithRows() for StoredProc using Output Params and a ResultSet

### DIFF
--- a/subprojects/groovy-sql/src/test/groovy/groovy/sql/SqlCallTest.groovy
+++ b/subprojects/groovy-sql/src/test/groovy/groovy/sql/SqlCallTest.groovy
@@ -21,6 +21,7 @@ import static groovy.sql.SqlTestConstants.*
 
 /**
  * Test Sql transaction features using a Sql built from a connection
+ * along with testing Stored Procedure calls
  *
  * @author Paul King
  */
@@ -56,6 +57,48 @@ class SqlCallTest extends GroovyTestCase {
         people.add(id: 3, firstname: "Sam", lastname: "Pullara")
         people.add(id: 4, firstname: "Jean", lastname: "Gabin")
         people.add(id: 5, firstname: "Lino", lastname: "Ventura")
+
+        //Syntax for HSQLDB stored procedure creation
+        //Result goes into answer out parameter
+        sql.execute """
+          CREATE PROCEDURE FindByFirst(IN p_firstname VARCHAR(10), OUT answer VARCHAR(25))
+            READS SQL DATA
+            BEGIN ATOMIC
+              DECLARE lastN VARCHAR(10);
+              SELECT lastname into lastN FROM person where firstname = p_firstname;
+              SET answer = ('Last Name is ' + lastN);
+            END;
+        """
+
+        //Syntax for HSQLDB stored procedure creation
+        //Results go into ResultSet
+        sql.execute """
+          CREATE PROCEDURE FindAllByFirst(IN p_firstname VARCHAR(10))
+            READS SQL DATA DYNAMIC RESULT SETS 1
+            BEGIN ATOMIC
+              DECLARE resultSet CURSOR WITHOUT HOLD WITH RETURN FOR
+                SELECT id, firstname, lastname FROM person where firstname like (p_firstname + '%')
+                  order by id asc
+                FOR READ ONLY;
+              OPEN resultSet;
+            END;
+        """
+
+        //Results in both an Out Parameter and a ResultSet
+        sql.execute """
+          CREATE PROCEDURE FindAllByFirstWithTotal(IN p_firstname VARCHAR(10), OUT answer VARCHAR(25))
+            READS SQL DATA DYNAMIC RESULT SETS 1
+            BEGIN ATOMIC
+              DECLARE total INTEGER;
+              DECLARE resultSet CURSOR WITHOUT HOLD WITH RETURN FOR
+                SELECT id, firstname, lastname FROM person where firstname like (p_firstname + '%')
+                  order by id asc
+                FOR READ ONLY;
+              OPEN resultSet;
+              SELECT count(*) into total FROM person where firstname like (p_firstname + '%');
+              SET answer = ('Found total ' + total);
+            END;
+        """
     }
 
     @Override
@@ -72,6 +115,79 @@ class SqlCallTest extends GroovyTestCase {
     void testSelectWithFunction() {
         def result = sql.firstRow("select firstname, lastname, CHAR_LENGTH(firstname) as firstsize from PERSON")
         assert result.firstname == 'James' && result.firstsize == 5
+    }
+
+    void testCallUsingOutParameters() {
+        String found
+        sql.call '{call FindByFirst(?, ?)}', ['James', Sql.VARCHAR], { ans ->
+            found = ans
+        }
+        assert found == 'Last Name is Strachan'
+    }
+
+    void testCallGStringUsingOutParameters() {
+        def first = 'James'
+        String found
+        sql.call "{call FindByFirst($first, ${Sql.VARCHAR})}", { ans ->
+            found = ans
+        }
+        assert found == 'Last Name is Strachan'
+    }
+
+    void testStoredProcedureRows() {
+        List<GroovyRowResult> rows = sql.rows '{call FindAllByFirst(?)}', ['J']
+        assert rows.size() == 2
+        assert rows[0].id == 1
+        assert rows[0].firstname == 'James'
+        assert rows[0].lastname == 'Strachan'
+        assert rows[1].id == 4
+        assert rows[1].firstname == 'Jean'
+        assert rows[1].lastname == 'Gabin'
+    }
+
+    void testStoredProcedureRowsGString() {
+        def first = 'J'
+        List<GroovyRowResult> rows = sql.rows "{call FindAllByFirst($first)}"
+        assert rows.size() == 2
+        assert rows[0].id == 1
+        assert rows[0].firstname == 'James'
+        assert rows[0].lastname == 'Strachan'
+        assert rows[1].id == 4
+        assert rows[1].firstname == 'Jean'
+        assert rows[1].lastname == 'Gabin'
+    }
+
+    void testCallWithRows() {
+        String found
+        List<GroovyRowResult> rows = sql.callWithRows '{call FindAllByFirstWithTotal(?, ?)}', ['J', Sql.VARCHAR], { total ->
+            found = total
+        }
+        assert found == 'Found total 2'
+
+        assert rows.size() == 2
+        assert rows[0].id == 1
+        assert rows[0].firstname == 'James'
+        assert rows[0].lastname == 'Strachan'
+        assert rows[1].id == 4
+        assert rows[1].firstname == 'Jean'
+        assert rows[1].lastname == 'Gabin'
+    }
+
+    void testCallWithRowsGString() {
+        def first = 'J'
+        String found
+        List<GroovyRowResult> rows = sql.callWithRows "{call FindAllByFirstWithTotal($first, ${Sql.VARCHAR})}", { total ->
+            found = total
+        }
+        assert found == 'Found total 2'
+
+        assert rows.size() == 2
+        assert rows[0].id == 1
+        assert rows[0].firstname == 'James'
+        assert rows[0].lastname == 'Strachan'
+        assert rows[1].id == 4
+        assert rows[1].firstname == 'Jean'
+        assert rows[1].lastname == 'Gabin'
     }
 
 }


### PR DESCRIPTION
Added new callWithRows() methods for handling Stored Procedures that use both Output Parameters and a single ResultSet. http://jira.codehaus.org/browse/GROOVY-3048

The main callWithRows method is essentially identical to the original call() method, but with an extra few lines to return the ResultSet rows. I also took care to make sure the original call() method was not affected by the additions.

Also added test cases for Stored Procedures for the existing call() and rows() methods as well as the new callWithRows() methods. The gradle test cases work against hsqldb. I've also tested the code against a db2 stored procedure.

These changes were originally discussed in this blog post:
http://www.objectpartners.com/2014/01/24/simpler-stored-procedures-with-groovy/

I welcome any and all comments, thanks!
