### PR TITLE
GROOVY-6158 ObjectGraphBuilder.NewInstanceResolver disregards node value

### DIFF
--- a/src/main/groovy/util/ObjectGraphBuilder.java
+++ b/src/main/groovy/util/ObjectGraphBuilder.java
@@ -266,11 +266,11 @@ public class ObjectGraphBuilder extends FactoryBuilderSupport {
         } else if (newInstanceResolver instanceof Closure) {
             final ObjectGraphBuilder self = this;
             this.newInstanceResolver = new NewInstanceResolver() {
-                public Object newInstance(Class klass, Map attributes)
+                public Object newInstance(Class klass,  Object value, Map attributes)
                         throws InstantiationException, IllegalAccessException {
                     Closure cls = (Closure) newInstanceResolver;
                     cls.setDelegate(self);
-                    return cls.call(new Object[]{klass, attributes});
+                    return cls.call(new Object[]{klass, value, attributes});
                 }
             };
         } else {
@@ -466,7 +466,7 @@ public class ObjectGraphBuilder extends FactoryBuilderSupport {
      * Default impl that calls Class.newInstance()
      */
     public static class DefaultNewInstanceResolver implements NewInstanceResolver {
-        public Object newInstance(Class klass, Map attributes) throws InstantiationException,
+        public Object newInstance(Class klass,  Object value, Map attributes) throws InstantiationException,
                 IllegalAccessException {
             return klass.newInstance();
         }
@@ -539,7 +539,7 @@ public class ObjectGraphBuilder extends FactoryBuilderSupport {
          * @param klass      the resolved class name
          * @param attributes the attribute Map available for the node
          */
-        Object newInstance(Class klass, Map attributes) throws InstantiationException,
+        Object newInstance(Class klass,  Object value, Map attributes) throws InstantiationException,
                 IllegalAccessException;
     }
 
@@ -665,7 +665,7 @@ public class ObjectGraphBuilder extends FactoryBuilderSupport {
                 return value;
             }
 
-            return ogbuilder.newInstanceResolver.newInstance(klass, properties);
+            return ogbuilder.newInstanceResolver.newInstance(klass, value, properties);
         }
 
         public void setChild(FactoryBuilderSupport builder, Object parent, Object child) {

--- a/src/test/groovy/util/ObjectGraphBuilderTest.groovy
+++ b/src/test/groovy/util/ObjectGraphBuilderTest.groovy
@@ -317,6 +317,24 @@ class ObjectGraphBuilderTest extends GroovyTestCase {
       reflectionBuilder = new ObjectGraphBuilder()
       reflectionBuilder.classNameResolver = [ name: 'reflection', root: "groovy.util" ]
    }
+
+   void testGroovy6185() {
+      builder.newInstanceResolver = { klass, value, attributes ->
+          if (klass.simpleName == 'Company' && value instanceof String) {
+              klass.newInstance(name: value)
+          } else {
+              klass.newInstance()
+          }
+      }
+
+      def expected = new Company(name: 'ACME', employees: [])
+      def actual = builder.company('ACME', employees: [])
+      assert actual != null
+      //assert actual.class == Company
+      assert actual.name == expected.name
+      assert actual.address == expected.address
+      assert actual.employees == expected.employees
+   }
 }
 
 class Company {


### PR DESCRIPTION
This fix introduces a binary incompatibility as a method signature
was changed from

```
Object newInstance(Class klass, Map attributes)
```

to

```
Object newInstance(Class klass, Object value, Map attributes)
```

Merge with caution (into 2.2 or greater) or wait until 3.0
