### PR TITLE
GROOVY-7112: Correct memoization array parameter name generation

### DIFF
--- a/src/main/org/codehaus/groovy/transform/MemoizedASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/MemoizedASTTransformation.java
@@ -165,7 +165,7 @@ public class MemoizedASTTransformation extends AbstractASTTransformation {
         StringBuilder nameBuilder = new StringBuilder("memoizedMethod" + ident + "$").append(methodNode.getName());
         if (methodNode.getParameters() != null) {
             for (Parameter parameter : methodNode.getParameters()) {
-                nameBuilder.append(parameter.getType().getNameWithoutPackage());
+                nameBuilder.append(buildTypeName(parameter.getType()));
             }
         }
         while (owner.getField(nameBuilder.toString()) != null) {
@@ -173,6 +173,13 @@ public class MemoizedASTTransformation extends AbstractASTTransformation {
         }
 
         return nameBuilder.toString();
+    }
+
+    private static String buildTypeName(ClassNode type) {
+        if (type.isArray()) {
+            return String.format("%sArray", buildTypeName(type.getComponentType()));
+        }
+        return type.getNameWithoutPackage();
     }
 
 }

--- a/src/test/org/codehaus/groovy/transform/MemoizedASTTransformationTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/MemoizedASTTransformationTest.groovy
@@ -144,6 +144,16 @@ class MemoizedASTTransformationTest extends GroovyTestCase {
         assertEquals(ins.methodWithoutParams(), 123)
     }
 
+    void testVarargsMemoizedMethod() {
+        def ins = new MemoizedTestClassWithVarargs()
+        assertEquals(ins.getValue(12, 'foo', 'boo'), 'foo')
+    }
+
+    void testMultiDimensionalArrayMemoizedMethod() {
+        def ins = new MemoizedTestClassWithMultiDimensionalArray()
+        assertEquals(ins.getValue(new String[2][2]), 'foo')
+    }
+
     // -- static methods -- //
 
     void testStaticMethodWithoutParams() {
@@ -271,6 +281,20 @@ class MemoizedTestClass {
     private static long privateStaticMethodWithParams(long n, long m) {
         privateStaticMethodWithParamsCounter++
         n - m
+    }
+}
+
+class MemoizedTestClassWithVarargs {
+    @Memoized
+    String getValue(Integer inp, ... params) {
+        'foo'
+    }
+}
+
+class MemoizedTestClassWithMultiDimensionalArray {
+    @Memoized
+    String getValue(Object[][] params) {
+        'foo'
     }
 }
 


### PR DESCRIPTION
For class/interface arrays java type name generated using following encoding: 'Lclassname;', now for arrays using componentType.class + 'Array'
