### PR TITLE
Fix toString override problem of GString

### DIFF
--- a/src/main/org/codehaus/groovy/reflection/stdclasses/StringCachedClass.java
+++ b/src/main/org/codehaus/groovy/reflection/stdclasses/StringCachedClass.java
@@ -19,6 +19,7 @@ import groovy.lang.GString;
 import org.codehaus.groovy.reflection.CachedClass;
 import org.codehaus.groovy.reflection.ClassInfo;
 import org.codehaus.groovy.reflection.ReflectionCache;
+import org.codehaus.groovy.runtime.InvokerHelper;
 
 /**
  * @author Alex.Tkachman
@@ -42,6 +43,6 @@ public class StringCachedClass extends CachedClass {
     }
 
     public Object coerceArgument(Object argument) {
-        return argument instanceof GString ? argument.toString() : argument;
+        return argument instanceof GString ? InvokerHelper.invokeMethod(argument, "toString", null) : argument;
     }
 }


### PR DESCRIPTION
In some cases we can't override toString() method of GString

When we coerce GString to String method 
org.codehaus.groovy.reflection.stdclasses.StringCachedClass.coerceArgument(Object)
invoked.
In this method toString() method of GString invokes directly, so if we override toString method of GString in ExtensionModule it does not work.
