### PR TITLE
GROOVY-6778: Allow "-n" in filenames and command line arguments

### DIFF
--- a/src/bin/startGroovy.bat
+++ b/src/bin/startGroovy.bat
@@ -183,11 +183,12 @@ if "x3" == "x%_SKIP%" goto skip_3
 if "x2" == "x%_SKIP%" goto skip_2
 if "x1" == "x%_SKIP%" goto skip_1
 
-rem now unescape -q, -s, -d
+rem now unescape -s, -q, -n, -d
+rem -d must be the last to be unescaped
 set _ARG=%_ARG:-s=*%
 set _ARG=%_ARG:-q="%
-set _ARG=%_ARG:-d=-%
 set _ARG=%_ARG:-n=?%
+set _ARG=%_ARG:-d=-%
 
 set CMD_LINE_ARGS=%CMD_LINE_ARGS% %_ARG%
 set _ARG=


### PR DESCRIPTION
The string "-d" is being used to escape dashes. Thus, converting all dashes to "-d" must be the first replacement that is done (it was) and converting them back must be the last (it wasn't). The bug resulted in the following erroneous conversion:

"-n" -> "-dn" -> "-n" -> "?"
