### PR TITLE
Removed wildcard processing from startGroovy.bat

### DIFF
--- a/src/bin/startGroovy.bat
+++ b/src/bin/startGroovy.bat
@@ -159,7 +159,7 @@ goto process_arg
 
 :get_arg
 rem remove quotes around first arg
-for %%i in (%1) do set _ARG=%_ARG% %%~i
+for /f %%i in (%1) do set _ARG=%_ARG% %%~i
 rem set the remaining args
 set _ARGS=%2
 rem remove the leading space we'll add the first time


### PR DESCRIPTION
Given a simple script:

```
args.eachWithIndex{ arg, idx -> println "$idx - $arg" }
```

run with a command:

```
> groovy test first second third.*
```

the Windows command line issues an error: _The syntax of the command is incorrect._

---

I have modified the `startGroovy.bat` script to skip wildcard processing altogether. It's a very simple fix, but now the output is:

```
> groovy test first second third.*
0 - first
1 - second
2 - third.*
```
