### PR TITLE
GROOVY-7181: Change DefaultGroovyMethods inject to avoid closure arguments mutation

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -5371,9 +5371,10 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      */
     public static <E,T, U extends T, V extends T> T inject(Iterator<E> self, U initialValue, @ClosureParams(value=FromString.class,options="U,E") Closure<V> closure) {
         T value = initialValue;
-        Object[] params = new Object[2];
         while (self.hasNext()) {
             Object item = self.next();
+
+            Object[] params = new Object[2];
             params[0] = value;
             params[1] = item;
             value = closure.call(params);
@@ -5454,9 +5455,10 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      * @since 1.5.0
      */
     public static <E, T, U extends T, V extends T> T inject(E[] self, U initialValue, @ClosureParams(value=FromString.class,options="U,E") Closure<V> closure) {
-        Object[] params = new Object[2];
         T value = initialValue;
         for (Object next : self) {
+            Object[] params = new Object[2];
+
             params[0] = value;
             params[1] = next;
             value = closure.call(params);

--- a/src/test/org/codehaus/groovy/runtime/memoize/MemoizeTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/memoize/MemoizeTest.groovy
@@ -5,7 +5,33 @@ package org.codehaus.groovy.runtime.memoize
  */
 
 public class MemoizeTest extends AbstractMemoizeTestCase {
+
     Closure buildMemoizeClosure(Closure cl) {
         cl.memoize()
+    }
+
+    void testMemoizeWithInject() {
+        int maxExecutionCount = 0
+        Closure max = { int a, int b ->
+            maxExecutionCount++
+            Math.max(a, b)
+        }.memoize()
+
+        int minExecutionCount = 0
+        Closure min = { int a, int b ->
+            minExecutionCount++
+            Math.min(a, b)
+        }.memoize()
+
+        100.times {
+            max.call(max.call(1, 2), 3)
+        }
+
+        100.times {
+            [1, 2, 3].inject(min)
+        }
+
+        assert maxExecutionCount == 2
+        assert minExecutionCount == 2
     }
 }


### PR DESCRIPTION
Change DefaultGroovyMethods inject to avoid closure arguments mutation, it creates problem currently for memoization because of Arrays.asList(Object[] params) use as key for caching value but during the iteration underlying array modified and which is breaking java.util.Map contract.
