### PR TITLE
GROOVY-6964: Build on Windows

### DIFF
--- a/gradle/assemble.gradle
+++ b/gradle/assemble.gradle
@@ -133,9 +133,10 @@ allprojects {
         classifier = jar.classifier
         includeEmptyDirs = false
         def target = new File("${archivePath}.tmp")
+        def targetTmp = new File("${archivePath}.tmp.1.tmp")
 
         doFirst {
-            from zipTree(target)
+            from zipTree(targetTmp)
 
             def keepUntouched = [
                     'org/codehaus/groovy/cli/GroovyPosixParser*.class',
@@ -147,7 +148,7 @@ allprojects {
             def gradleProject = project
             ant {
                 taskdef name: 'jarjar', classname: 'com.tonicsystems.jarjar.JarJarTask', classpath: rootProject.configurations.tools.asPath
-                jarjar(jarfile: target) {
+                jarjar(jarfile: targetTmp) {
                     zipfileset(
                             src: jar.archivePath,
                             excludes: keepUntouched)
@@ -175,13 +176,14 @@ allprojects {
             manifest = osgiManifest {
                 symbolicName = gradleProject.name
                 instruction 'Import-Package', '*;resolution:=optional'
-                classesDir = target
+                classesDir = targetTmp
             }
             manifest(manifestSpec)
 
             def manifestPath = "${temporaryDir}/META-INF/MANIFEST.MF"
             manifest.writeTo(manifestPath)
 
+            ant.copy(file: targetTmp, tofile: target)
             ant.jar(destfile: target, update: true, manifest: manifestPath) {
                 zipfileset(
                         src: jar.archivePath,
@@ -191,6 +193,7 @@ allprojects {
         }
         doLast {
             target.delete()
+            ant.delete(file: targetTmp, quiet: true, deleteonexit: true)
         }
     }
 
@@ -310,9 +313,10 @@ task jarAll(type: Jar, dependsOn: replaceJarWithJarJar) {
         }
         logger.info 'Packaging with jarjar'
 
+        def archivePathTmp = new File("${archivePath}.1.tmp")
         ant {
             taskdef name: 'jarjar', classname: 'com.tonicsystems.jarjar.JarJarTask', classpath: configurations.tools.asPath
-            jarjar(jarfile: archivePath, manifest: "$owner.ext.metaInfDir/MANIFEST.MF") {
+            jarjar(jarfile: archivePathTmp, manifest: "$owner.ext.metaInfDir/MANIFEST.MF") {
                 zipfileset(dir: "$owner.ext.metaInfDir", prefix: 'META-INF', excludes: 'META-INF')
                 zipfileset(src: jar.archivePath)
                 moduleJars().each {
@@ -324,16 +328,18 @@ task jarAll(type: Jar, dependsOn: replaceJarWithJarJar) {
         manifest = osgiManifest {
             symbolicName = 'groovy-all'
             instruction 'Import-Package', '*;resolution:=optional'
-            classesDir = archivePath
+            classesDir = archivePathTmp
         }
         manifest groovyOsgiManifest
         manifestPath = "${temporaryDir}/META-INF/MANIFEST.MF"
         manifest.writeTo(manifestPath)
 
         ant {
+            copy(file: archivePathTmp, tofile: archivePath)
             jar(destfile: archivePath, update:true, manifest: manifestPath) {
                 zipfileset(src: jar.archivePath)
             }
+            delete(file: archivePathTmp, quiet: true, deleteonexit: true)
         }
     }
 }


### PR DESCRIPTION
Building on Windows was not supported because JarJarTask does not release a file lock.
Please read http://groovy.329449.n5.nabble.com/Build-issue-with-groovy-core-master-td5719619.html for the detail.
I fixed this problem.
I checked this is running correctly on Windows 8.1 and Ubuntu 14.04.
