### PR TITLE
GROOVY-6992: Added support for collecting over sets

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -2632,6 +2632,50 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
     }
 
     /**
+     * Iterates through this Set transforming each value into a new value using the <code>transform</code> closure
+     * and adding it to the supplied <code>collector</code>.
+     * <pre class="groovyTestCase">assert [1,2,3] as HashSet == [2,4,5,6].collect { (int)(it / 2) }</pre>
+     *
+     * @param self      a set
+     * @param collector the Set to which the transformed values are added
+     * @param transform the closure used to transform each item of the collection
+     * @return the collector with all transformed values added to it
+     */
+    public static <T,E> Set<T> collect(Set<E> self, Set<T> collector, @ClosureParams(FirstParam.FirstGenericType.class) Closure<? extends T> transform) {
+        return collectSet(self, collector, transform);
+    }
+
+    /**
+     * Iterates through this set transforming each entry into a new value using the <code>transform</code> closure
+     * returning a list of transformed values.
+     * <pre class="groovyTestCase">assert [1,2,3] as Set == [2,4,5,6].collect { (int) (it / 2) }</pre>
+     *
+     * @param self      a set
+     * @param transform the closure used to transform each item of the collection
+     * @return a List of the transformed values
+     */
+    public static <T,E> Set<T> collect(Set<E> self, @ClosureParams(FirstParam.FirstGenericType.class) Closure<? extends T> transform) {
+        return collectSet(self, DefaultGroovyMethods.<T>defaultSet(), transform);
+    }
+
+    /**
+     * Iterates through this set transforming each entry into a new value using Closure.IDENTITY
+     * as a transformer, basically returning a set of items copied from the original collection.
+     * <pre class="groovyTestCase">assert [1,2,3] as Set == ([1,2,3] as Set).collect()</pre>
+     *
+     * @param self    a set
+     * @return a Set of the transformed values
+     * @see Closure#IDENTITY
+     */
+    public static <T,E> Set<T> collect(Set<E> self) {
+        return collectSet(self, DefaultGroovyMethods.<T>defaultSet(), Closure.IDENTITY);
+    }
+
+    private static <A> Set<A> defaultSet() {
+        return new LinkedHashSet<A>();
+    }
+
+    /**
      * Iterates through this collection transforming each entry into a new value using Closure.IDENTITY
      * as a transformer, basically returning a list of items copied from the original collection.
      * <pre class="groovyTestCase">assert [1,2,3] == [1,2,3].collect()</pre>
@@ -4063,7 +4107,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @since 2.2.0
      */
     public static <T,V> List<V> permutations(Iterable<T> self, Closure<V> function) {
-        return collect(permutations(self),function);
+        return collect((Collection) permutations(self),function);
     }
 
     /**

--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethodsSupport.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethodsSupport.java
@@ -15,9 +15,12 @@
  */
 package org.codehaus.groovy.runtime;
 
+import groovy.lang.Closure;
 import groovy.lang.EmptyRange;
 import groovy.lang.IntRange;
 import groovy.lang.Range;
+import groovy.transform.stc.ClosureParams;
+import groovy.transform.stc.FirstParam;
 import org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation;
 
 import java.io.Closeable;
@@ -125,6 +128,10 @@ public class DefaultGroovyMethodsSupport {
             }
         }
         return null;
+    }
+
+    protected static <T,E> Set<T> collectSet(Set<E> self, Set<T> collector, @ClosureParams(FirstParam.FirstGenericType.class) Closure<? extends T> transform) {
+        return (Set<T>) DefaultGroovyMethods.collect((Collection) self, collector, transform);
     }
 
     protected static Collection createSimilarOrDefaultCollection(Object object) {

--- a/src/test/groovy/MapTest.groovy
+++ b/src/test/groovy/MapTest.groovy
@@ -117,7 +117,7 @@ class MapTest extends GroovyTestCase {
         assert map1 == control
 
         map1 = [a:1, b:2]
-        map1.putAll(map3.entrySet().collect{ [it.value, it.key] as MapEntry })
+        map1.putAll(map3.entrySet().toList().collect{ [it.value, it.key] as MapEntry })
         assert map1 == control
 
         map1 = [a:1, b:2]
@@ -137,7 +137,7 @@ class MapTest extends GroovyTestCase {
         assert control == map1 + map2.entrySet()
         assert map1 == [a:1, b:2]
 
-        assert control == map1 + map3.entrySet().collect{ [it.value, it.key] as MapEntry }
+        assert control == map1 + map3.entrySet().toList().collect{ [it.value, it.key] as MapEntry }
         assert map1 == [a:1, b:2]
 
         map1 = [a:1, b:2]

--- a/src/test/groovy/SetTest.groovy
+++ b/src/test/groovy/SetTest.groovy
@@ -39,6 +39,22 @@ class SetTest extends GroovyTestCase {
         assert flat == [3, 4, 5, 6, 7, 46, 78, "erer"] as Set
     }
 
+    void testCollect() {
+        def s1 = [1, 1, 2] as Set
+        assert(s1 instanceof Set)
+        def s2 = s1.collect {
+            (it + 1).toString()
+        }
+        assert(s2 == ["2", "3"] as Set)
+        def s3 = s1.collect {
+            s1
+        }
+        assert(s3 == [[1, 2] as Set] as Set)
+        s3.each {
+            assert(it instanceof Set)
+        }
+    }
+
     void testFlattenSetOfMapsWithClosure() {
         Set orig = [[a:1, b:2], [c:3, d:4]] as Set
         def flat = orig.flatten{ it instanceof Map ? it.values() : it }


### PR DESCRIPTION
Pull request for https://jira.codehaus.org/browse/GROOVY-6992.

Collecting over sets without passing in a collection to add to returns a list.  We really want it to return a set.  

I added support for this to DefaultGroovyMethods for a set using the default set of LinkedHashSet.  I noticed this was used as the default.  It worked for HashSet too, but I have kept the current default.  I initially tried TreeSet, but this class is broken in Java and should always require an ordering operation for elements.

A warning, this may break existing code that relies on collecting over a set returning a list.  For this behaviour, toList() can be called either before or after the collect method.
