### PR TITLE
Fix for Groovy5687Bug test case failing due to locale

### DIFF
--- a/src/test/groovy/bugs/Groovy5687Bug.groovy
+++ b/src/test/groovy/bugs/Groovy5687Bug.groovy
@@ -23,7 +23,7 @@ class Groovy5687Bug extends GroovyTestCase {
     }
 
     static interface DateTimeFormatConstants {
-        SimpleDateFormat AM_PM_TIME_FORMAT = new SimpleDateFormat("h:mma")
+        SimpleDateFormat AM_PM_TIME_FORMAT = new SimpleDateFormat("h:mma", new Locale('en_US'))
         SimpleDateFormat MILITARY_TIME_FORMAT = new SimpleDateFormat("HH:mm")
     }
 


### PR DESCRIPTION
Fixing Groovy5687Bug test case failing due to default locale producing 'em' as am/pm marker.

When having swedish as default locale Groovy5687Bug.groovy fails with

```
Assertion failed:
assert DateTimeUtils.convertMilitaryTimeToAmPm('20:30') == '8:30pm'
                     |                                  |
                     8:30em                             false
```

this pr fixes this and all 7215 tests pass
