### PR TITLE
[GROOVY-6623] Interpreter mode for groovysh, with caveats

### DIFF
--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/SetCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/SetCommand.groovy
@@ -50,6 +50,7 @@ class SetCommand
             set << Preferences.PARSER_FLAVOR_KEY
             set << Preferences.SANITIZE_STACK_TRACE_KEY
             set << Preferences.SHOW_LAST_RESULT_KEY
+            set << Groovysh.INTERPRETER_MODE_PREFERENCE_KEY
             set << Groovysh.AUTOINDENT_PREFERENCE_KEY
             set << Groovysh.COLORS_PREFERENCE_KEY
             set << Groovysh.METACLASS_COMPLETION_PREFIX_LENGTH_PREFERENCE_KEY

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/util/ScriptVariableAnalyzer.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/util/ScriptVariableAnalyzer.groovy
@@ -1,0 +1,94 @@
+package org.codehaus.groovy.tools.shell.util
+
+import groovy.transform.TypeChecked
+import org.codehaus.groovy.ast.ClassCodeVisitorSupport
+import org.codehaus.groovy.ast.ClassNode
+import org.codehaus.groovy.ast.DynamicVariable
+import org.codehaus.groovy.ast.GroovyClassVisitor
+import org.codehaus.groovy.ast.expr.VariableExpression
+import org.codehaus.groovy.classgen.GeneratorContext
+import org.codehaus.groovy.control.*
+
+import java.security.CodeSource
+
+/**
+ * Class to Class parsing a script to detect all bound and unbound variables.
+ * Based on http://glaforge.appspot.com/article/knowing-which-variables-are-bound-or-not-in-a-groovy-script
+ */
+@TypeChecked
+class ScriptVariableAnalyzer {
+
+    protected final Logger log = Logger.create(ScriptVariableAnalyzer.class)
+
+    /**
+     * define a visitor that visits all variable expressions
+     */
+    static class VariableVisitor extends ClassCodeVisitorSupport implements GroovyClassVisitor {
+        Set<String> bound = new HashSet<String>()
+        Set<String> unbound = new HashSet<String>()
+
+        void visitVariableExpression(VariableExpression expression) {
+            // we're not interested in some special implicit variables
+            if (!(expression.variable in ['args', 'context', 'this', 'super'])) {
+                // thanks to this instanceof
+                // we know if the variable is bound or not
+                if (expression.accessedVariable instanceof DynamicVariable) {
+                    unbound << expression.variable
+                } else {
+                    bound << expression.variable
+                }
+            }
+            super.visitVariableExpression(expression)
+        }
+
+        @Override
+        protected SourceUnit getSourceUnit() {
+            return null;
+        }
+    }
+
+    /**
+     * custom PrimaryClassNodeOperation
+     * to be able to hook our code visitor
+     */
+    static class VisitorSourceOperation extends CompilationUnit.PrimaryClassNodeOperation {
+
+        GroovyClassVisitor visitor
+
+        VisitorSourceOperation(GroovyClassVisitor visitor) {
+            this.visitor = visitor
+        }
+
+        void call(SourceUnit source, GeneratorContext context, ClassNode classNode) throws CompilationFailedException {
+            classNode.visitContents(visitor)
+        }
+    }
+
+    /**
+     * class loader to add our phase operation
+     */
+    static class VisitorClassLoader extends GroovyClassLoader {
+        GroovyClassVisitor visitor
+
+        public VisitorClassLoader(GroovyClassVisitor visitor) {
+            this.visitor = visitor
+        }
+
+        protected CompilationUnit createCompilationUnit(CompilerConfiguration config, CodeSource source) {
+            CompilationUnit cu = super.createCompilationUnit(config, source)
+            cu.addPhaseOperation(new VisitorSourceOperation(visitor), Phases.CLASS_GENERATION)
+            return cu
+        }
+    }
+
+    static Set<String> getBoundVars(String scriptText) {
+        assert scriptText != null
+        GroovyClassVisitor visitor = new VariableVisitor()
+        VisitorClassLoader myCL = new VisitorClassLoader(visitor)
+        // simply by parsing the script with our classloader
+        // our visitor will be called and will visit all the variables
+        myCL.parseClass(scriptText)
+        return visitor.bound
+    }
+
+}

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/CommandCompletorTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/CommandCompletorTest.groovy
@@ -53,6 +53,7 @@ extends CompletorTestSupport {
     void testSet() {
         CommandsMultiCompleter completor = new CommandsMultiCompleter()
         def candidates = []
+        groovyshMocker.demand.getINTERPRETER_MODE_PREFERENCE_KEY(1){"interpreterMode"}
         groovyshMocker.demand.getAUTOINDENT_PREFERENCE_KEY(1){'autoindent'}
         groovyshMocker.demand.getCOLORS_PREFERENCE_KEY(1){'colors'}
         groovyshMocker.demand.getMETACLASS_COMPLETION_PREFIX_LENGTH_PREFERENCE_KEY(1){'meta-completion-prefix-length'}
@@ -116,6 +117,7 @@ extends CompletorTestSupport {
     void testSaveSetShow() {
         CommandsMultiCompleter completor = new CommandsMultiCompleter()
         def candidates = []
+        groovyshMocker.demand.getINTERPRETER_MODE_PREFERENCE_KEY(1){"interpreterMode"}
         groovyshMocker.demand.getAUTOINDENT_PREFERENCE_KEY(1){'autoindent'}
         groovyshMocker.demand.getCOLORS_PREFERENCE_KEY(1){'colors'}
         groovyshMocker.demand.getMETACLASS_COMPLETION_PREFIX_LENGTH_PREFERENCE_KEY(1){'meta-completion-prefix-length'}

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/GroovyshTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/GroovyshTest.groovy
@@ -21,6 +21,7 @@ import org.codehaus.groovy.tools.shell.completion.ReflectionCompletionCandidate
 import org.codehaus.groovy.tools.shell.completion.ReflectionCompletor
 import org.codehaus.groovy.tools.shell.completion.TokenUtilTest
 import org.codehaus.groovy.tools.shell.util.JAnsiHelper
+import org.codehaus.groovy.tools.shell.util.Preferences
 
 class GroovyshTest extends GroovyTestCase {
 
@@ -42,6 +43,22 @@ class GroovyshTest extends GroovyTestCase {
         assert mockOut.toString().length() > 0
         assert " 3\n" == mockOut.toString().normalize()[-3..-1]
     }
+
+    void testClassDef() {
+        Groovysh groovysh = new Groovysh(testio)
+        groovysh.execute("class Foo {}")
+        assert mockOut.toString().length() > 0
+        assert " true\n" == mockOut.toString().normalize()[-6..-1]
+    }
+
+    void testmethodDef() {
+        Groovysh groovysh = new Groovysh(testio)
+        groovysh.execute("int foo() {42}")
+        assert mockOut.toString().length() > 0
+        assert " true\n" == mockOut.toString().normalize()[-6..-1]
+    }
+
+
 
     void testIncompleteExpr() {
         Groovysh groovysh = new Groovysh(testio)
@@ -246,6 +263,49 @@ class GroovyshTest extends GroovyTestCase {
         groovyCode.deleteOnExit()
         return groovyCode
     }
+}
+
+/**
+ * Runs all tests of groovyshTests with interpreter mode enabled
+ */
+class GroovyshInterpreterModeTest extends GroovyshTest {
+
+    @Override
+    void setUp() {
+        super.setUp()
+        Preferences.put(Groovysh.INTERPRETER_MODE_PREFERENCE_KEY, 'true')
+    }
+
+    @Override
+    void tearDown() {
+        super.tearDown()
+        Preferences.put(Groovysh.INTERPRETER_MODE_PREFERENCE_KEY, 'false')
+    }
+
+    void testBoundVar() {
+        Groovysh groovysh = new Groovysh(testio)
+        // default is false
+
+        groovysh.execute("int x = 3")
+        assert mockOut.toString().length() > 0
+        assert " 3\n" == mockOut.toString().normalize()[-3..-1]
+        groovysh.execute("x")
+        assert mockOut.toString().length() > 0
+        assert " 3\n" == mockOut.toString().normalize()[-3..-1]
+    }
+
+    void testBoundVarmultiple() {
+        Groovysh groovysh = new Groovysh(testio)
+        // default is false
+        Preferences.put(Groovysh.INTERPRETER_MODE_PREFERENCE_KEY, 'true')
+        groovysh.execute("int x, y, z")
+        assert mockOut.toString().length() > 0
+        assert " 0\n" == mockOut.toString().normalize()[-3..-1]
+        groovysh.execute("y")
+        assert mockOut.toString().length() > 0
+        assert " 0\n" == mockOut.toString().normalize()[-3..-1]
+    }
+
 }
 
 

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/util/ScriptVariableAnalyzerTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/util/ScriptVariableAnalyzerTest.groovy
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2003-2007 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.codehaus.groovy.tools.shell.util
+
+/**
+ * Unit tests for the {@link ScriptVariableAnalyzer} class.
+ *
+ */
+class ScriptVariableAnalyzerTest extends GroovyTestCase {
+
+    void testEmptyScript() {
+        assert ['name', 'value'] as Set == ScriptVariableAnalyzer.getBoundVars('')
+    }
+
+    void testBound() {
+        def scriptText = '''
+   int a = 6
+   String b = "7"
+'''
+        assert ['a', 'b', 'name', 'value'] as Set == ScriptVariableAnalyzer.getBoundVars(scriptText)
+    }
+
+    void testUnBound() {
+        def scriptText = '''
+   a = 6
+   b = "7"
+'''
+        assert ['name', 'value'] as Set == ScriptVariableAnalyzer.getBoundVars(scriptText)
+    }
+
+    void testMixed() {
+        def scriptText = '''
+   def foo(args) { args && !d }
+   Closure c = { 4 }
+   int b = 6
+   try {
+       println(a + 5 - b + c() / foo(a))
+   } catch (Throwable t) {
+       println b
+   } finally {
+       throw d
+   }
+   assert b
+'''
+        assert ['b', 'c', 'name', 'value'] as Set == ScriptVariableAnalyzer.getBoundVars(scriptText)
+    }
+}


### PR DESCRIPTION
Now works:

```
groovy:000> def x = 3
===> 3
groovy:000> x
Unknown property: x
groovy:000> :set interpreterMode true
groovy:000> def x = 3
===> 3
groovy:000> x
===> 3
```

Now fails (Type/method declaration on same line as statement):

```
x = 3; class Foo{}
x = 3; def foo() {}
```
