### PR TITLE
Don't vary the generated filename by the time

### DIFF
--- a/src/main/groovy/lang/GroovyClassLoader.java
+++ b/src/main/groovy/lang/GroovyClassLoader.java
@@ -210,7 +210,7 @@ public class GroovyClassLoader extends URLClassLoader {
      * @return the main class defined in the given script
      */
     public Class parseClass(String text) throws CompilationFailedException {
-        return parseClass(text, "script" + System.currentTimeMillis() +
+        return parseClass(text, "script" +
                 Math.abs(text.hashCode()) + ".groovy");
     }
 


### PR DESCRIPTION
There's no need to vary the generated filename by time, and varying the filename by time can cause problems, such as if the same source is repeatedly compiled, it will get a different filename each time causing the classCache to grow needlessly.
