### PR TITLE
revert jline dependency to 2.11 until fix is available

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,7 +109,7 @@ ext {
     ivyVersion = '2.4.0-rc1'
     jansiVersion = '1.11'
     jarjarVersion = '1.3'
-    jlineVersion = '2.12'
+    jlineVersion = '2.11'
     jmockVersion = '1.2.0'
     logbackVersion = '1.1.2'
     log4jVersion = '1.2.17'


### PR DESCRIPTION
Jline 2.12 causes bash shell to have invisble typing after exiting groovysh
https://github.com/jline/jline2/issues/163
