### PR TITLE
GROOVY-6548: improve import command

### DIFF
--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/Groovysh.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/Groovysh.groovy
@@ -138,8 +138,10 @@ class Groovysh extends Shell {
         // Append the line to the current buffer
         current << line
 
+        String importsSpec = this.getImportStatements()
+
         // Attempt to parse the current buffer
-        def status = parser.parse(imports + current)
+        def status = parser.parse([importsSpec] + current)
 
         switch (status.code) {
             case ParseCode.COMPLETE:
@@ -150,7 +152,7 @@ class Groovysh extends Shell {
                 }
 
                 // Evaluate the current buffer w/imports and dummy statement
-                List buff = imports + [ 'true' ] + current
+                List buff = [importsSpec] + [ 'true' ] + current
 
                 setLastResult(result = interp.evaluate(buff))
                 buffers.clearSelected()
@@ -187,6 +189,10 @@ class Groovysh extends Shell {
             
             io.out.println(" ${lineNum}@|bold >|@ $line")
         }
+    }
+
+    String getImportStatements() {
+        return this.imports.collect({String it -> "import $it;"}).join('')
     }
 
     //

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/ImportCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/ImportCommand.groovy
@@ -72,6 +72,15 @@ class ImportCommand
             fail("Command 'import' requires one or more arguments") // TODO: i18n
         }
 
+        def importSpec = args.join(' ')
+        if (! (importSpec ==~ '[a-zA-Z_. *]+;?$')) {
+            def msg = "Invalid import definition: '${importSpec}'" // TODO: i18n
+            log.debug(msg)
+            fail(msg)
+        }
+        // remove last semicolon
+        importSpec = importSpec.replaceAll(';', '')
+
         def buff = [ 'import ' + args.join(' ') ]
         buff << 'def dummp = false'
         
@@ -82,16 +91,17 @@ class ImportCommand
             // No need to keep duplicates, but order may be important so remove the previous def, since
             // the last defined import will win anyways
             
-            if (imports.remove(buff[0])) {
+            if (imports.remove(importSpec)) {
                 log.debug("Removed duplicate import from list")
             }
             
-            log.debug("Adding import: ${buff[0]}")
+            log.debug("Adding import: $importSpec")
             
-            imports << buff[0]
+            imports.add(importSpec)
+            return imports.join(', ')
         }
         catch (CompilationFailedException e) {
-            def msg = "Invalid import definition: '${buff[0]}'; reason: $e.message" // TODO: i18n
+            def msg = "Invalid import definition: '${importSpec}'; reason: $e.message" // TODO: i18n
             log.debug(msg, e)
             fail(msg)
         }

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/completion/ReflectionCompletor.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/completion/ReflectionCompletor.groovy
@@ -130,7 +130,7 @@ class ReflectionCompletor {
             try {
                 String instanceRefExpression = tokenListToEvalString(invokerTokens)
                 instanceRefExpression = instanceRefExpression.replace('\n', '')
-                Object instance = shell.interp.evaluate(shell.imports + ['true'] + [instanceRefExpression])
+                Object instance = shell.interp.evaluate([shell.getImportStatements()] + ['true'] + [instanceRefExpression])
                 return instance
             } catch (MissingPropertyException |
                     MissingMethodException |

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/ImportCommandTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/ImportCommandTest.groovy
@@ -25,7 +25,16 @@ class ImportCommandTest
     extends CommandTestSupport
 {
     void testImport() {
-
-        shell << 'import'
+        assert null == shell << 'import'
+        assert 'java.awt.TextField' == shell << 'import java.awt.TextField'
+        // test semicolon does not lead to duplicate import
+        assert 'java.awt.TextField' == shell << 'import java.awt.TextField;'
+        // test last import is added at the end
+        assert 'java.awt.TextField, java.awt.TextArea' == shell << 'import java.awt.TextArea;'
+        assert 'java.awt.TextArea, java.awt.TextField' == shell << 'import java.awt.TextField;'
+        // test multiple commands are not allowed (as they would be executed on every next buffer evaluation)
+        assert null == shell << 'import java.awt.TextField; println("foo")'
+        // test *, recognizing unnecessary imports sadly not implemented
+        assert 'java.awt.TextArea, java.awt.TextField, java.awt.*' == shell << 'import java.awt.*'
     }
 }


### PR DESCRIPTION
- validate import statement is single command
- check duplicates without considering semicolon
- store and show list of imports without leading "import " prefix
- proper unit test for the command
