### PR TITLE
GROOVY-6969: Set.flatten() should return Set

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -10164,7 +10164,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @since 1.6.0
      */
     public static Collection<?> flatten(Iterable<?> self) {
-        return flatten(self, createSimilarCollection(asList(self)));
+        return flatten(self, createSimilarCollection(self));
     }
 
     /**
@@ -10312,7 +10312,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @since 1.6.0
      */
     public static <T> Collection<T> flatten(Iterable<T> self, Closure<? extends T> flattenUsing) {
-        return flatten(self, createSimilarCollection(asList(self)), flattenUsing);
+        return flatten(self, createSimilarCollection(self), flattenUsing);
     }
 
     private static <T> Collection<T> flatten(Iterable elements, Collection<T> addTo, Closure<? extends T> flattenUsing) {

--- a/src/test/groovy/SetTest.groovy
+++ b/src/test/groovy/SetTest.groovy
@@ -34,13 +34,15 @@ class SetTest extends GroovyTestCase {
 
     void testSetFlatten() {
         Set orig = [[[4, 5, 6, [46, 7, "erer"] as Set] as Set, 4, [3, 6, 78] as Set] as Set, 4]
-        Set flat = orig.flatten()
+        def flat = orig.flatten()
+        assert flat instanceof Set
         assert flat == [3, 4, 5, 6, 7, 46, 78, "erer"] as Set
     }
 
     void testFlattenSetOfMapsWithClosure() {
         Set orig = [[a:1, b:2], [c:3, d:4]] as Set
-        Set flat = orig.flatten{ it instanceof Map ? it.values() : it }
+        def flat = orig.flatten{ it instanceof Map ? it.values() : it }
+        assert flat instanceof Set
         assert flat == [1, 2, 3 ,4] as Set
         flat = orig.flatten{ it instanceof Map ? it.keySet() : it }
         assert flat == ["a", "b", "c", "d"] as Set


### PR DESCRIPTION
Bug fix. `Set.flatten()` should return `Set`, but currently returns `List`.
