### PR TITLE
fix misnamed partial include tag in docs

### DIFF
--- a/src/spec/test/typing/TypeCheckingTest.groovy
+++ b/src/spec/test/typing/TypeCheckingTest.groovy
@@ -104,9 +104,9 @@ class TypeCheckingTest extends StaticTypeCheckingTestCase {
         '''
 
         shouldFailWithMessages '''
-            // tag::stc_assign_array[]
+            // tag::stc_assign_array_fail[]
             int[] i = new String[4]     // fails
-            // end::stc_assign_array[]
+            // end::stc_assign_array_fail[]
         ''', 'Cannot assign value of type java.lang.String[] to variable of type int[]'
 
         shouldFailWithMessages '''


### PR DESCRIPTION
Resolves warning message:

> asciidoctor: WARNING: src/spec/doc/core-semantics.adoc: line 691: tag 'stc_assign_array_fail' not found in include file: /home/dallen/projects/asciidoctor/use-cases/groovy-core/src/spec/test/typing/TypeCheckingTest.groovy
