### PR TITLE
GROOVY-7057: Fix JsonParserLax to allow comments between array elements 

### DIFF
--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/JsonParserLax.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/JsonParserLax.java
@@ -602,25 +602,40 @@ public class JsonParserLax extends JsonParserCharArray {
 
             list.add(arrayItem);
 
-            skipWhiteSpace();
+            boolean doStop = false;
 
-            char c = __currentChar;
+            done:
+            do { // Find either next array element or end of array while ignoring comments
 
-            if (c == ',') {
-                __index++;
-                continue;
-            } else if (c == ']') {
-                __index++;
-                break;
-            } else {
-                String charString = charDescription(c);
+                skipWhiteSpace();
 
-                complain(
-                        String.format("expecting a ',' or a ']', " +
-                                " but got \nthe current character of  %s " +
-                                " on array index of %s \n", charString, list.size())
-                );
-            }
+                switch (__currentChar) {
+                    case '/':
+                        handleComment();
+                        continue;
+                    case '#':
+                        handleBashComment();
+                        continue;
+                    case ',':
+                        __index++;
+                        break done;
+                    case ']':
+                        __index++;
+                        doStop = true;
+                        break done;
+                    default:
+                        String charString = charDescription(__currentChar);
+
+                        complain(
+                                String.format("expecting a ',' or a ']', " +
+                                        " but got \nthe current character of  %s " +
+                                        " on array index of %s \n", charString, list.size())
+                        );
+                }
+            } while (this.hasMore());
+
+            if (doStop) break;
+
         } while (this.hasMore());
 
         return value;

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperLaxTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperLaxTest.groovy
@@ -84,6 +84,13 @@ class JsonSlurperLaxTest extends JsonSlurperTest {
             flag2 : false,
             strings : [we, are, string, here, us, roar],
             he said : '"fire all your guns at once baby, and explode into the night"',
+            "going deeper" : [
+                "nestedArrays", // needs comments
+                "anotherThing" // commented
+                // only one comment
+                ,
+                "a last thing" // explain that too
+            ],
             the : end
             }
         """


### PR DESCRIPTION
This fixes https://jira.codehaus.org/browse/GROOVY-7057
Currently comments in json arrays before the separating comma (',') oder the end of the array (']') throw an exception.

This fix advances the parser to the next element oder end of array while ignoring comments. 
