### PR TITLE
Collection.min() is deprecated and comment updated

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -4814,6 +4814,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @see #min(Iterable)
      * @since 1.0
      */
+    @Deprecated 
     public static <T> T min(Collection<T> self) {
         return GroovyCollections.min(self);
     }


### PR DESCRIPTION
Collection.min() is deprecated and should use Iterable.min().
However, the Javadoc comment is not updated as such.
