### PR TITLE
GROOVY-7151: Allow meta annotation with Target TYPE

### DIFF
--- a/src/main/org/codehaus/groovy/ast/AnnotationNode.java
+++ b/src/main/org/codehaus/groovy/ast/AnnotationNode.java
@@ -30,7 +30,6 @@ import org.codehaus.groovy.GroovyBugError;
  * @version $Revision$
  */
 public class AnnotationNode extends ASTNode {
-    public static final int TYPE_TARGET = 1;
     public static final int CONSTRUCTOR_TARGET = 1 << 1;
     public static final int METHOD_TARGET = 1 << 2;
     public static final int FIELD_TARGET = 1 << 3;
@@ -38,6 +37,7 @@ public class AnnotationNode extends ASTNode {
     public static final int LOCAL_VARIABLE_TARGET = 1 << 5;
     public static final int ANNOTATION_TARGET = 1 << 6;
     public static final int PACKAGE_TARGET = 1 << 7;
+    public static final int TYPE_TARGET = 1 + ANNOTATION_TARGET;    //GROOVY-7151
     private static final int ALL_TARGETS = TYPE_TARGET | CONSTRUCTOR_TARGET | METHOD_TARGET
         | FIELD_TARGET | PARAMETER_TARGET | LOCAL_VARIABLE_TARGET | ANNOTATION_TARGET | PACKAGE_TARGET;
     

--- a/src/test/gls/annotations/AnnotationTest.groovy
+++ b/src/test/gls/annotations/AnnotationTest.groovy
@@ -41,13 +41,13 @@ class AnnotationTest extends CompilableTestSupport {
         """
     }
 
-    void testCannotAnnotateAnotationDefinitionIfTargetIsNotOfType() {
+    void testCannotAnnotateAnnotationDefinitionIfTargetIsNotOfTypeOrAnnotationType() {
         shouldNotCompile """
             import java.lang.annotation.*
             import static java.lang.annotation.ElementType.*
 
-            // all target elements except ANNOTATION_TYPE
-            @Target([CONSTRUCTOR, METHOD, FIELD, LOCAL_VARIABLE, PACKAGE, PARAMETER, TYPE])
+            // all target elements except ANNOTATION_TYPE and TYPE
+            @Target([CONSTRUCTOR, METHOD, FIELD, LOCAL_VARIABLE, PACKAGE, PARAMETER])
             @interface MyAnnotation { }
 
             @MyAnnotation
@@ -646,5 +646,32 @@ class AnnotationTest extends CompilableTestSupport {
             }
             assert GroovyEnum.class.getField('BAD').isAnnotationPresent(XmlEnumValue)
         '''
+    }
+
+    // GROOVY-7151
+    void testAnnotateAnnotationDefinitionWithAnnotationWithTypeTarget() {
+        shouldCompile codeWithMetaAnnotationWithTarget("TYPE")
+    }
+
+    void testAnnotateAnnotationDefinitionWithAnnotationWithAnnotationTypeTarget() {
+        shouldCompile codeWithMetaAnnotationWithTarget("ANNOTATION_TYPE")
+    }
+
+    //Parametrized tests in Spock would allow to make it much more readable
+    private static String codeWithMetaAnnotationWithTarget(String targetElementTypeName) {
+        """
+            import java.lang.annotation.*
+            import static java.lang.annotation.RetentionPolicy.*
+            import static java.lang.annotation.ElementType.*
+
+            @Retention(RUNTIME)
+            @Target(${targetElementTypeName})
+            @interface Import {}
+
+            @Retention(RUNTIME)
+            @Target([FIELD])
+            @Import
+            @interface EnableFeature { }
+        """
     }
 }


### PR DESCRIPTION
To follow Java Language Specification meta annotation with
target TYPE is a valid construction for Groovy annotations.

See [GROOVY-7151](https://jira.codehaus.org/browse/GROOVY-7151) for more details.