### PR TITLE
GROOVY-6990: Do not add timestamp fields if possible

### DIFF
--- a/src/main/org/codehaus/groovy/classgen/Verifier.java
+++ b/src/main/org/codehaus/groovy/classgen/Verifier.java
@@ -77,6 +77,8 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
     public static final String SWAP_INIT = "__$swapInit";
     public static final String INITIAL_EXPRESSION = "INITIAL_EXPRESSION";
 
+    // NOTE: timeStamp constants shouldn't belong to Verifier but kept here
+    // for binary compatibility
     public static final String __TIMESTAMP = "__timeStamp";
     public static final String __TIMESTAMP__ = "__timeStamp__239_neverHappen";
     private static final Parameter[] INVOKE_METHOD_PARAMS = new Parameter[]{
@@ -187,9 +189,6 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
         if (!knownSpecialCase) addGroovyObjectInterfaceAndMethods(node, classInternalName);
 
         addDefaultConstructor(node);
-
-        // add a static timestamp field to the class
-        if (!(node instanceof InnerClassNode)) addTimeStamp(node);
 
         addInitialization(node);
         checkReturnInObjectInitializer(node.getObjectInitializerStatements());
@@ -487,30 +486,8 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
         }
     }
 
+    @Deprecated
     protected void addTimeStamp(ClassNode node) {
-        if (node.getDeclaredField(Verifier.__TIMESTAMP) == null) { // in case if verifier visited the call already
-            FieldNode timeTagField = new FieldNode(
-                    Verifier.__TIMESTAMP,
-                    ACC_PUBLIC | ACC_STATIC | ACC_SYNTHETIC,
-                    ClassHelper.long_TYPE,
-                    //"",
-                    node,
-                    new ConstantExpression(System.currentTimeMillis()));
-            // alternatively, FieldNode timeTagField = SourceUnit.createFieldNode("public static final long __timeStamp = " + System.currentTimeMillis() + "L");
-            timeTagField.setSynthetic(true);
-            node.addField(timeTagField);
-
-            timeTagField = new FieldNode(
-                    Verifier.__TIMESTAMP__ + String.valueOf(System.currentTimeMillis()),
-                    ACC_PUBLIC | ACC_STATIC | ACC_SYNTHETIC,
-                    ClassHelper.long_TYPE,
-                    //"",
-                    node,
-                    new ConstantExpression((long) 0));
-            // alternatively, FieldNode timeTagField = SourceUnit.createFieldNode("public static final long __timeStamp = " + System.currentTimeMillis() + "L");
-            timeTagField.setSynthetic(true);
-            node.addField(timeTagField);
-        }
     }
 
     private void checkReturnInObjectInitializer(List init) {

--- a/src/main/org/codehaus/groovy/control/CompilationUnit.java
+++ b/src/main/org/codehaus/groovy/control/CompilationUnit.java
@@ -258,6 +258,11 @@ public class CompilationUnit extends ProcessingUnit {
         phaseOperations[phase].add(op);
     }
 
+    public void addFirstPhaseOperation(PrimaryClassNodeOperation op, int phase) {
+        if (phase < 0 || phase > Phases.ALL) throw new IllegalArgumentException("phase " + phase + " is unknown");
+        phaseOperations[phase].add(0, op);
+    }
+
     public void addPhaseOperation(GroovyClassOperation op) {
         phaseOperations[Phases.OUTPUT].addFirst(op);
     }


### PR DESCRIPTION
This pull request disables the generation of the timestamp fields. The responsability of adding them is delegated to the `GroovyClassLoader`, depending on its configuration.

There are actually two flags in GCL that could trigger generation of the timestamp:
- `recompile`
- `config.recompileGroovySource`

The behavior should normally be a breaking change if you have a .class file (precompiled class) which was compiled with recompilation set to false (which would not generate the timestamp) then try to reload the source file with recompilation set to true. However, as the unit test illustrates, this is not the case. Uncommenting the `config.targetDirectory` line will _do_ fail the test, but not for the expected reason. Putting in a debugger will show that `groovy.lang.GroovyClassLoader#isRecompilable` is not reached because a `.class` file is found and is preferred anyway.

So as is, it seems that this PR doesn't break anything, but the current behavior seems a bit strange.
