### PR TITLE
Fix type of value parameter in setColor

### DIFF
--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/Main.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/Main.groovy
@@ -176,14 +176,16 @@ class Main
     }
 
     static void setColor(String value) {
+        boolean ansiEnabled
+
         if (value == null) {
-            value = true // --color is the same as --color=true
+            ansiEnabled = true // --color is the same as --color=true
         }
         else {
-            value = Boolean.valueOf(value).booleanValue(); // For JDK 1.4 compat
+            ansiEnabled = Boolean.valueOf(value).booleanValue(); // For JDK 1.4 compat
         }
 
-        Ansi.enabled = value
+        Ansi.enabled = ansiEnabled
     }
 
     static void setSystemProperty(final String nameValue) {


### PR DESCRIPTION
Parameter value receives Strings as options.getOptionValue returns string. This fixes --color option.
