### PR TITLE
GROOVY-6867: Added init(), dropRight() and takeRight() to Iterable, List and Object[]

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -7056,6 +7056,70 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
     }
 
     /**
+     * Returns the items from the Iterable excluding the last item.
+     * <pre class="groovyTestCase">def list = [3, 4, 2]
+     * assert list.init() == [3, 4]
+     * assert list == [3, 4, 2]</pre>
+     *
+     * @param self an Iterable
+     * @return a list without its last element
+     * @throws NoSuchElementException if the iterable is empty and you try to access the init() item.
+     * @since 2.4.0
+     */
+    public static <T> List<T> init(Iterable<T> self) {
+        List<T> result = toList(self);
+        if (result.isEmpty()) {
+            throw new NoSuchElementException("Cannot access init() for an empty Iterable");
+        }
+        result.remove(result.size() - 1);
+        return result;
+    }
+
+    /**
+     * Returns the items from the List excluding the last item.
+     * <pre class="groovyTestCase">def list = [3, 4, 2]
+     * assert list.init() == [3, 4]
+     * assert list == [3, 4, 2]</pre>
+     *
+     * @param self a List
+     * @return a list without its last element
+     * @throws NoSuchElementException if the list is empty and you try to access the init() item.
+     * @since 2.4.0
+     */
+    public static <T> List<T> init(List<T> self) {
+        if (self.isEmpty()) {
+            throw new NoSuchElementException("Cannot access init() for an empty List");
+        }
+        List<T> result = new ArrayList<T>(self);
+        result.remove(result.size() - 1);
+        return result;
+    }
+
+    /**
+     * Returns the items from the Object array excluding the last item.
+     * <pre class="groovyTestCase">
+     *     String[] strings = ["a", "b", "c"]
+     *     def result = strings.init()
+     *     assert result.length == 2
+     *     assert strings.class.componentType == String
+     * </pre>
+     *
+     * @param self an Object array
+     * @return an Object array without its last element
+     * @throws NoSuchElementException if the array is empty and you try to access the init() item.
+     * @since 2.4.0
+     */
+    public static <T> T[] init(T[] self) {
+        if (self.length == 0) {
+            throw new NoSuchElementException("Cannot access init() for an empty Object array");
+        }
+        Class<T> componentType = (Class<T>) self.getClass().getComponentType();
+        T[] result = (T[]) Array.newInstance(componentType, self.length - 1);
+        System.arraycopy(self, 0, result, 0, self.length - 1);
+        return result;
+    }
+
+    /**
      * Returns the first <code>num</code> elements from the head of this list.
      * <pre class="groovyTestCase">
      * def strings = [ 'a', 'b', 'c' ]
@@ -7225,6 +7289,91 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
     }
 
     /**
+     * Returns the last <code>num</code> elements from the tail of this list.
+     * <pre class="groovyTestCase">
+     * def strings = [ 'a', 'b', 'c' ]
+     * assert strings.takeRight( 0 ) == []
+     * assert strings.takeRight( 2 ) == [ 'b', 'c' ]
+     * assert strings.takeRight( 5 ) == [ 'a', 'b', 'c' ]
+     * </pre>
+     * Similar to {@link #takeRight(Iterable, int)}
+     * except that it attempts to preserve the type of the original list.
+     *
+     * @param self the original list
+     * @param num  the number of elements to take from this list
+     * @return a list consisting of the last <code>num</code> elements of this list,
+     *         or else the whole list if it has less then <code>num</code> elements.
+     * @since 2.4.0
+     */
+    public static <T> List<T> takeRight(List<T> self, int num) {
+        if (self.isEmpty() || num <= 0) {
+            return createSimilarList(self, 0);
+        }
+        if (self.size() <= num) {
+            List<T> ret = createSimilarList(self, self.size());
+            ret.addAll(self);
+            return ret;
+        }
+        List<T> ret = createSimilarList(self, num);
+        ret.addAll(self.subList(self.size() - num, self.size()));
+        return ret;
+    }
+
+    /**
+     * Returns the last <code>num</code> elements from the tail of this array.
+     * <pre class="groovyTestCase">
+     * String[] strings = [ 'a', 'b', 'c' ]
+     * assert strings.takeRight( 0 ) == [] as String[]
+     * assert strings.takeRight( 2 ) == [ 'b', 'c' ] as String[]
+     * assert strings.takeRight( 5 ) == [ 'a', 'b', 'c' ] as String[]
+     * </pre>
+     *
+     * @param self the original array
+     * @param num  the number of elements to take from this array
+     * @return an array consisting of the last <code>num</code> elements of this array,
+     *         or else the whole array if it has less then <code>num</code> elements.
+     * @since 2.4.0
+     */
+    public static <T> T[] takeRight(T[] self, int num) {
+        if (self.length == 0 || num <= 0) {
+            return createSimilarArray(self, 0);
+        }
+
+        if (self.length <= num) {
+            T[] ret = createSimilarArray(self, self.length);
+            System.arraycopy(self, 0, ret, 0, self.length);
+            return ret;
+        }
+
+        T[] ret = createSimilarArray(self, num);
+        System.arraycopy(self, self.length - num, ret, 0, num);
+        return ret;
+    }
+
+    /**
+     * Returns the last <code>num</code> elements from the tail of this Iterable.
+     * <pre class="groovyTestCase">
+     * class AbcIterable implements Iterable<String> {
+     *     Iterator<String> iterator() { "abc".iterator() }
+     * }
+     * def abc = new AbcIterable()
+     * assert abc.takeRight(0) == []
+     * assert abc.takeRight(1) == ['c']
+     * assert abc.takeRight(3) == ['a', 'b', 'c']
+     * assert abc.takeRight(5) == ['a', 'b', 'c']
+     * </pre>
+     *
+     * @param self the original Iterable
+     * @param num  the number of elements to take from this Iterable
+     * @return a List consisting of the last <code>num</code> elements from this Iterable,
+     *         or else all the elements from the Iterable if it has less then <code>num</code> elements.
+     * @since 2.4.0
+     */
+    public static <T> List<T> takeRight(Iterable<T> self, int num) {
+        return takeRight(asList(self), num);
+    }
+
+    /**
      * Drops the given number of elements from the head of this list
      * if they are available.
      * <pre class="groovyTestCase">
@@ -7371,6 +7520,94 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
             self.next();
         }
         return self;
+    }
+
+    /**
+     * Drops the given number of elements from the tail of this list
+     * if they are available.
+     * <pre class="groovyTestCase">
+     * def strings = [ 'a', 'b', 'c' ]
+     * assert strings.dropRight( 0 ) == [ 'a', 'b', 'c' ]
+     * assert strings.dropRight( 2 ) == [ 'a' ]
+     * assert strings.dropRight( 5 ) == []
+     * </pre>
+     * Similar to {@link #dropRight(Iterable, int)}
+     * except that it attempts to preserve the type of the original list.
+     *
+     * @param self the original list
+     * @param num  the number of elements to drop from this list
+     * @return a list consisting of all elements of this list except the last
+     *         <code>num</code> ones, or else the empty list, if this list has
+     *         less than <code>num</code> elements.
+     * @since 2.4.0
+     */
+    public static <T> List<T> dropRight(List<T> self, int num) {
+        if (self.size() <= num) {
+            return createSimilarList(self, 0);
+        }
+        if (num <= 0) {
+            List<T> ret = createSimilarList(self, self.size());
+            ret.addAll(self);
+            return ret;
+        }
+        List<T> ret = createSimilarList(self, self.size() - num);
+        ret.addAll(self.subList(0, self.size() - num));
+        return ret;
+    }
+
+    /**
+     * Drops the given number of elements from the tail of this Iterable.
+     * <pre class="groovyTestCase">
+     * class AbcIterable implements Iterable<String> {
+     *     Iterator<String> iterator() { "abc".iterator() }
+     * }
+     * def abc = new AbcIterable()
+     * assert abc.dropRight(0) == ['a', 'b', 'c']
+     * assert abc.dropRight(1) == ['a', 'b']
+     * assert abc.dropRight(3) == []
+     * assert abc.dropRight(5) == []
+     * </pre>
+     *
+     * @param self the original Iterable
+     * @param num  the number of elements to drop from this Iterable
+     * @return a List consisting of all the elements of this Iterable minus the last <code>num</code> elements,
+     *         or an empty list if it has less then <code>num</code> elements.
+     * @since 2.4.0
+     */
+    public static <T> List<T> dropRight(Iterable<T> self, int num) {
+        return dropRight(asList(self), num);
+    }
+
+    /**
+     * Drops the given number of elements from the tail of this array
+     * if they are available.
+     * <pre class="groovyTestCase">
+     * String[] strings = [ 'a', 'b', 'c' ]
+     * assert strings.dropRight( 0 ) == [ 'a', 'b', 'c' ] as String[]
+     * assert strings.dropRight( 2 ) == [ 'a' ] as String[]
+     * assert strings.dropRight( 5 ) == [] as String[]
+     * </pre>
+     *
+     * @param self the original array
+     * @param num  the number of elements to drop from this array
+     * @return an array consisting of all elements of this array except the
+     *         last <code>num</code> ones, or else the empty array, if this
+     *         array has less than <code>num</code> elements.
+     * @since 2.4.0
+     */
+    public static <T> T[] dropRight(T[] self, int num) {
+        if (self.length <= num) {
+            return createSimilarArray(self, 0);
+        }
+        if (num <= 0) {
+            T[] ret = createSimilarArray(self, self.length);
+            System.arraycopy(self, 0, ret, 0, self.length);
+            return ret;
+        }
+
+        T[] ret = createSimilarArray(self, self.length - num);
+        System.arraycopy(self, 0, ret, 0, self.length - num);
+        return ret;
     }
 
     /**

--- a/src/test/groovy/GroovyMethodsTest.groovy
+++ b/src/test/groovy/GroovyMethodsTest.groovy
@@ -432,13 +432,83 @@ class GroovyMethodsTest extends GroovyTestCase {
         assert !('d' in list)
     }
 
-    void testFirstLastHeadTailForLists() {
+    void testFirstLastHeadTailInitForLists() {
         def list = ['a', 'b', 'c']
         assert 'a' == list.first()
-        assert 'c' == list.last()
         assert 'a' == list.head()
+        assert 'c' == list.last()
         assert ['b', 'c'] == list.tail()
+        assert ['a', 'b'] == list.init()
         assert list.size() == 3
+
+        list = []
+        shouldFail(NoSuchElementException) {
+            list.first()
+        }
+        shouldFail(NoSuchElementException) {
+            list.head()
+        }
+        shouldFail(NoSuchElementException) {
+            list.last()
+        }
+        shouldFail(NoSuchElementException) {
+            list.tail()
+        }
+        shouldFail(NoSuchElementException) {
+            list.init()
+        }
+        assert list.size() == 0
+    }
+
+    void testFirstLastHeadTailInitForIterables() {
+        int a
+        Iterable iterable = { [ hasNext:{ a < 6 }, next:{ a++ } ] as Iterator } as Iterable
+
+        a = 1
+        assert 1 == iterable.first()
+        a = 1
+        assert 5 == iterable.last()
+        a = 1
+        assert [1, 2, 3, 4] == iterable.init()
+
+        iterable = { [ hasNext:{ false }, next:{ 1 } ] as Iterator } as Iterable
+        shouldFail(NoSuchElementException) {
+            iterable.first()
+        }
+        shouldFail(NoSuchElementException) {
+            iterable.last()
+        }
+        shouldFail(NoSuchElementException) {
+            iterable.init()
+        }
+    }
+
+    void testFirstLastHeadTailInitForArrays() {
+        String[] ary = ['a', 'b', 'c'] as String[]
+        assert 'a' == ary.first()
+        assert 'a' == ary.head()
+        assert 'c' == ary.last()
+        assert ['b', 'c'] == ary.tail()
+        assert ['a', 'b'] == ary.init()
+        assert ary.length == 3
+
+        ary = [] as String[]
+        shouldFail(NoSuchElementException) {
+            ary.first()
+        }
+        shouldFail(NoSuchElementException) {
+            ary.head()
+        }
+        shouldFail(NoSuchElementException) {
+            ary.last()
+        }
+        shouldFail(NoSuchElementException) {
+            ary.tail()
+        }
+        shouldFail(NoSuchElementException) {
+            ary.init()
+        }
+        assert ary.length == 0
     }
 
     void testPushPopForLists() {
@@ -985,6 +1055,11 @@ class GroovyMethodsTest extends GroovyTestCase {
             assert it.take(  0 ) == []
             assert it.take(  2 ) == [ 1, 2 ]
             assert it.take(  4 ) == [ 1, 2, 3 ]
+
+            assert it.takeRight( -1 ) == []
+            assert it.takeRight(  0 ) == []
+            assert it.takeRight(  2 ) == [ 2, 3 ]
+            assert it.takeRight(  4 ) == [ 1, 2, 3 ]
         }
     }
 
@@ -995,6 +1070,11 @@ class GroovyMethodsTest extends GroovyTestCase {
         assert items.take(  0 ) == [] as String[]
         assert items.take(  2 ) == [ 'ant', 'bee' ] as String[]
         assert items.take(  4 ) == [ 'ant', 'bee', 'cat' ] as String[]
+
+        assert items.takeRight( -1 ) == [] as String[]
+        assert items.takeRight(  0 ) == [] as String[]
+        assert items.takeRight(  2 ) == [ 'bee', 'cat' ] as String[]
+        assert items.takeRight(  4 ) == [ 'ant', 'bee', 'cat' ] as String[]
     }
 
     void testMapTake() {
@@ -1019,6 +1099,26 @@ class GroovyMethodsTest extends GroovyTestCase {
         assert items.take(  0 ).collect { it } == []
         assert items.take(  2 ).collect { it } == [ 1, 2 ]
         assert items.take(  4 ).collect { it } == [ 3, 4, 5, 6 ]
+    }
+
+    void testIterableTake() {
+        int a = 1
+        Iterable items = { [ hasNext:{ true }, next:{ a++ } ] as Iterator } as Iterable
+
+        assert items.take( -1 ).collect { it } == []
+        assert items.take(  0 ).collect { it } == []
+        assert items.take(  2 ).collect { it } == [ 1, 2 ]
+        assert items.take(  4 ).collect { it } == [ 3, 4, 5, 6 ]
+
+        items = { [ hasNext:{ a < 6 }, next:{ a++ } ] as Iterator } as Iterable
+
+        assert items.takeRight( -1 ).collect { it } == []
+        a = 1
+        assert items.takeRight(  0 ).collect { it } == []
+        a = 1
+        assert items.takeRight(  2 ).collect { it } == [ 4, 5 ]
+        a = 1
+        assert items.takeRight(  4 ).collect { it } == [ 2, 3, 4, 5 ]
     }
 
     void testCharSequenceTake() {
@@ -1049,6 +1149,11 @@ class GroovyMethodsTest extends GroovyTestCase {
             assert it.drop(  0 ) == [ 1, 2, 3 ]
             assert it.drop(  2 ) == [ 3 ]
             assert it.drop(  4 ) == []
+
+            assert it.dropRight( -1 ) == [ 1, 2, 3 ]
+            assert it.dropRight(  0 ) == [ 1, 2, 3 ]
+            assert it.dropRight(  2 ) == [ 1 ]
+            assert it.dropRight(  4 ) == []
         }
     }
 
@@ -1059,6 +1164,11 @@ class GroovyMethodsTest extends GroovyTestCase {
         assert items.drop(  4 ) == [] as String[]
         assert items.drop(  0 ) == [ 'ant', 'bee', 'cat' ] as String[]
         assert items.drop( -1 ) == [ 'ant', 'bee', 'cat' ] as String[]
+
+        assert items.dropRight(  2 ) == [ 'ant' ] as String[]
+        assert items.dropRight(  4 ) == [] as String[]
+        assert items.dropRight(  0 ) == [ 'ant', 'bee', 'cat' ] as String[]
+        assert items.dropRight( -1 ) == [ 'ant', 'bee', 'cat' ] as String[]
     }
 
     void testMapDrop() {
@@ -1088,6 +1198,28 @@ class GroovyMethodsTest extends GroovyTestCase {
         assert items.drop( 5 ).collect { it } == []
     }
 
+    void testIterableDrop() {
+        int a = 1
+        Iterable items = { [ hasNext:{ a < 6 }, next:{ a++ } ] as Iterator } as Iterable
+
+        assert items.drop( 0 ).collect { it } == [ 1, 2, 3, 4, 5 ]
+        a = 1
+        assert items.drop( 2 ).collect { it } == [ 3, 4, 5 ]
+        a = 1
+        assert items.drop( 4 ).collect { it } == [ 5 ]
+        a = 1
+        assert items.drop( 5 ).collect { it } == []
+
+        a = 1
+        assert items.dropRight( 0 ).collect { it } == [ 1, 2, 3, 4, 5 ]
+        a = 1
+        assert items.dropRight( 2 ).collect { it } == [ 1, 2, 3 ]
+        a = 1
+        assert items.dropRight( 4 ).collect { it } == [ 1 ]
+        a = 1
+        assert items.dropRight( 5 ).collect { it } == []
+    }
+
     void testCharSequenceDrop() {
         def data = [ 'groovy',      // String
                      "${'groovy'}", // GString
@@ -1105,6 +1237,7 @@ class GroovyMethodsTest extends GroovyTestCase {
     }
 
     void testTakeDropClassSymmetry() {
+        int a
         // NOTES:
         // - Cannot test plain HashMap, as Groovy will always default to a LinkedHashMap
         //   See org.codehaus.groovy.runtime.DefaultGroovyMethodsSupport.java:183
@@ -1121,13 +1254,33 @@ class GroovyMethodsTest extends GroovyTestCase {
           (java.util.Hashtable)     : new Hashtable( [ a:1, b:2, c:3 ] ),
           // Iterators
           (java.util.Iterator)      : [ hasNext:{ true }, next:{ 'groovy' } ] as Iterator,
+          // Iterables
+          (java.lang.Iterable)      : { [ hasNext:{ a < 6 }, next:{ a++ } ] as Iterator } as Iterable,
           // CharSequences
           (java.lang.String)        : new String( 'groovy' ),
           (java.nio.CharBuffer)     : java.nio.CharBuffer.wrap( 'groovy' ),
         ]
         data.each { Class clazz, object ->
+            a = 1
             assert clazz.isInstance( object.take( 5 ) )
+            a = 1
             assert clazz.isInstance( object.drop( 5 ) )
+        }
+
+        data = [
+          // Lists
+          (java.util.ArrayList)     : new ArrayList( [ 1, 2, 3 ] ),
+          (java.util.LinkedList)    : new LinkedList( [ 1, 2, 3 ] ),
+          (java.util.Stack)         : new Stack() {{ addAll( [ 1, 2, 3 ] ) }},
+          (java.util.Vector)        : new Vector( [ 1, 2, 3 ] ),
+          // Iterables
+          (java.lang.Iterable)      : { [ hasNext:{ a < 6 }, next:{ a++ } ] as Iterator } as Iterable,
+        ]
+        data.each { Class clazz, object ->
+            a = 1
+            assert clazz.isInstance( object.takeRight( 5 ) )
+            a = 1
+            assert clazz.isInstance( object.dropRight( 5 ) )
         }
     }
 

--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/completion/ReflectionCompletor.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/completion/ReflectionCompletor.groovy
@@ -397,13 +397,13 @@ class ReflectionCompletor {
                     'combinations()',
                     'count(',
                     'countBy(',
-                    'drop(',
-                    'dropWhile(',
+                    'drop(', 'dropRight(', 'dropWhile(',
                     'each()', 'each(',
                     'eachPermutation(',
                     'every()', 'every(',
                     'find(', 'findResult(', 'findResults(',
                     'flatten()',
+                    'init()',
                     'inject(',
                     'intersect(',
                     'join(',
@@ -412,7 +412,7 @@ class ReflectionCompletor {
                     'size()',
                     'sort()',
                     'split(',
-                    'take(', 'takeWhile(',
+                    'take(', 'takeRight(', 'takeWhile(',
                     'toSet()',
                     'retainAll(', 'removeAll(',
                     'unique()', 'unique('
@@ -461,12 +461,12 @@ class ReflectionCompletor {
                     'collect()', 'collect(',
                     'count(',
                     'countBy(',
-                    'drop(',
-                    'dropWhile(',
+                    'drop(', 'dropRight(', 'dropWhile(',
                     'each()', 'each(',
                     'every()', 'every(',
                     'find(', 'findResult(',
                     'flatten()',
+                    'init()',
                     'inject(',
                     'join(',
                     'max()', 'min()',
@@ -474,7 +474,7 @@ class ReflectionCompletor {
                     'size()',
                     'sort()',
                     'split(',
-                    'take(', 'takeWhile('
+                    'take(', 'takeRight(', 'takeWhile('
             ].findAll({it.startsWith(prefix)}).each({candidates.add(it)})
         }
         return candidates


### PR DESCRIPTION
Iterable, List and Object[] have tail(), drop() and take() but init(), dropRight() and takeRight() are missing.
I added them.

Method names are from Scala.
http://www.scala-lang.org/api/2.10.4/index.html#scala.collection.immutable.List
