### PR TITLE
Fix README - No need to login to TeamCity with guest=1 specified

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -75,7 +75,7 @@ Please note that the following Gradle tasks generate both indy and non indy vari
 
 == Continuous Integration
 
-The official CI server runs {groovy-ci}[here] (login as user guest and leave the password blank) and is sponsored by http://www.jetbrains.com[JetBrains].
+The official CI server runs {groovy-ci}[here] and is sponsored by http://www.jetbrains.com[JetBrains].
 
 == License
 


### PR DESCRIPTION
Removes an old message in README
