### PR TITLE
documentation recommendations

### DIFF
--- a/src/spec/doc/index.adoc
+++ b/src/spec/doc/index.adoc
@@ -1,54 +1,60 @@
 = Groovy Language Documentation
+:doctype: book
+ifndef::projectdir[:projectdir: ../../..]
 
 include::{projectdir}/src/spec/doc/core-introduction.adoc[]
 
 == Groovy Language Specification
 
 :leveloffset: 2
-include::{projectdir}/src/spec/doc/core-syntax.adoc[]
-include::{projectdir}/src/spec/doc/core-operators.adoc[]
-include::{projectdir}/src/spec/doc/core-program-structure.adoc[]
-include::{projectdir}/src/spec/doc/core-object-orientation.adoc[]
-:leveloffset: 0
 
-:leveloffset: 2
+include::{projectdir}/src/spec/doc/core-syntax.adoc[]
+
+include::{projectdir}/src/spec/doc/core-operators.adoc[]
+
+include::{projectdir}/src/spec/doc/core-program-structure.adoc[]
+
+include::{projectdir}/src/spec/doc/core-object-orientation.adoc[]
+
 include::{projectdir}/src/spec/doc/core-closures.adoc[]
+
 include::{projectdir}/src/spec/doc/core-semantics.adoc[]
+
 :leveloffset: 0
 
 == Tools
 
 :leveloffset: 2
+
 include::{projectdir}/src/spec/doc/tools-groovyc.adoc[]
+
 include::{projectdir}/src/spec/doc/tools-groovysh.adoc[]
+
 include::{projectdir}/src/spec/doc/tools-groovyconsole.adoc[]
+
 include::{projectdir}/src/spec/doc/tools-groovydoc.adoc[]
+
 include::{projectdir}/src/spec/doc/tools-ide.adoc[]
+
 :leveloffset: 0
 
 == User Guides
-:leveloffset: 2
-include::{projectdir}/src/spec/doc/core-getting-started.adoc[]
-:leveloffset: 0
-:leveloffset: 2
-include::{projectdir}/src/spec/doc/core-differences-java.adoc[]
-:leveloffset: 0
-:leveloffset: 2
-include::{projectdir}/src/spec/doc/core-gdk.adoc[]
-:leveloffset: 0
-:leveloffset: 2
-include::{projectdir}/src/spec/doc/core-metaprogramming.adoc[]
-:leveloffset: 0
-:leveloffset: 2
-include::{projectdir}/src/spec/doc/grape.adoc[]
-:leveloffset: 0
-:leveloffset: 2
-include::{projectdir}/src/spec/doc/core-testing-guide.adoc[]
-:leveloffset: 0
 
 :leveloffset: 2
+
+include::{projectdir}/src/spec/doc/core-getting-started.adoc[]
+
+include::{projectdir}/src/spec/doc/core-differences-java.adoc[]
+
+include::{projectdir}/src/spec/doc/core-gdk.adoc[]
+
+include::{projectdir}/src/spec/doc/core-metaprogramming.adoc[]
+
+include::{projectdir}/src/spec/doc/grape.adoc[]
+
+include::{projectdir}/src/spec/doc/core-testing-guide.adoc[]
+
 include::{subprojroot}json/{specfolder}/json-userguide.adoc[]
-:leveloffset: 0
 
 === Interacting with a SQL database (TBD)
 === Processing XML (TBD)
@@ -63,12 +69,13 @@ include::{projectdir}/src/spec/doc/template-engines.adoc[]
 === Servlet support (TBD)
 
 :leveloffset: 2
-include::{projectdir}/src/spec/doc/guide-integrating.adoc[]
-:leveloffset: 0
 
-:leveloffset: 2
+include::{projectdir}/src/spec/doc/guide-integrating.adoc[]
+
 include::{projectdir}/src/spec/doc/core-domain-specific-languages.adoc[]
+
 include::{projectdir}/subprojects/groovy-jmx/src/spec/doc/jmx.adoc[]
+
 :leveloffset: 0
 
 === Creating Swing UIs (TBD)
@@ -83,5 +90,7 @@ include::{projectdir}/src/spec/doc/design-pattern-in-groovy.adoc[]
 == Acknowledgements
 
 :leveloffset: 2
+
 include::{projectdir}/src/spec/doc/license-contributors.adoc[]
+
 :leveloffset: 0


### PR DESCRIPTION
fixes AsciiDoc preview outside Gradle build (such as in Asciidoctor.js
Live Preview) by making the following changes:
- always set doctype in book master file (semantic integrity)
- always use fallback value for attributes used for resolution
- use blank lines around include directives to avoid unseen parse errors
- use blank lines around leveloffset entries to avoid unseen parse errors
