### PR TITLE
GROOVY-6857: fix parse on byte array to not throw stack over flow exceptions

### DIFF
--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/BaseJsonParser.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/BaseJsonParser.java
@@ -108,7 +108,11 @@ public abstract class BaseJsonParser implements JsonParser {
     }
 
     public Object parse(byte[] bytes, String charset) {
-        return parse(bytes, charset);
+        try {
+            return parse(new String(bytes, charset));
+        } catch (UnsupportedEncodingException e) {
+            return Exceptions.handle(Object.class, e);
+        }
     }
 
     public Object parse(CharSequence charSequence) {

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperTest.groovy
@@ -299,4 +299,11 @@ class JsonSlurperTest extends GroovyTestCase {
             parser.parseText('{"a":"c:\\\"}')
         }
     }
+  
+    void testParseWithByteArray() {
+        def slurper = new JsonSlurper()
+        
+        assert slurper.parse('{"a":true}'.bytes) == [a: true]
+        
+    }
 }


### PR DESCRIPTION
Fix parse(byte[], string) method to not be endlessly recursive and add test case
