### PR TITLE
GROOVY-7017: Use a new class loader for each GStringTemplateScript class

### DIFF
--- a/subprojects/groovy-templates/src/main/groovy/groovy/text/GStringTemplateEngine.java
+++ b/subprojects/groovy-templates/src/main/groovy/groovy/text/GStringTemplateEngine.java
@@ -90,6 +90,7 @@ import org.codehaus.groovy.control.CompilationFailedException;
 public class GStringTemplateEngine extends TemplateEngine {
     private final ClassLoader parentLoader;
     private static AtomicInteger counter = new AtomicInteger();
+    private static final boolean reuseClassLoader = Boolean.getBoolean("groovy.GStringTemplateEngine.reuseClassLoader");
 
     public GStringTemplateEngine() {
         this(GStringTemplate.class.getClassLoader());
@@ -178,7 +179,8 @@ public class GStringTemplateEngine extends TemplateEngine {
 
             templateExpressions.append("}}");
 
-            final GroovyClassLoader loader = parentLoader instanceof GroovyClassLoader?(GroovyClassLoader)parentLoader:(
+            // Use a new class loader by default for each class so each class can be independently garbage collected
+            final GroovyClassLoader loader = reuseClassLoader && parentLoader instanceof GroovyClassLoader?(GroovyClassLoader)parentLoader:(
                     (GroovyClassLoader) AccessController.doPrivileged(new PrivilegedAction() {
                         public Object run() {
                             return new GroovyClassLoader(parentLoader);


### PR DESCRIPTION
I discovered this issue while working on https://jira.grails.org/browse/GRAILS-11296

Each time GStringTemplateEngine compiles a template, it makes a new class. However, it makes all those new classes on the main (parent) class loader. Since that class loader has loaded many other classes that won't ever get GC'ed, and a class can only be GC'ed when it's class loader is GC'ed and vice versa, these GStringTemplateEngine created classes can never be GC'ed. With enough invocations, memory is exhausted. These classes show up in memory dumps as "GStringTemplateScript" followed by a number.
