### PR TITLE
GROOVY-7062: Use low concurrencyLevel in rarely updated maps

### DIFF
--- a/src/main/groovy/lang/ExpandoMetaClass.java
+++ b/src/main/groovy/lang/ExpandoMetaClass.java
@@ -280,16 +280,16 @@ public class ExpandoMetaClass extends MetaClassImpl implements GroovyObject {
     public boolean inRegistry;
     
     private final Set<MetaMethod> inheritedMetaMethods = new HashSet<MetaMethod>();
-    private final Map<String, MetaProperty> beanPropertyCache = new ConcurrentHashMap<String, MetaProperty>();
-    private final Map<String, MetaProperty> staticBeanPropertyCache = new ConcurrentHashMap<String, MetaProperty>();
-    private final Map<MethodKey, MetaMethod> expandoMethods = new ConcurrentHashMap<MethodKey, MetaMethod>();
+    private final Map<String, MetaProperty> beanPropertyCache = new ConcurrentHashMap<String, MetaProperty>(16, 0.75f, 1);
+    private final Map<String, MetaProperty> staticBeanPropertyCache = new ConcurrentHashMap<String, MetaProperty>(16, 0.75f, 1);
+    private final Map<MethodKey, MetaMethod> expandoMethods = new ConcurrentHashMap<MethodKey, MetaMethod>(16, 0.75f, 1);
 
     public Collection getExpandoSubclassMethods() {
         return expandoSubclassMethods.values();
     }
 
-    private final ConcurrentHashMap expandoSubclassMethods = new ConcurrentHashMap();
-    private final Map<String, MetaProperty> expandoProperties = new ConcurrentHashMap<String, MetaProperty>();
+    private final ConcurrentHashMap expandoSubclassMethods = new ConcurrentHashMap(16, 0.75f, 1);
+    private final Map<String, MetaProperty> expandoProperties = new ConcurrentHashMap<String, MetaProperty>(16, 0.75f, 1);
     private ClosureStaticMetaMethod invokeStaticMethodMethod;
     private final Set<MixinInMetaClass> mixinClasses = new LinkedHashSet<MixinInMetaClass>();
 


### PR DESCRIPTION
The maps in ExpandoMetaClass are very rarely updated, and when they are, it's usually not by multiple concurrent threads. Therefore, using a lower concurrency level would result in less memory being used with no performance penalty. Since there are so many ExpandoMetaClass instances at runtime, this per instance savings is significant for a whole application.

Since writes are so rare for these maps, I think a concurrencyLevel of 1 is most appropriate.

http://jira.codehaus.org/browse/GROOVY-7062
