### PR TITLE
GROOVY-7055: Groovysh: fix Hyphen checking breaking entering code

### DIFF
--- a/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/util/CommandArgumentParser.groovy
+++ b/subprojects/groovy-groovysh/src/main/groovy/org/codehaus/groovy/tools/shell/util/CommandArgumentParser.groovy
@@ -36,21 +36,22 @@ class CommandArgumentParser {
     static List<String> parseLine(final String untrimmedLine, final int numTokensToCollect = -1) {
         assert untrimmedLine != null
 
-        String line = untrimmedLine.trim()
+        final String line = untrimmedLine.trim()
         List<String> tokens = []
         String currentToken = ''
         // state machine being either in neutral state, in singleHyphenOpen state, or in doubleHyphenOpen State.
         boolean singleHyphenOpen = false
         boolean doubleHyphenOpen = false
-        for (int i = 0; i < line.length(); i++) {
+        int index = 0
+        for (; index < line.length(); index++) {
             if (tokens.size() == numTokensToCollect) {
                 break
             }
-            String ch = line.charAt(i)
+            String ch = line.charAt(index)
             // escaped char?
             if (ch == '\\' && (singleHyphenOpen || doubleHyphenOpen)) {
-                ch = (i == line.length() - 1) ? '\\' : line.charAt(i + 1)
-                i++
+                ch = (index == line.length() - 1) ? '\\' : line.charAt(index + 1)
+                index++
                 currentToken += ch
                 continue
             }
@@ -91,12 +92,12 @@ class CommandArgumentParser {
                 continue
             }
             currentToken += ch
+        } // end for char in line
+        if (index == line.length() && doubleHyphenOpen) {
+            throw new IllegalArgumentException('Missing closing " in ' + line + ' -- ' + tokens)
         }
-        if (doubleHyphenOpen) {
-            throw new IllegalArgumentException('Missing closing "')
-        }
-        if (singleHyphenOpen) {
-            throw new IllegalArgumentException('Missing closing \'')
+        if (index == line.length() && singleHyphenOpen) {
+            throw new IllegalArgumentException('Missing closing \' in ' + line  + ' -- ' + tokens)
         }
         if (currentToken.size() > 0) {
             tokens.add(currentToken)

--- a/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/util/CommandArgumentParserTest.groovy
+++ b/subprojects/groovy-groovysh/src/test/groovy/org/codehaus/groovy/tools/shell/util/CommandArgumentParserTest.groovy
@@ -42,6 +42,10 @@ public class CommandArgumentParserTest extends GroovyTestCase {
         // limited number of tokens
         assertEquals(['foo'], CommandArgumentParser.parseLine("  foo bar  ", 1))
         assertEquals(['bar', 'foo'], CommandArgumentParser.parseLine('bar"foo"\'bam\'\'baz\'', 2))
+
+        assertEquals(['map.put('], CommandArgumentParser.parseLine("map.put('a': 2)", 1))
+        assertEquals(['map.put('], CommandArgumentParser.parseLine("map.put('a", 1))
+
     }
 
 }


### PR DESCRIPTION
See https://jira.codehaus.org/browse/GROOVY-7055
This one is URGENT, if it cannot be merged into 2.4.0 for one reason or another, consider reverting commits
6101791074aebb264
and
50259524574eb50d
instead.

For reviewer: The code loops over all chars in a line to get a desired number of individual tokens shelll style. The bug is that when only one token is desired, tokenizing stops e.g. at the first hyphen, and the checks after the loop complain hyphens were not closed. The checks are invalid in that case.
