### PR TITLE
GROOVY-6700: deprecate old GroovyAssert class from groovy.util in favor ...

### DIFF
--- a/subprojects/groovy-test/src/main/java/groovy/util/GroovyAssert.java
+++ b/subprojects/groovy-test/src/main/java/groovy/util/GroovyAssert.java
@@ -22,6 +22,10 @@ import org.codehaus.groovy.runtime.ScriptBytecodeAdapter;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+/**
+ * @deprecated Use the {@link groovy.test.GroovyAssert} class instead
+ */
+@Deprecated
 public class GroovyAssert {
     private static final int MAX_NESTED_EXCEPTIONS = 10;
 


### PR DESCRIPTION
...of the new one in groovy.test package
