### PR TITLE
Changed Path.size() to return 0 instead of throwing NoSuchFileException

### DIFF
--- a/subprojects/groovy-nio/src/main/java/org/codehaus/groovy/runtime/NioGroovyMethods.java
+++ b/subprojects/groovy-nio/src/main/java/org/codehaus/groovy/runtime/NioGroovyMethods.java
@@ -41,6 +41,7 @@ import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
+import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
@@ -116,7 +117,12 @@ public class NioGroovyMethods extends DefaultGroovyMethodsSupport {
      * @since 2.3.0
      */
     public static long size(Path self) throws IOException {
-        return Files.size(self);
+        try {
+            return Files.size(self);
+        }
+        catch( NoSuchFileException e ) {
+            return 0;
+        }
     }
 
     /**

--- a/subprojects/groovy-nio/src/test/groovy/org/codehaus/groovy/runtime/NioGroovyMethodsTest.groovy
+++ b/subprojects/groovy-nio/src/test/groovy/org/codehaus/groovy/runtime/NioGroovyMethodsTest.groovy
@@ -20,9 +20,13 @@ class NioGroovyMethodsTest extends Specification {
         def str = 'Hello world!'
         Path path = Files.createTempFile('test-size', null)
         Files.copy( new ByteArrayInputStream(str.getBytes()), path, StandardCopyOption.REPLACE_EXISTING )
-
         then:
         path.size() == str.size()
+
+        when:
+        Files.deleteIfExists(path)
+        then:
+        path.size() == 0    // no exception is thrown
 
         cleanup:
         Files.deleteIfExists(path)


### PR DESCRIPTION
Modified the method `ResourceGroovyMethods#size(Path)` so that it turns 0 when the target file does not exist instead of throwing NoSuchFileException. 

Thus it behaves in more uniform manner with `File#length()` and `ResourceGroovyMethods#size(File)` methods

See https://jira.codehaus.org/browse/GROOVY-6974