### PR TITLE
Add macros for JDK and Groovy JDK links.

### DIFF
--- a/gradle/asciidoctor.gradle
+++ b/gradle/asciidoctor.gradle
@@ -59,20 +59,19 @@ asciidoctor.doLast {
 <script src='assets/js/jquery-2.1.1.min.js'></script>
 <script src='assets/js/view-example.js'></script>'''
 
+    def baseUrls = [
+            jdk: "http://docs.oracle.com/javase/8/docs/api/index.html",
+            gjdk: "http://docs.groovy-lang.org/${version}/html/groovy-jdk/index.html",
+            gapi: "http://docs.groovy-lang.org/${version}/html/gapi/index.html",
+    ]
+
     // gapi macro expansion
     outputDir.eachFileMatch(~'.*html') { File file ->
         def text = file.getText('UTF-8')
-        text = text.replaceAll(/gapi::([a-zA-Z0-9$.#]+)/) { m ->
-            def cName = m[1]
-            def cPath = m[1].replace('.', '/')
-            def anchor = ''
-            int anchorIdx = cPath.indexOf('#')
-            if (anchorIdx > 0) {
-                anchor = cPath.substring(anchorIdx)
-                cPath = cPath.substring(0, anchorIdx)
-            }
-
-            "<a href='http://docs.groovy-lang.org/${version}/html/gapi/index.html?${cPath}.html${anchor}' target='_blank'><code>$cName</code></a>"
+        text = text.replaceAll(/(gapi|gjdk|jdk)::([a-zA-Z0-9$.#]+)(?:\[([^\]]*)\])?/) { m ->
+            def (className, anchor) = m[2].split('#') as List
+            def label = m[3] ?: '<code>' + className + '</code>'
+            "<a href='${calculateDocUrl(baseUrls[m[1]], className, anchor)}' target='_blank'>$label</a>"
         }
 
         text = text.replaceAll('</head>', "$scripts</head>")
@@ -80,4 +79,10 @@ asciidoctor.doLast {
         file.write(text, 'UTF-8')
     }
 
+}
+
+String calculateDocUrl(String baseUrl, String className, String anchor) {
+    if (className == "index") return baseUrl
+
+    return baseUrl + "?" + className.replace('.', '/') + '.html' + (anchor ? '#' + anchor : '')
 }


### PR DESCRIPTION
This extends the current support for Groovy API macros to the JDK and the
Groovy JDK. It also allows the author to do some extra things:
- Add a custom label for a link using square brackets
- Link to the index page

As an example, you could link to the Groovy JDK index page with a dedicated
label using

```
gjdk::index[Groovy JDK]
```

Even if you don't want to use a custom label, the square brackets can help
delimit class names at the end of a sentence:

```
gapi::groovy.xml.MarkupBuilder[].
```

This should help immensely with cross-documentation links and I'm using it
already in the Groovy Development Kit chapter.
