### PR TITLE
GROOVY-6863: Move many methods from Collection to Iterable

### DIFF
--- a/src/main/groovy/util/PermutationGenerator.java
+++ b/src/main/groovy/util/PermutationGenerator.java
@@ -15,6 +15,8 @@
  */
 package groovy.util;
 
+import org.codehaus.groovy.runtime.DefaultGroovyMethods;
+
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -52,6 +54,10 @@ public class PermutationGenerator<E> implements Iterator<List<E>> {
         a = new int[n];
         total = getFactorial(n);
         reset();
+    }
+
+    public PermutationGenerator(Iterable<E> items) {
+        this(DefaultGroovyMethods.asCollection(items));
     }
 
     public void reset() {

--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethodsSupport.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethodsSupport.java
@@ -134,6 +134,14 @@ public class DefaultGroovyMethodsSupport {
         return new ArrayList();
     }
 
+    protected static <T> Collection<T> createSimilarCollection(Iterable<T> iterable) {
+        if (iterable instanceof Collection) {
+            return createSimilarCollection((Collection<T>) iterable);
+        } else {
+            return new ArrayList<T>();
+        }
+    }
+
     protected static <T> Collection<T> createSimilarCollection(Collection<T> collection) {
         return createSimilarCollection(collection, collection.size());
     }


### PR DESCRIPTION
GROOVY-6863: Move many methods from Collection to Iterable.

Added these methods to Iterable.

contains(Object)
containsAll(Object[])
eachPermutation(Closure)
inject(Closure)
head()
tail()
asCollection()
plus(Iterable)
plus(Object)
multiply(Number)
intersect(Iterable)
toSet()

Deprecated this method from Collection.

eachPermutation(Closure)

Did not add these methods to Iterable because GPathResult conflicts.
Read https://github.com/groovy/groovy-core/pull/444 for the detail.

toListString()
toListString(int)

I also added this method.

DefaultGroovyMethodsSupport.createSimilarCollection(Iterable)

I cannot move these methods because they exists in Object
and Groovy cannot handle properly if I move them from Collection to Iterable.

grep(Object)
grep()
collect(Closure)
collect()
collect(Collection, Closure)
find(Closure)
find()
findResult(Object, Closure)
findResult(Closure)
findAll(Closure)
findAll()
split(Closure)
inject(Closure)
inject(Object, Closure)
