### PR TITLE
GROOVY-7181: Change DefaultGroovyMethods inject impl. to avoid closure arguments mutation

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/memoize/Memoize.java
+++ b/src/main/org/codehaus/groovy/runtime/memoize/Memoize.java
@@ -22,6 +22,7 @@ import java.lang.ref.SoftReference;
 import java.util.Collections;
 
 import static java.util.Arrays.asList;
+import static java.util.Arrays.copyOf;
 
 /**
  * Implements memoize for Closures.
@@ -91,7 +92,8 @@ public abstract class Memoize {
      */
     private static Object generateKey(final Object[] args) {
         if (args == null) return Collections.emptyList();
-        return asList(args);
+        Object[] copyOfArgs = copyOf(args, args.length);
+        return asList(copyOfArgs);
     }
 
     /**

--- a/src/test/org/codehaus/groovy/runtime/memoize/MemoizeTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/memoize/MemoizeTest.groovy
@@ -5,7 +5,29 @@ package org.codehaus.groovy.runtime.memoize
  */
 
 public class MemoizeTest extends AbstractMemoizeTestCase {
+
     Closure buildMemoizeClosure(Closure cl) {
         cl.memoize()
+    }
+
+    void testMemoizeWithInject() {
+        int maxExecutionCount = 0
+        Closure max = { int a, int b ->
+            maxExecutionCount++
+            Math.max(a, b)
+        }.memoize()
+        int minExecutionCount = 0
+        Closure min = { int a, int b ->
+            minExecutionCount++
+            Math.min(a, b)
+        }.memoize()
+        100.times {
+            max.call(max.call(1, 2), 3)
+        }
+        100.times {
+            [1, 2, 3].inject(min)
+        }
+        assert maxExecutionCount == 2
+        assert minExecutionCount == 2
     }
 }


### PR DESCRIPTION
Change DefaultGroovyMethods inject impl. to avoid closure arguments mutation, it creates problem currently for memoization because of Arrays.asList(Object[] params) use as key for caching value but during
the iteration underlying array modified and which is breaking java.util.Map contract.
