### PR TITLE
Differences in Strings and Character literals

### DIFF
--- a/src/spec/doc/core-differences-java.adoc
+++ b/src/spec/doc/core-differences-java.adoc
@@ -198,3 +198,88 @@ instead:
 Runnable run = { println 'run' }
 list.each { println it } // or list.each(this.&println)
 ----
+
+== GStrings
+
+As double-quoted string literals are interpreted as `GString` values, Groovy may fail 
+with compile error or produce different code if a `String` literal containing a dollar
+character, is compiled with Groovy and Java compiler.
+
+[source,groovy]
+----
+// contrived example, but equivalent seen in production code
+String name="John Smith";
+String age=30;
+System.out.printf("User details: $name=%s, $age=%d%n", name, age);
+----
+
+
+== String and Character literals
+
+Singly-quoted literals in Groovy are used for `String`, and double-quoted result in 
+`String` or `GString`, depending whether there is interpolation in the literal. 
+
+[source,groovy]
+----
+assert 'c'.getClass()==String
+assert "c".getClass()==String
+assert "c${1}".getClass() in GString
+----
+
+Groovy will automatically cast a single-character `String` to `char` when assigning to
+a variable of type `char`. When calling methods with arguments of type `char` we need 
+to either cast explicitly or make sure the value has been casted in advance.
+
+[source,groovy]
+----
+char a='a'
+assert Character.digit(a, 16)==10 : "But Groovy does boxing"
+assert Character.digit((char) 'a', 16)==10 
+
+try {
+  assert Character.digit('a', 16)==10 
+  assert false: 'Need explicit cast'
+} catch(MissingMethodException e) {
+}
+----
+
+Keep in mind that even if a Groovy reference has a type `char`, Groovy's type system 
+does not support primitives and the actual used value is Character, resulting in 
+boxing/unboxing performance penalty every time we cross the Java boundary.
+
+[source,groovy]
+----
+char c = 'c'
+assert c.class == Character
+
+char cs = "c"
+assert cs.class == Character
+
+def cp= ((char)'c').charValue()
+assert cp.class == Character : "Groovy does not support primitives"
+
+// few more attempts
+assert ((char) 'c').class==Character
+assert ('c' as char).class==Character
+----
+
+Groovy supports two styles of casting and in the case of casting to `char` there 
+are subtle differences when casting a multi-char strings. The Groovy style cast is 
+more lenient and will take the first character, while the C-style cast will fail 
+with exception.
+
+[source,groovy]
+----
+// for single char strings, both are the same
+assert ((char) "c").class==Character
+assert ("c" as char).class==Character
+
+// for multi char strings they are not
+try {
+  ((char) 'cx') == 'c'
+  assert false: 'will fail - not castable'
+} catch(GroovyCastException e) {
+}
+assert ('cx' as char) == 'c'
+assert 'cx'.asType(char) == 'c'
+----


### PR DESCRIPTION
A first batch of proposed changes for the Groovy/Java differences page.

Looking at my notes, many of the things I have are not so much about differences between the languages, but about counterintuitive behavior from the point of view of a Java developer learning Groovy. I am not sure whether they belong in this page or a separate page.

Here is a summary, please let me know what you think:

```
Characters
- single quotes define Strings (double quotes are for GStrings)
- implicitly cast 1 char String and GString to character
- the Groovy language does not support primitive char variables
- primitive and wrapper char boxing/unboxing works with 1-char strings
- casting multi-char string with the 'as' operator returns first char
- casting multi-char string with the C-cast operator fails

--- --- --- --- ---

Numbers
- int and long literals
- integer overflow on addition, subtraction and multiplication
- division operator promotes int types to BigDecimal
- integer division

Strings
- introducing GString interpolation
- delayed expansion of interpolated expressions
- GStrings are usually equal to equivalent Strings, but hash code is different
- enclosing scope from another function
- multi-line strings
- slashy strings

Regexes
- full and partial matching operators
- partial matching returns a java.util.regex.Matcher
- accessing matches
- slicing matches
- accessing matched groups by index
- accessing matched groups by iteration
- using slashy strings for regexes

Collections
- determining map's class (MOP property redefinition)
- unquoted keys in maps are treated as strings (unless ints)
- multi-word keys need quotes, expressions need parens)
- dynamic dispatch for List<Integer>.remove(int)
- sort() and unique() chained API's are mutating the subject
- use defensive copies
- flatten and reverse are functional

Groovy Truth

Signatures
- varargs and named params
- empty varargs is empty list, empty named params is null
- can be changed with explicit default value
- parens can be skipped when we don't use the function's return value
- but not when the only argument is a list literal (parse ambiguous with indexing)
- trailing closures can be behind parens
- but not for constructors (ambiguous with anonymous subclass)
- call println without parens
- except when argument is starting with parenthesized expression
```
