### PR TITLE
Expanded the regex utilized to validate imports in groovysh. GROOVY-6743

### DIFF
--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/ImportCommand.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/commands/ImportCommand.groovy
@@ -73,7 +73,15 @@ class ImportCommand
         }
 
         def importSpec = args.join(' ')
-        if (! (importSpec ==~ '[a-zA-Z_. *]+;?$')) {
+
+        // technically java conventions don't allow numerics at the start of package/class names so the regex below
+        // is a bit lacking.  this approach works reasonably well ->
+        // "(\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart}*\\.)+((\\p{javaJavaIdentifierStart}\\p{javaJavaIdentifierPart})|\\*)+;?$"
+        // but there's something preventing it from working when class names end in a "d" or "D" like
+        // "java.awt.TextField" so it is not implemented as such here.  Perhaps this could be made to be more
+        // intelligent if someone could figure out why that is happening or could write a nicer batch of regex to
+        // solve the problem
+        if (! (importSpec ==~ '[\\da-zA-Z_. *]+;?$')) {
             def msg = "Invalid import definition: '${importSpec}'" // TODO: i18n
             log.debug(msg)
             fail(msg)

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/ImportCommandTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/commands/ImportCommandTest.groovy
@@ -36,5 +36,8 @@ class ImportCommandTest
         assert null == shell << 'import java.awt.TextField; println("foo")'
         // test *, recognizing unnecessary imports sadly not implemented
         assert 'java.awt.TextArea, java.awt.TextField, java.awt.*' == shell << 'import java.awt.*'
+        // test numerics being allowed in class/package names
+        assert 'java.awt.TextArea, java.awt.TextField, java.awt.*, org.w3c.dom.*' == shell << 'import org.w3c.dom.*'
+        assert 'java.awt.TextArea, java.awt.TextField, java.awt.*, org.w3c.dom.*, java.awt.Graphics2D' == shell << 'import java.awt.Graphics2D'
     }
 }


### PR DESCRIPTION
Prior to this change, classes/packages that contained digits were not allowed.

http://jira.codehaus.org/browse/GROOVY-6743
