### PR TITLE
GROOVY-6621 fix Node#text when value is NodeList

### DIFF
--- a/src/main/groovy/util/Node.java
+++ b/src/main/groovy/util/Node.java
@@ -329,13 +329,21 @@ public class Node implements Serializable, Cloneable {
         if (value instanceof String) {
             return (String) value;
         }
+        if (value instanceof NodeList) {
+            return ((NodeList) value).text();
+        }
         if (value instanceof Collection) {
             Collection coll = (Collection) value;
             String previousText = null;
             StringBuilder sb = null;
             for (Object child : coll) {
+                String childText = null;
                 if (child instanceof String) {
-                    String childText = (String) child;
+                    childText = (String) child;
+                } else if (child instanceof Node) {
+                    childText = ((Node) child).text();
+                }
+                if (childText != null) {
                     if (previousText == null) {
                         previousText = childText;
                     } else {

--- a/src/test/groovy/util/NodeTest.groovy
+++ b/src/test/groovy/util/NodeTest.groovy
@@ -1,0 +1,32 @@
+package groovy.util
+
+/**
+ * @author Andrew Hamilton
+ **/
+class NodeTest extends GroovyTestCase {
+
+    org.w3c.dom.Document document
+    Node node
+
+    void setUp() {
+        def xml = "<doc><node>node1</node><node>node2</node><node>node3</node><nested><node>nested node</node></nested><empty-nest/></doc>"
+        def bais = new ByteArrayInputStream(xml.getBytes("utf-8"))
+        def factory = javax.xml.parsers.DocumentBuilderFactory.newInstance()
+        def builder = factory.newDocumentBuilder()
+        document = builder.parse(bais)
+        def parser = new XmlParser()
+        node = parser.parseText(xml)
+    }
+
+    void testTextEmpty() {
+        assertEquals document.getFirstChild().getLastChild().getTextContent(), node.children().last().text()
+    }
+
+    void testTextBasic() {
+        assertEquals document.getFirstChild().getFirstChild().getTextContent(), node.children().first().text()
+    }
+
+    void testTextWithChildren() {
+        assertEquals document.getFirstChild().getTextContent(), node.text()
+    }
+}


### PR DESCRIPTION
by accounting for non-String children elements. Also added  short-cut case for NodeList value.

When groovy.util.Node#text checks for it's value being an instance of Collection, it only accounts for String children elements, which means the text() values of Node children of a NodeList value will not be part of the result.

Before this change, the testTextEmpty and testTextBasic test cases would pass, but the testTextWithChildren test could fail.

[Jira issue](http://jira.codehaus.org/browse/GROOVY-6621)
