### PR TITLE
Make groovyc log build failure at the error level with failOnError 

### DIFF
--- a/subprojects/groovy-ant/src/main/java/org/codehaus/groovy/ant/Groovyc.java
+++ b/subprojects/groovy-ant/src/main/java/org/codehaus/groovy/ant/Groovyc.java
@@ -1120,7 +1120,7 @@ public class Groovyc extends MatchingTask {
             }
 
             if (failOnError) {
-                log.info(message);
+                log.error(message);
                 throw new BuildException("Compilation Failed", t, getLocation());
             } else {
                 log.error(message);


### PR DESCRIPTION
Pull request for https://jira.codehaus.org/browse/GROOVY-6756

Make it so that that running ant with the -q flag shows compilation errors, as is consistent with the javac task
