### PR TITLE
GROOVY-3971: adding method to class in ASTBuilder not working

### DIFF
--- a/src/main/org/codehaus/groovy/ast/builder/AstSpecificationCompiler.groovy
+++ b/src/main/org/codehaus/groovy/ast/builder/AstSpecificationCompiler.groovy
@@ -106,17 +106,14 @@ class AstSpecificationCompiler implements GroovyInterceptable {
     /**
      * Creates the DSL compiler.
      */
-
     AstSpecificationCompiler(@DelegatesTo(AstSpecificationCompiler) Closure spec) {
         spec.delegate = this
         spec()
     }
 
-
     /**
      * Gets the current generated expression.
      */
-
     List<ASTNode> getExpression() {
         return expression
     }
@@ -187,12 +184,9 @@ class AstSpecificationCompiler implements GroovyInterceptable {
     */ 
     private void makeNode(Class target, String typeAlias, List<Class<? super ASTNode>> ctorArgs, @DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         captureAndCreateNode(target.class.simpleName, argBlock) {
-            target.newInstance(
-                    * enforceConstraints(typeAlias, ctorArgs)
-            )
+            target.newInstance(*enforceConstraints(typeAlias, ctorArgs))
         }
     }
-
 
     /**
     * Helper method to convert a DSL invocation with a list of parameters specified 
@@ -210,7 +204,6 @@ class AstSpecificationCompiler implements GroovyInterceptable {
         }
     }
 
-
     /**
     * Helper method to convert a DSL invocation with a String parameter into a List of ASTNode instances. 
     * 
@@ -225,7 +218,6 @@ class AstSpecificationCompiler implements GroovyInterceptable {
         }
     }
 
-
     /**
     * Helper method to convert a DSL invocation with a String parameter into an Array of ASTNode instances. 
     * 
@@ -239,7 +231,6 @@ class AstSpecificationCompiler implements GroovyInterceptable {
             expression.toArray(target)
         }
     }
-
     
     /**
     * Helper method to convert a DSL invocation into an ASTNode instance when a Class parameter is specified. 
@@ -258,107 +249,83 @@ class AstSpecificationCompiler implements GroovyInterceptable {
     private void makeNodeWithClassParameter(Class target, String alias, List<Class> spec, @DelegatesTo(AstSpecificationCompiler) Closure argBlock, Class type) {
         captureAndCreateNode(target.class.simpleName, argBlock) {
             expression.add(0, ClassHelper.make(type))
-            target.newInstance(
-                    * enforceConstraints(alias, spec)
-            )
+            target.newInstance(*enforceConstraints(alias, spec))
         }
     }
 
     private void makeNodeWithStringParameter(Class target, String alias, List<Class> spec, @DelegatesTo(AstSpecificationCompiler) Closure argBlock, String text) {
         captureAndCreateNode(target.class.simpleName, argBlock) {
             expression.add(0, text)
-            target.newInstance(
-                    * enforceConstraints(alias, spec)
-            )
+            target.newInstance(*enforceConstraints(alias, spec))
         }
     }
-
 
     /**
      * Creates a CastExpression.
      */
-
     void cast(Class type, @DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNodeWithClassParameter(CastExpression, 'cast', [ClassNode, Expression], argBlock, type)
     }
 
-
     /**
      * Creates an ConstructorCallExpression.
      */
-
     void constructorCall(Class type, @DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNodeWithClassParameter(ConstructorCallExpression, 'constructorCall', [ClassNode, Expression], argBlock, type)
     }
 
-
     /**
      * Creates a MethodCallExpression.
      */
-
     void methodCall(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNode(MethodCallExpression, 'methodCall', [Expression, Expression, Expression], argBlock)
     }
 
-
     /**
      * Creates an AnnotationConstantExpression.
      */
-
     void annotationConstant(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNode(AnnotationConstantExpression, 'annotationConstant', [AnnotationNode], argBlock)
     }
 
-
     /**
      * Creates a PostfixExpression.
      */
-
     void postfix(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNode(PostfixExpression, 'postfix', [Expression, Token], argBlock)
     }
 
-
     /**
      * Creates a FieldExpression.
      */
-
     void field(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNode(FieldExpression, 'field', [FieldNode], argBlock)
     }
 
-
     /**
      * Creates a MapExpression.
      */
-
     void map(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNodeFromList(MapExpression, argBlock)
     }
 
-
     /**
      * Creates a TupleExpression.
      */
-
     void tuple(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNodeFromList(TupleExpression, argBlock)
     }
 
-
     /**
      * Creates a MapEntryExpression.
      */
-
     void mapEntry(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNode(MapEntryExpression, 'mapEntry', [Expression, Expression], argBlock)
     }
 
-
     /**
      * Creates a gString.
      */
-
     void gString(String verbatimText, @DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNodeWithStringParameter(GStringExpression, 'gString', [String, List, List], argBlock, verbatimText)
     }
@@ -372,87 +339,68 @@ class AstSpecificationCompiler implements GroovyInterceptable {
         makeNode(MethodPointerExpression, 'methodPointer', [Expression, Expression], argBlock)
     }
 
-
     /**
      * Creates a property.
      */
-
     void property(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNode(PropertyExpression, 'property', [Expression, Expression], argBlock)
     }
 
-
     /**
      * Creates a RangeExpression.
      */
-
     void range(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNode(RangeExpression, 'range', [Expression, Expression, Boolean], argBlock)
     }
 
-
     /**
      * Creates EmptyStatement.
      */
-
     void empty() {
         expression << EmptyStatement.INSTANCE
     }
 
-
     /**
      * Creates a label.
      */
-
     void label(String label) {
         expression << label
     }
 
-
     /**
      * Creates an ImportNode.
      */
-
     void importNode(Class target, String alias = null) {
         expression << new ImportNode(ClassHelper.make(target), alias)
     }
 
-
     /**
      * Creates a CatchStatement.
      */
-
     void catchStatement(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNode(CatchStatement, 'catchStatement', [Parameter, Statement], argBlock)
     }
 
-
     /**
      * Creates a ThrowStatement.
      */
-
     void throwStatement(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNode(ThrowStatement, 'throwStatement', [Expression], argBlock)
     }
 
-
     /**
      * Creates a SynchronizedStatement.
      */
-
     void synchronizedStatement(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNode(SynchronizedStatement, 'synchronizedStatement', [Expression, Statement], argBlock)
     }
 
-
     /**
      * Creates a ReturnStatement.
      */
-
     void returnStatement(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNode(ReturnStatement, 'returnStatement', [Expression], argBlock)
     }
-
 
     /**
      * Creates a TernaryExpression.
@@ -466,16 +414,13 @@ class AstSpecificationCompiler implements GroovyInterceptable {
     /**
      * Creates an ElvisOperatorExpression.
      */
-
     void elvisOperator(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNode(ElvisOperatorExpression, 'elvisOperator', [Expression, Expression], argBlock)
     }
 
-
     /**
      * Creates a BreakStatement.
      */
-
     void breakStatement(String label = null) {
         if (label) {
             expression << new BreakStatement(label)
@@ -484,11 +429,9 @@ class AstSpecificationCompiler implements GroovyInterceptable {
         }
     }
 
-
     /**
      * Creates a ContinueStatement.
      */
-
     void continueStatement(@DelegatesTo(AstSpecificationCompiler) Closure argBlock = null) {
         if (!argBlock) {
             expression << new ContinueStatement()
@@ -497,67 +440,82 @@ class AstSpecificationCompiler implements GroovyInterceptable {
         }
     }
 
-
     /**
      * Create a CaseStatement.
      */
-
     void caseStatement(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNode(CaseStatement, 'caseStatement', [Expression, Statement], argBlock)
     }
 
-
     /**
      * Creates a BlockStatement.
      */
-
     void defaultCase(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         block(argBlock) // same as arg block
     }
 
-
     /**
      * Creates a PrefixExpression.
      */
-
     void prefix(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNode(PrefixExpression, 'prefix', [Token, Expression], argBlock)
     }
 
-
     /**
      * Creates a NotExpression.
      */
-
     void not(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNode(NotExpression, 'not', [Expression], argBlock)
     }
 
-
     /**
      * Creates a DynamicVariable.
      */
-
     void dynamicVariable(String variable, boolean isStatic = false) {
         expression << new DynamicVariable(variable, isStatic)
     }
 
-
     /**
      * Creates a ClassNode[].
      */
-
     void exceptions(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeArrayOfNodes([] as ClassNode[], argBlock)
     }
 
-
     /**
      * Designates a list of AnnotationNodes.
      */
-
     void annotations(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeListOfNodes(argBlock, "List<AnnotationNode>")
+    }
+
+
+    /**
+     * Designates a list of MethodNodes.
+     */
+    void methods(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
+        makeListOfNodes(argBlock, "List<MethodNode>")
+    }
+
+    /**
+     * Designates a list of ConstructorNodes.
+     */
+    void constructors(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
+        makeListOfNodes(argBlock, "List<ConstructorNode>")
+    }
+
+    /**
+     * Designates a list of {@code PropertyNode}s.
+     */
+    void properties(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
+        makeListOfNodes(argBlock, "List<PropertyNode>")
+    }
+
+    /**
+     * Designates a list of {@code FieldNode}s.
+     */
+    void fields(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
+        makeListOfNodes(argBlock, "List<FieldNode>")
     }
 
     /**
@@ -576,247 +534,193 @@ class AstSpecificationCompiler implements GroovyInterceptable {
         makeListOfNodes(argBlock, "List<Expression>")
     }
 
-
     /**
      * Creates a boolean value.
      */
-
     void inclusive(boolean value) {
         expression << value
     }
 
-
     /**
      * Creates a ConstantExpression.
      */
-
     void constant(Object value) {
         expression << new ConstantExpression(value)
     }
 
-
     /**
      * Creates an IfStatement.
      */
-
     void ifStatement(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNode(IfStatement, 'ifStatement', [BooleanExpression, Statement, Statement], argBlock)
     }
 
-
     /**
      * Creates a SpreadExpression.
      */
-
     void spread(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNode(SpreadExpression, 'spread', [Expression], argBlock)
     }
 
-
     /**
      * Creates a SpreadMapExpression.
      */
-
     void spreadMap(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNode(SpreadMapExpression, 'spreadMap', [Expression], argBlock)
     }
 
-
     /**
      * Creates a WhileStatement.
      */
-
     void whileStatement(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNode(WhileStatement, 'whileStatement', [BooleanExpression, Statement], argBlock)
     }
 
-
     /**
      * Create a ForStatement.
      */
-
     void forStatement(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNode(ForStatement, 'forStatement', [Parameter, Expression, Statement], argBlock)
     }
 
-
     /**
      * Creates a ClosureListExpression.
      */
-
     void closureList(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNodeFromList(ClosureListExpression, argBlock)
     }
 
-
     /**
      * Creates a DeclarationExpression.
      */
-
     void declaration(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNode(DeclarationExpression, 'declaration', [Expression, Token, Expression], argBlock)
     }
 
-
     /**
      * Creates a ListExpression.
      */
-
     void list(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNodeFromList(ListExpression, argBlock)
     }
 
-
     /**
      * Creates a BitwiseNegationExpression.
      */
-
     void bitwiseNegation(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNode(BitwiseNegationExpression, 'bitwiseNegation', [Expression], argBlock)
     }
 
-
     /**
      * Creates a ClosureExpression.
      */
-
     void closure(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNode(ClosureExpression, 'closure', [Parameter[], Statement], argBlock)
     }
 
-
     /**
      * Creates a BooleanExpression.
      */
-
     void booleanExpression(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNode(BooleanExpression, 'booleanExpression', [Expression], argBlock)
     }
 
-
     /**
      * Creates a BinaryExpression.
      */
-
     void binary(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNode(BinaryExpression, 'binary', [Expression, Token, Expression], argBlock)
     }
 
-
     /**
      * Creates a UnaryPlusExpression.
      */
-
     void unaryPlus(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNode(UnaryPlusExpression, 'unaryPlus', [Expression], argBlock)
     }
 
-
     /**
      * Creates a ClassExpression.
      */
-
     void classExpression(Class type) {
         expression << new ClassExpression(ClassHelper.make(type))
     }
 
-
     /**
      * Creates a UnaryMinusExpression
      */
-
     void unaryMinus(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNode(UnaryMinusExpression, 'unaryMinus', [Expression], argBlock)
     }
 
-
     /**
      * Creates an AttributeExpression.
      */
-
     void attribute(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNode(AttributeExpression, 'attribute', [Expression, Expression], argBlock)
     }
 
-
     /**
      * Creates an ExpressionStatement.
      */
-
     void expression(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNode(ExpressionStatement, 'expression', [Expression], argBlock)
     }
 
-
     /**
      * Creates a NamedArgumentListExpression.
      */
-
     void namedArgumentList(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeNodeFromList(NamedArgumentListExpression, argBlock)
     }
 
-
     /**
      * Creates a ClassNode[].
      */
-
     void interfaces(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeListOfNodes(argBlock, "List<ClassNode>")
     }
 
-
     /**
      * Creates a MixinNode[].
      */
-
     void mixins(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeListOfNodes(argBlock, "List<MixinNode>")
     }
 
-
     /**
      * Creates a GenericsTypes[].
      */
-
     void genericsTypes(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeListOfNodes(argBlock, "List<GenericsTypes>")
     }
 
-
     /**
      * Creates a ClassNode.
      */
-
     void classNode(Class target) {
         expression << ClassHelper.make(target, false)
     }
 
-
     /**
      * Creates a Parameter[].
      */
-
     void parameters(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeArrayOfNodes([] as Parameter[], argBlock)
     }
 
-
     /**
      * Creates a BlockStatement.
      */
-
     void block(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         captureAndCreateNode("BlockStatement", argBlock) {
             return new BlockStatement(new ArrayList(expression), new VariableScope())
         }
     }
 
-
     /**
      * Creates a Parameter.
      */
-
     void parameter(Map<String, Class> args, @DelegatesTo(AstSpecificationCompiler) Closure argBlock = null) {
         if (!args) throw new IllegalArgumentException()
         if (args.size() > 1) throw new IllegalArgumentException()
@@ -835,23 +739,18 @@ class AstSpecificationCompiler implements GroovyInterceptable {
         }
     }
 
-
     /**
      * Creates an ArrayExpression.
      */
-
     void array(Class type, @DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         captureAndCreateNode("ArrayExpression", argBlock) {
             new ArrayExpression(ClassHelper.make(type), new ArrayList(expression))
         }
     }
 
-
-
     /**
      * Creates a GenericsType.
      */
-
     void genericsType(Class type, @DelegatesTo(AstSpecificationCompiler) Closure argBlock = null) {
         if (argBlock) {
             captureAndCreateNode("GenericsType", argBlock) {
@@ -863,14 +762,14 @@ class AstSpecificationCompiler implements GroovyInterceptable {
     }
 
     /**
-     * Creates a list of ClassNodes.
+     * Creates a list of upperBound ClassNodes.
      */
     void upperBound(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         makeListOfNodes(argBlock, 'List<ClassNode>')
     }
 
     /**
-     * Creates a list of ClassNodes. 
+     * Create lowerBound ClassNode.
      */
     void lowerBound(Class target) {
         expression << ClassHelper.make(target)
@@ -879,18 +778,15 @@ class AstSpecificationCompiler implements GroovyInterceptable {
     /**
      * Creates a 2 element list of name and Annotation. Used with Annotation Members.
      */
-
     void member(String name, @DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         captureAndCreateNode("Annotation Member", argBlock) {
             [name, expression[0]]
         }
     }
 
-
     /**
      * Creates an ArgumentListExpression.
      */
-
     void argumentList(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         if (!argBlock) {
             expression << new ArgumentListExpression()
@@ -899,11 +795,9 @@ class AstSpecificationCompiler implements GroovyInterceptable {
         }
     }
 
-
     /**
      * Creates an AnnotationNode.
      */
-
     void annotation(Class target, @DelegatesTo(AstSpecificationCompiler) Closure argBlock = null) {
         if (argBlock) {
             //todo: add better error handling
@@ -919,11 +813,9 @@ class AstSpecificationCompiler implements GroovyInterceptable {
         }
     }
 
-
     /**
      * Creates a MixinNode.
      */
-
     void mixin(String name, int modifiers, @DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         captureAndCreateNode("AttributeExpression", argBlock) {
             if (expression.size() > 1) {
@@ -934,87 +826,73 @@ class AstSpecificationCompiler implements GroovyInterceptable {
         }
     }
 
-
-
     /**
      * Creates a ClassNode
      */
-
     void classNode(String name, int modifiers, @DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         captureAndCreateNode("ClassNode", argBlock) {
-            List<MethodNode> methods = []
-            List<FieldNode> fields = []
-            List<ConstructorNode> constructors = []
-            List<PropertyNode> properties = []
-            def index = 0
-            while (index < expression.size()) {
-                switch(expression[index].getClass()) {
-                    case MethodNode:
-                        constructors << expression[index]
-                        expression.remove(index)
-                        break
-                    case ConstructorNode:
-                        methods << expression[index]
-                        expression.remove(index)
-                        break
-                    case PropertyNode:
-                        properties << expression[index]
-                        expression.remove(index)
-                        break
-                    case FieldNode:
-                        fields << expression[index]
-                        expression.remove(index)
-                        break
-                    default:
-                        index++
-                }
-            }
             def result = new ClassNode(name, modifiers,
                     expression[0],
                     new ArrayList(expression[1]) as ClassNode[],
                     new ArrayList(expression[2]) as MixinNode[]
             )
-            if (expression[3]) {
-                result.setGenericsTypes(new ArrayList(expression[3]) as GenericsType[])
-            }
-            methods.each{ result.addMethod(it) }
-            constructors.each{ result.addMethod(it) }
-            properties.each{
-                it.field.owner = result
-                result.addProperty(it)
-            }
-            fields.each{
-                it.owner = result
-                result.addField(it)
+            while (expression.size() > 3) {
+                if (!List.isAssignableFrom(expression[3].getClass())) {
+                    throw new IllegalArgumentException("Expecting to find list of additional items instead found: " + expression[3].getClass())
+                }
+                if (expression[3].size() > 0) {
+                    def clazz = expression[3][0].getClass()
+                    switch(clazz) {
+                        case GenericsType:
+                            result.setGenericsTypes(new ArrayList(expression[3]) as GenericsType[])
+                            break
+                        case MethodNode:
+                            expression[3].each{ result.addMethod(it) }
+                            break
+                        case ConstructorNode:
+                            expression[3].each{ result.addConstructor(it) }
+                            break
+                        case PropertyNode:
+                            expression[3].each{
+                                it.field.owner = result
+                                result.addProperty(it)
+                            }
+                            break
+                        case FieldNode:
+                            expression[3].each{
+                                it.owner = result
+                                result.addField(it)
+                            }
+                            break
+                        case AnnotationNode:
+                            result.addAnnotations(new ArrayList(expression[3]))
+                            break
+                        default:
+                            throw new IllegalArgumentException("Unexpected item found in ClassNode spec. Expecting [Field|Method|Property|Constructor|Annotation|GenericsType] but found: $clazz.name")
+                    }
+                }
+                expression.remove(3)
             }
             result
         }
     }
 
-
     /**
      * Creates an AssertStatement.
      */
-
     void assertStatement(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         captureAndCreateNode("AssertStatement", argBlock) {
             if (expression.size() < 2) {
-                new AssertStatement(
-                        * enforceConstraints('assertStatement', [BooleanExpression])
-                )
+                new AssertStatement(*enforceConstraints('assertStatement', [BooleanExpression]))
             } else {
-                new AssertStatement(
-                        * enforceConstraints('assertStatement', [BooleanExpression, Expression])
-                )
+                new AssertStatement(*enforceConstraints('assertStatement', [BooleanExpression, Expression]))
             }
         }
     }
 
-
     /**
      * Creates a TryCatchStatement.
      */
-
     void tryCatch(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         captureAndCreateNode("TryCatchStatement", argBlock) {
             def result = new TryCatchStatement(expression[0], expression[1])
@@ -1024,39 +902,30 @@ class AstSpecificationCompiler implements GroovyInterceptable {
         }
     }
 
-
     /**
      * Creates a VariableExpression.
      */
-
     void variable(String variable) {
         expression << new VariableExpression(variable)
     }
 
-
     /**
      * Creates a MethodNode.
      */
-
     void method(String name, int modifiers, Class returnType, @DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         captureAndCreateNode("MethodNode", argBlock) {
             //todo: enforce contract
-            def result = new MethodNode(
-                    name, modifiers, ClassHelper.make(returnType), expression[0], expression[1], expression[2]
-            )
+            def result = new MethodNode(name, modifiers, ClassHelper.make(returnType), expression[0], expression[1], expression[2])
             if (expression[3]) {
-                def annotations = expression[3]
-                result.addAnnotations(new ArrayList(annotations))
+                result.addAnnotations(new ArrayList(expression[3]))
             }
             result
         }
     }
 
-
     /**
      * Creates a token.
      */
-
     void token(String value) {
         if (value == null) throw new IllegalArgumentException("Null: value")
 
@@ -1069,24 +938,17 @@ class AstSpecificationCompiler implements GroovyInterceptable {
         expression << new Token(tokenID, value, -1, -1)
     }
 
-
     /**
      * Creates a RangeExpression.
      */
-
     void range(Range range) {
         if (range == null) throw new IllegalArgumentException('Null: range')
-        expression << new RangeExpression(
-                new ConstantExpression(range.getFrom()),
-                new ConstantExpression(range.getTo()),
-                true)   //default is inclusive
+        expression << new RangeExpression(new ConstantExpression(range.getFrom()), new ConstantExpression(range.getTo()), true) //default is inclusive
     }
-
 
     /**
      * Creates a SwitchStatement.
      */
-
     void switchStatement(@DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         captureAndCreateNode("SwitchStatement", argBlock) {
             def switchExpression = expression.head()
@@ -1096,11 +958,9 @@ class AstSpecificationCompiler implements GroovyInterceptable {
         }
     }
 
-
     /**
      * Creates a mapEntry.
      */
-
     void mapEntry(Map map) {
         map.entrySet().each {
             expression << new MapEntryExpression(
@@ -1113,28 +973,31 @@ class AstSpecificationCompiler implements GroovyInterceptable {
     // todo: these methods can still be reduced smaller
     //
 
-
     /**
      * Creates a FieldNode.
      */
-
     void fieldNode(String name, int modifiers, Class type, Class owner, @DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         captureAndCreateNode("FieldNode", argBlock) {
+            def annotations = null
+            if (expression.size() > 1) {
+                annotations = expression[1]
+                expression.remove(1)
+            }
             expression.add(0, ClassHelper.make(owner))
             expression.add(0, ClassHelper.make(type))
             expression.add(0, modifiers)
             expression.add(0, name)
-            new FieldNode(
-                    * enforceConstraints('fieldNode', [String, Integer, ClassNode, ClassNode, Expression]))
+            def result = new FieldNode(*enforceConstraints('fieldNode', [String, Integer, ClassNode, ClassNode, Expression]))
+            if (annotations) {
+                result.addAnnotations(new ArrayList(annotations))
+            }
+            result
         }
     }
 
-
-
     /**
-     * Creates a property.
+     * Creates an inner class.
      */
-
     void innerClass(String name, int modifiers, @DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         captureAndCreateNode("InnerClassNode", argBlock) {
             //todo: enforce contract
@@ -1148,63 +1011,67 @@ class AstSpecificationCompiler implements GroovyInterceptable {
         }
     }
 
-
     /**
      * Creates a PropertyNode.
      */
-
     void propertyNode(String name, int modifiers, Class type, Class owner, @DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         //todo: improve error handling?
         captureAndCreateNode("PropertyNode", argBlock) {
-            new PropertyNode(name, modifiers, ClassHelper.make(type), ClassHelper.make(owner),
-                    expression[0],  // initial value
-                    expression[1],  // getter block
-                    expression[2])  // setter block
+            def annotations = null
+            // check if the last expression looks like annotations
+            if (List.isAssignableFrom(expression[-1].getClass())) {
+                annotations = expression[-1]
+                expression.remove(expression.size() - 1)
+            }
+            def result = new PropertyNode(name, modifiers, ClassHelper.make(type), ClassHelper.make(owner),
+                    expression[0],  // initial value (possibly null)
+                    expression[1],  // getter block (possibly null)
+                    expression[2])  // setter block (possibly null)
+            if (annotations) {
+                result.addAnnotations(new ArrayList(annotations))
+            }
+            result
         }
     }
-
-
 
     /**
      * Creates a StaticMethodCallExpression.
      */
-
     void staticMethodCall(Class target, String name, @DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         captureAndCreateNode("StaticMethodCallExpression", argBlock) {
             expression.add(0, name)
             expression.add(0, ClassHelper.make(target))
-            new StaticMethodCallExpression(
-                    * enforceConstraints('staticMethodCall', [ClassNode, String, Expression])
-            )
+            new StaticMethodCallExpression(*enforceConstraints('staticMethodCall', [ClassNode, String, Expression]))
         }
     }
-
 
     /**
      * Creates a StaticMethodCallExpression.
      */
-
     void staticMethodCall(MethodClosure target, @DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         captureAndCreateNode("StaticMethodCallExpression", argBlock) {
             expression.add(0, target.method)
             expression.add(0, ClassHelper.makeWithoutCaching(target.owner.class, false))
-            new StaticMethodCallExpression(
-                    * enforceConstraints('staticMethodCall', [ClassNode, String, Expression])
-            )
+            new StaticMethodCallExpression(*enforceConstraints('staticMethodCall', [ClassNode, String, Expression]))
         }
     }
-
 
     /**
      * Creates a ConstructorNode.
      */
-
     void constructor(int modifiers, @DelegatesTo(AstSpecificationCompiler) Closure argBlock) {
         captureAndCreateNode("ConstructorNode", argBlock) {
+            def annotations = null
+            if (expression.size() > 3) {
+                annotations = expression[3]
+                expression.remove(3)
+            }
             expression.add(0, modifiers)
-            new ConstructorNode(
-                    * enforceConstraints('constructor', [Integer, Parameter[], ClassNode[], Statement])
-            )
+            def result = new ConstructorNode(*enforceConstraints('constructor', [Integer, Parameter[], ClassNode[], Statement]))
+            if (annotations) {
+                result.addAnnotations(new ArrayList(annotations))
+            }
+            result
         }
     }
 }

--- a/src/test/org/codehaus/groovy/ast/builder/AstBuilderFromSpecificationTest.groovy
+++ b/src/test/org/codehaus/groovy/ast/builder/AstBuilderFromSpecificationTest.groovy
@@ -1,5 +1,5 @@
 /*
- * Copyright 2003-2012 the original author or authors.
+ * Copyright 2003-2014 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -102,7 +102,6 @@ public class AstBuilderFromSpecificationTest extends GroovyTestCase {
         AstAssert.assertSyntaxTree([expected], result)
     }
 
-
     public void testArgumentListExpression_NoArgs() {
 
         def result = new AstBuilder().buildFromSpec {
@@ -112,7 +111,6 @@ public class AstBuilderFromSpecificationTest extends GroovyTestCase {
         def expected = new ArgumentListExpression()
         AstAssert.assertSyntaxTree([expected], result)
     }
-
 
     public void testArgumentListExpression_OneListArg() {
 
@@ -135,7 +133,6 @@ public class AstBuilderFromSpecificationTest extends GroovyTestCase {
         AstAssert.assertSyntaxTree([expected], result)
     }
 
-
     public void testAttributeExpression() {
 
         // represents foo.bar attribute invocation
@@ -152,7 +149,6 @@ public class AstBuilderFromSpecificationTest extends GroovyTestCase {
         )
         AstAssert.assertSyntaxTree([expected], result)
     }
-
 
     /**
      * Test for code:
@@ -222,7 +218,6 @@ public class AstBuilderFromSpecificationTest extends GroovyTestCase {
         AstAssert.assertSyntaxTree([expected], result)
     }
 
-
     public void testDeclarationAndListExpression() {
 
         // represents def foo = [1, 2, 3]
@@ -250,7 +245,6 @@ public class AstBuilderFromSpecificationTest extends GroovyTestCase {
         AstAssert.assertSyntaxTree([expected], result)
     }
 
-
     public void testArrayExpression() {
 
         // new Integer[]{1, 2, 3}
@@ -271,7 +265,6 @@ public class AstBuilderFromSpecificationTest extends GroovyTestCase {
         )
         AstAssert.assertSyntaxTree([expected], result)
     }
-
 
     public void testBitwiseNegationExpression() {
         def result = new AstBuilder().buildFromSpec {
@@ -344,7 +337,6 @@ public class AstBuilderFromSpecificationTest extends GroovyTestCase {
         AstAssert.assertSyntaxTree([expected], result)
     }
 
-
     public void testClosureExpression_MultipleParameters() {
 
         // { x,y,z -> println z }
@@ -412,7 +404,6 @@ public class AstBuilderFromSpecificationTest extends GroovyTestCase {
         AstAssert.assertSyntaxTree([expected], result)
     }
 
-
     public void testNotExpression() {
         // !true
         def result = new AstBuilder().buildFromSpec {
@@ -427,7 +418,6 @@ public class AstBuilderFromSpecificationTest extends GroovyTestCase {
 
         AstAssert.assertSyntaxTree([expected], result)
     }
-
 
     public void testPostfixExpression() {
         // 1++
@@ -445,7 +435,6 @@ public class AstBuilderFromSpecificationTest extends GroovyTestCase {
 
         AstAssert.assertSyntaxTree([expected], result)
     }
-
 
     public void testPrefixExpression() {
         // ++1
@@ -478,7 +467,6 @@ public class AstBuilderFromSpecificationTest extends GroovyTestCase {
 
         AstAssert.assertSyntaxTree([expected], result)
     }
-
 
     public void testUnaryPlusExpression() {
         // (+foo)
@@ -515,30 +503,31 @@ public class AstBuilderFromSpecificationTest extends GroovyTestCase {
         AstAssert.assertSyntaxTree([expected], result)
     }
 
-
     public void testFieldExpression() {
         // public static String foo = "a value"
         def result = new AstBuilder().buildFromSpec {
             field {
                 fieldNode "foo", ACC_PUBLIC | ACC_STATIC, String, this.class, {
                     constant "a value"
+                    annotations {
+                        annotation Deprecated
+                    }
                 }
             }
         }
 
-        def expected = new FieldExpression(
-                new FieldNode(
-                        "foo",
-                        ACC_PUBLIC | ACC_STATIC,
-                        ClassHelper.make(String, false),
-                        ClassHelper.make(this.class, false),
-                        new ConstantExpression("a value")
-                )
+        def fieldNode = new FieldNode(
+                "foo",
+                ACC_PUBLIC | ACC_STATIC,
+                ClassHelper.make(String, false),
+                ClassHelper.make(this.class, false),
+                new ConstantExpression("a value")
         )
+        fieldNode.addAnnotation(new AnnotationNode(ClassHelper.make(Deprecated, false)))
+        def expected = new FieldExpression(fieldNode)
 
         AstAssert.assertSyntaxTree([expected], result)
     }
-
 
     public void testMapAndMapEntryExpression() {
 
@@ -556,18 +545,10 @@ public class AstBuilderFromSpecificationTest extends GroovyTestCase {
             }
         }
 
-        def expected = new MapExpression(
-                [
-                        new MapEntryExpression(
-                                new ConstantExpression('foo'),
-                                new ConstantExpression('bar')
-                        ),
-                        new MapEntryExpression(
-                                new ConstantExpression('baz'),
-                                new ConstantExpression('buz')
-                        ),
-                ]
-        )
+        def expected = new MapExpression([
+                new MapEntryExpression(new ConstantExpression('foo'), new ConstantExpression('bar')),
+                new MapEntryExpression(new ConstantExpression('baz'), new ConstantExpression('buz')),
+        ])
 
         AstAssert.assertSyntaxTree([expected], result)
     }
@@ -583,30 +564,15 @@ public class AstBuilderFromSpecificationTest extends GroovyTestCase {
             }
         }
 
-        def expected = new MapExpression(
-                [
-                        new MapEntryExpression(
-                                new ConstantExpression('foo'),
-                                new ConstantExpression('bar')
-                        ),
-                        new MapEntryExpression(
-                                new ConstantExpression('baz'),
-                                new ConstantExpression('buz')
-                        ),
-                        new MapEntryExpression(
-                                new ConstantExpression('qux'),
-                                new ConstantExpression('quux')
-                        ),
-                        new MapEntryExpression(
-                                new ConstantExpression('corge'),
-                                new ConstantExpression('grault')
-                        ),
-                ]
-        )
+        def expected = new MapExpression([
+                new MapEntryExpression(new ConstantExpression('foo'), new ConstantExpression('bar')),
+                new MapEntryExpression(new ConstantExpression('baz'), new ConstantExpression('buz')),
+                new MapEntryExpression(new ConstantExpression('qux'), new ConstantExpression('quux')),
+                new MapEntryExpression(new ConstantExpression('corge'), new ConstantExpression('grault')),
+        ])
 
         AstAssert.assertSyntaxTree([expected], result)
     }
-
 
     public void testGStringExpression() {
         // "$foo"
@@ -632,7 +598,6 @@ public class AstBuilderFromSpecificationTest extends GroovyTestCase {
         AstAssert.assertSyntaxTree([expected], result)
     }
 
-
     public void testMethodPointerExpression() {
         // Integer.&toString
         def result = new AstBuilder().buildFromSpec {
@@ -649,7 +614,6 @@ public class AstBuilderFromSpecificationTest extends GroovyTestCase {
 
         AstAssert.assertSyntaxTree([expected], result)
     }
-
 
     public void testRangeExpression() {
         // (0..10)
@@ -720,7 +684,6 @@ public class AstBuilderFromSpecificationTest extends GroovyTestCase {
 
         AstAssert.assertSyntaxTree([expected], result)
     }
-
 
     public void testSwitchAndCaseAndBreakStatements() {
         /*
@@ -820,7 +783,6 @@ public class AstBuilderFromSpecificationTest extends GroovyTestCase {
         AstAssert.assertSyntaxTree([expected], result)
     }
 
-
     public void testAssertStatement() {
         /*
                   assert true : "should always be true"
@@ -901,7 +863,6 @@ public class AstBuilderFromSpecificationTest extends GroovyTestCase {
         AstAssert.assertSyntaxTree([expected], result)
     }
 
-
     public void testTryCatchAndCatchAndThrowStatements() {
         /*
                   try {
@@ -953,7 +914,6 @@ public class AstBuilderFromSpecificationTest extends GroovyTestCase {
         )
         AstAssert.assertSyntaxTree([expected], result)
     }
-
 
     public void testFinallyStatement() {
         /*
@@ -1010,7 +970,6 @@ public class AstBuilderFromSpecificationTest extends GroovyTestCase {
         )
         AstAssert.assertSyntaxTree([expected], result)
     }
-
 
     public void testForStatementAndClosureListExpression() {
         /*
@@ -1091,7 +1050,6 @@ public class AstBuilderFromSpecificationTest extends GroovyTestCase {
         AstAssert.assertSyntaxTree([expected], result)
     }
 
-
     public void testStaticMethodCallExpression_MethodAsString() {
         // Math.min(1,2)
         def result = new AstBuilder().buildFromSpec {
@@ -1138,7 +1096,6 @@ public class AstBuilderFromSpecificationTest extends GroovyTestCase {
         AstAssert.assertSyntaxTree([expected], result)
     }
 
-
     public void testSpreadExpression() {
         // ['foo', *['bar','baz']]
         def result = new AstBuilder().buildFromSpec {
@@ -1166,7 +1123,6 @@ public class AstBuilderFromSpecificationTest extends GroovyTestCase {
         AstAssert.assertSyntaxTree([expected], result)
     }
 
-
     public void testSpreadMapExpression() {
         // func (*:m)
         def result = new AstBuilder().buildFromSpec {
@@ -1186,9 +1142,7 @@ public class AstBuilderFromSpecificationTest extends GroovyTestCase {
                 new VariableExpression('this', ClassHelper.make(Object, false)),
                 'func',
                 new MapEntryExpression(
-                        new SpreadMapExpression(
-                                new VariableExpression('m', ClassHelper.make(Object, false))
-                        ),
+                        new SpreadMapExpression(new VariableExpression('m', ClassHelper.make(Object, false))),
                         new VariableExpression('m', ClassHelper.make(Object, false))
                 )
 
@@ -1196,7 +1150,6 @@ public class AstBuilderFromSpecificationTest extends GroovyTestCase {
 
         AstAssert.assertSyntaxTree([expected], result)
     }
-
 
     public void testTernaryExpression() {
         // true ? "male" : "female"
@@ -1211,16 +1164,13 @@ public class AstBuilderFromSpecificationTest extends GroovyTestCase {
         }
 
         def expected = new TernaryExpression(
-                new BooleanExpression(
-                        new ConstantExpression(true)
-                ),
+                new BooleanExpression(new ConstantExpression(true)),
                 new ConstantExpression('male'),
                 new ConstantExpression('female')
         )
 
         AstAssert.assertSyntaxTree([expected], result)
     }
-
 
     public void testDoWhileStatement() {
         // DoWhileStatement doesn't seemed to be used, and the do/while source doesn't compile either
@@ -1322,7 +1272,6 @@ public class AstBuilderFromSpecificationTest extends GroovyTestCase {
         AstAssert.assertSyntaxTree([expected], result)
     }
 
-
     public void testElvisOperatorExpression() {
         // name ?: 'Anonymous'
         def result = new AstBuilder().buildFromSpec {
@@ -1339,7 +1288,6 @@ public class AstBuilderFromSpecificationTest extends GroovyTestCase {
 
         AstAssert.assertSyntaxTree([expected], result)
     }
-
 
     public void testNamedArgumentListExpression() {
         // new String(foo: 'bar')
@@ -1578,37 +1526,50 @@ public class AstBuilderFromSpecificationTest extends GroovyTestCase {
                     classNode GroovyObject
                 }
                 mixins {}
-                method('myMethod', ACC_PUBLIC, String) {
-                    parameters {
-                        parameter 'parameter': String
+                methods {
+                    method('myMethod', ACC_PUBLIC, String) {
+                        parameters {
+                            parameter 'parameter': String
+                        }
+                        exceptions {
+                            classNode IOException
+                        }
+                        block {
+                            returnStatement {
+                                constant 'some result'
+                            }
+                        }
                     }
-                    exceptions {
-                        classNode IOException
-                    }
-                    block {
-                        returnStatement {
-                            constant 'some result'
+                    method('myOtherMethod', ACC_PUBLIC, String) {
+                        parameters {}
+                        exceptions {}
+                        block {
+                            returnStatement {
+                                constant 'some other result'
+                            }
                         }
                     }
                 }
-                method('myOtherMethod', ACC_PUBLIC, String) {
-                    parameters {}
-                    exceptions {}
-                    block {
-                        returnStatement {
-                            constant 'some other result'
+                properties {
+                    propertyNode "myProp", ACC_PUBLIC, String, this.class, {
+                        constant "foo"
+                        annotations {
+                            annotation Deprecated
                         }
                     }
                 }
-                propertyNode "myProp", ACC_PUBLIC, String, this.class, {
-                    constant "foo"
+                annotations {
+                    annotation Deprecated
                 }
             }
         }
 
         def expected = new ClassNode("MyClass", ACC_PUBLIC, ClassHelper.make(Object, false))
-        expected.addProperty(new PropertyNode("myProp", ACC_PUBLIC, ClassHelper.make(String, false),
-                ClassHelper.make(this.class, false), new ConstantExpression("foo"), null, null))
+        expected.addAnnotation(new AnnotationNode(ClassHelper.make(Deprecated, false)))
+        def pNode = new PropertyNode("myProp", ACC_PUBLIC, ClassHelper.make(String, false),
+                ClassHelper.make(this.class, false), new ConstantExpression("foo"), null, null)
+        pNode.addAnnotation(new AnnotationNode(ClassHelper.make(Deprecated, false)))
+        expected.addProperty(pNode)
         expected.addMethod(new MethodNode(
                 "myMethod",
                 ACC_PUBLIC,
@@ -1727,7 +1688,6 @@ public class AstBuilderFromSpecificationTest extends GroovyTestCase {
         expected.addAnnotation(new AnnotationNode(ClassHelper.make(Override, false)))
         AstAssert.assertSyntaxTree([expected], result)
     }
-
 
     public void testAnnotation_WithParameter() {
         // @org.junit.Test(timeout=50L) def myMethod() {}


### PR DESCRIPTION
DSL now supports:
- methods, annotations, fields, constructors, properties within class nodes
- annotations within field, constructor, property and class nodes
