### PR TITLE
GROOVY-6579: Groovy Console not responsive when running the closure

### DIFF
--- a/subprojects/groovy-console/src/main/groovy/groovy/ui/SystemOutputInterceptor.java
+++ b/subprojects/groovy-console/src/main/groovy/groovy/ui/SystemOutputInterceptor.java
@@ -17,16 +17,17 @@ package groovy.ui;
 
 import groovy.lang.Closure;
 
+import java.io.BufferedOutputStream;
 import java.io.FilterOutputStream;
 import java.io.IOException;
 import java.io.PrintStream;
 
 /**
  * Intercepts System.out/System.err. Implementation helper for Console.groovy.
- *
- * @version $Id$
  */
 public class SystemOutputInterceptor extends FilterOutputStream {
+
+    private static final int BUFFER_SIZE = 2048;
 
     private Closure callback;
     private boolean output;
@@ -60,13 +61,15 @@ public class SystemOutputInterceptor extends FilterOutputStream {
     }
 
     /**
-     * Starts intercepting System.out/System.err
+     * Installs the stream intercepting System.out/System.err stream. This will turn {@code autoFlush} mode off as this
+     * interceptor uses a {@link BufferedOutputStream} stream for more control on when the actual flush is done.
+     * This way we can decrease the actual amount of document updates for the outputArea.
      */
     public void start() {
         if (output) {
-            System.setOut(new PrintStream(this));
+            System.setOut(new PrintStream(new BufferedOutputStream(this, BUFFER_SIZE), false));
         } else {
-            System.setErr(new PrintStream(this));
+            System.setErr(new PrintStream(new BufferedOutputStream(this, BUFFER_SIZE), false));
         }
     }
 
@@ -83,7 +86,7 @@ public class SystemOutputInterceptor extends FilterOutputStream {
     }
 
     /**
-     * Intercepts output - moret common case of byte[]
+     * Intercepts output - more common case of byte[]
      */
     public void write(byte[] b, int off, int len) throws IOException {
         Boolean result = (Boolean) callback.call(new String(b, off, len));

--- a/subprojects/groovy-console/src/main/java/groovy/ui/OutputStreamSynchronisation.java
+++ b/subprojects/groovy-console/src/main/java/groovy/ui/OutputStreamSynchronisation.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2003-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package groovy.ui;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Implementation helper for groovyConsole. Flushes {@code System.out} and {@code System.err} at a fixed rate. This
+ * bundles updates for the outputArea Swing document as the {@link SystemOutputInterceptor} uses a
+ * a {@link java.io.BufferedOutputStream} with a certain size that will get flushed by this class constantly.
+ *
+ * @author Andre Steingress
+ */
+public class OutputStreamSynchronisation {
+
+    protected ScheduledExecutorService executorService;
+
+    protected final long delay;
+    protected final long period;
+
+    /**
+     * Creates a new instance without actually starting the synchronisation. This must be done with a separate call to
+     * {@link #start()}.
+     *
+     * @param delay the initial delay in milli-seconds till synchronisation will start
+     * @param period the time period in milli-seconds to be used between subsequent flushes
+     */
+    public OutputStreamSynchronisation(long delay, long period)  {
+        this.delay = delay;
+        this.period = period;
+    }
+
+    /**
+     * Starts the scheduled flushes with the given {@code delay} and {@code period}.
+     */
+    public synchronized void start() {
+        executorService = Executors.newSingleThreadScheduledExecutor();
+        executorService.scheduleAtFixedRate(new Runnable() {
+            @Override
+            public void run() {
+                System.out.flush();
+                System.err.flush();
+            }
+
+        }, delay, period, TimeUnit.MILLISECONDS);
+    }
+
+    /**
+     * Stops the scheduled flushes and blocks as long as all scheduled updates have been completed.
+     *
+     * @throws InterruptedException if waiting has been interrupted
+     */
+    public synchronized void stop() throws InterruptedException {
+        if (executorService == null)  return;
+
+        executorService.shutdown();
+        executorService.awaitTermination(Long.MAX_VALUE, TimeUnit.SECONDS);
+    }
+}

--- a/subprojects/groovy-console/src/test/groovy/groovy/swing/SwingBuilderConsoleTest.groovy
+++ b/subprojects/groovy-console/src/test/groovy/groovy/swing/SwingBuilderConsoleTest.groovy
@@ -432,4 +432,47 @@ class SwingBuilderConsoleTest extends GroovySwingTestCase {
             }
         }
     }
+
+    void testIterateOverLargeList() {
+        testInEDT {
+            SwingUtilities.metaClass.static.invokeLater = { Runnable runnable ->
+                runnable.run()
+            }
+            Thread.metaClass.static.start = { Runnable runnable ->
+                runnable.run()
+            }
+
+            // in case the static final var has been already initialized
+            Console.prefs = testPreferences
+
+            try {
+                final console = new Console()
+
+                def binding = new Binding()
+                binding.setVariable('controller', console)
+
+                final consoleActions = new ConsoleActions()
+
+                def swing = new SwingBuilder()
+                swing.controller = console
+
+                swing.build(consoleActions)
+                console.run()
+
+                console.inputArea.text = '(1..10000).each { println it }'
+                def start = System.currentTimeMillis()
+                console.runScript(new EventObject([:]))
+                def end = System.currentTimeMillis()
+
+                def doc = console.outputArea.document
+
+                assert (end - start) <= 10000
+                assert doc.getText(0, doc.length).contains('Result: 1..10000')
+            } finally {
+                GroovySystem.metaClassRegistry.removeMetaClass(Thread)
+                GroovySystem.metaClassRegistry.removeMetaClass(SwingUtilities)
+                GroovySystem.metaClassRegistry.removeMetaClass(Preferences)
+            }
+        }
+    }
 }


### PR DESCRIPTION
As described in 6579, groovyConsole almost always hangs for scripts that execute many writes on stdout/stderr (the issue mentions an example where `println` is called 200 times). The reason is that there is no buffering between writing to output streams and insertions into the underlying (slow) Swing `HtmlDocument`. I had a look at the IntelliJ console but they solve the issue with self-written panels for example.

This fix introduces buffered output between calls to stdout/stderr and HtmlDocument. The buffered output is either written to the `HtmlDocument` with an explicit `flush()` or if the buffer is full. For long running scripts, groovyConsole additionally uses the `OutputStreamSynchronisation`  class that periodically calls `flush()` on stdout and stderr (every 250ms is the default setting here).  This has the consequence of less frequent HtmlDocument modifications and improved performance.

I tested the changes on Mac OS X and Windows 7, had it running on JDK 7 and JDK 6. 

The rendering issues described in GROOVY-4096 which introduced the `doc.remove` calls have not been reproducible on Windows for me, so I assumed this was a JDK rendering issue at the time. I removed the calls because they did eat a specific amount of performance for larger HTML documents.
