### PR TITLE
GROOVY-6593 Operators other than dot do not support carriage returns

### DIFF
--- a/src/main/org/codehaus/groovy/antlr/groovy.g
+++ b/src/main/org/codehaus/groovy/antlr/groovy.g
@@ -2492,10 +2492,10 @@ pathElementStart!
     :   (nls! ( DOT
                 |   SPREAD_DOT
                 |   OPTIONAL_DOT
-                |   MEMBER_POINTER )
+                |   MEMBER_POINTER ) )
         |   LBRACK
         |   LPAREN
-        |   LCURLY )
+        |   LCURLY
     ;
 
 /** This is the grammar for what can follow a dot:  x.a, x.@a, x.&a, x.'a', etc.

--- a/src/test/groovy/DynamicMemberTest.groovy
+++ b/src/test/groovy/DynamicMemberTest.groovy
@@ -45,5 +45,11 @@ class DynamicMemberTest extends GroovyTestCase {
     cl = this.&"$name"
     assert cl("String") == "String"
   }
-  
+
+  void testNewLine() {
+      def x = 1
+      def y = x
+               .&toString
+      assert y() == '1'
+  }
 }

--- a/src/test/groovy/SafeNavigationTest.groovy
+++ b/src/test/groovy/SafeNavigationTest.groovy
@@ -43,9 +43,10 @@ class SafeNavigationTest extends GroovyTestCase {
                  .y
                  ?.toString()
         assert y == null
+        def m = 'toString'
         def z = x
                  .a
-                 ?.toString()
+                 ?."$m"()
         assert z == '1'
     }
 

--- a/src/test/groovy/SpreadDotTest.groovy
+++ b/src/test/groovy/SpreadDotTest.groovy
@@ -120,6 +120,23 @@ public class SpreadDotTest extends GroovyTestCase {
         assert wardrobe*.size == [1, 1]
         assert wardrobe*.@size == [12, 12]
     }
+
+    void testNewLine() {
+        def x = [ a:1, b:2 ]
+        def y = x
+                 *.value
+                 *.toString()
+        assert y == [ '1', '2' ]
+        def z = x
+                 *.value
+                 .sum()
+        assert z == 3
+
+        x = [ new Singlet(), new Singlet() ]
+        y = x
+             *.@size
+        assert y == [ 12, 12 ]
+    }
 }
 
 class SpreadDotDemo {


### PR DESCRIPTION
This commit works, but I'm always nervous about changing the grammar as there may be edge cases I haven't considered that would break existing code...

Can anyone think of any exceptions?

---

[From JIRA](http://jira.codehaus.org/browse/GROOVY-6593):

In Groovy, you can add carriage returns before the dot operator. For instance:

``` groovy
doSomething()
    .somethingElse()
    .collect { ... }
```

But with the safe navigation operator or the spread operator, it does not work.

``` groovy
doSomething()
    ?.somethingElse() // does not compile, "unexpected token ?."
    ?.collect { ... }
doSomething()
    *.somethingElse() // does not compile, "unexpected token *."
    .collect { ... }
```
