### PR TITLE
Fix spread-dot operator in user guide.

### DIFF
--- a/src/spec/doc/core-operators.adoc
+++ b/src/spec/doc/core-operators.adoc
@@ -393,7 +393,7 @@ include::{projectdir}/src/spec/test/OperatorsTest.groovy[tags=pattern_matcher_st
 
 === Spread operator
 
-The Spread Operator (`.*`) is used to invoke an action on all items of an aggregate object. It is equivalent to calling the action on each item
+The Spread Operator (`*.`) is used to invoke an action on all items of an aggregate object. It is equivalent to calling the action on each item
 and collecting the result into a list:
 
 [source,groovy]


### PR DESCRIPTION
The section on the spread-dot (or spread) operator had the `*` and `.` the wrong way round.
