### PR TITLE
make null.iterator() throw a NPE

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/NullObject.java
+++ b/src/main/org/codehaus/groovy/runtime/NullObject.java
@@ -105,7 +105,7 @@ public class NullObject extends GroovyObjectSupport {
      * @return an iterator for an empty list
      */
     public Iterator iterator() {
-        return Collections.EMPTY_LIST.iterator();
+        throw new NullPointerException("Cannot create Iterator for null");
     }
 
     /**

--- a/src/test/groovy/CategoryTest.groovy
+++ b/src/test/groovy/CategoryTest.groovy
@@ -140,8 +140,10 @@ class CategoryTest extends GroovyTestCase {
         // before to ensure for example indy will do the right things as well, 
         // since indy may need more than one call here.
         assertScript """
+            import org.codehaus.groovy.runtime.NullObject
             class Cat {
-              public static findAll(Integer x, Closure cl) {1}   
+              public static findAll(Integer x, Closure cl) {1}
+              public static findAll(NullObject x, Closure cl) {2}
             }
 
              def foo(x) {
@@ -152,7 +154,7 @@ class CategoryTest extends GroovyTestCase {
                  assert foo(1) == 1
                  assert foo(1) == 1
                  assert foo(1) == 1
-                 assert foo(null) == []
+                 assert foo(null) == 2
                  assert foo(1) == 1
                  assert foo(1) == 1
                  assert foo(1) == 1

--- a/src/test/groovy/ListTest.groovy
+++ b/src/test/groovy/ListTest.groovy
@@ -214,9 +214,9 @@ class ListTest extends GroovyTestCase {
     // incorporates GROOVY-2904 and GROOVY-3102
     void testFlattenListWithSuppliedClosure() {
         def orig = [[[4, 5, 6, [46, 7, "erer"]], null, 4, [3, 6, 78]], 4]
-        def notSelfAsList = { def ans = it.iterator().toList(); ans != [it] ? ans : it }
+        def notSelfAsList = { def ans = it?.iterator()?.toList(); ans != [it] ? ans : it }
         def flat = orig.flatten(notSelfAsList)
-        assert flat == [4, 5, 6, 46, 7, "e", "r", "e", "r", 4, 3, 6, 78, 4]
+        assert flat == [4, 5, 6, 46, 7, "e", "r", "e", "r", null, 4, 3, 6, 78, 4]
     }
 
     void testFlattenListOfMapsWithClosure() {

--- a/src/test/org/codehaus/groovy/runtime/NullObjectTest.groovy
+++ b/src/test/org/codehaus/groovy/runtime/NullObjectTest.groovy
@@ -74,6 +74,22 @@ class NullObjectTest extends GroovyTestCase {
         }
         assert a == 2
     }
+
+    void testIterator() {
+        shouldFail (NullPointerException) {
+            null.iterator()
+        }
+        shouldFail (NullPointerException) {
+            null.every{}
+        }
+        shouldFail (NullPointerException) {
+            null.each{}
+        }
+        shouldFail (NullPointerException) {
+            null.findAll{}
+        }
+        assert [null].flatten() == [null]
+    }
 }
 
 class MyCategory {

--- a/subprojects/groovy-console/src/main/groovy/groovy/inspect/swingui/ScriptToTreeNodeAdapter.groovy
+++ b/subprojects/groovy-console/src/main/groovy/groovy/inspect/swingui/ScriptToTreeNodeAdapter.groovy
@@ -642,7 +642,7 @@ class TreeNodeBuildingNodeOperation extends PrimaryClassNodeOperation {
     }
 
     protected void visitListOfExpressions(List<? extends Expression> list) {
-        list.each { Expression node ->
+        list?.each { Expression node ->
             if (node instanceof NamedArgumentListExpression ) {
                 addNode(node, NamedArgumentListExpression, { it.visit(this) })
             } else {

--- a/subprojects/groovy-jmx/src/main/groovy/groovy/jmx/builder/JmxBeanInfoManager.groovy
+++ b/subprojects/groovy-jmx/src/main/groovy/groovy/jmx/builder/JmxBeanInfoManager.groovy
@@ -60,7 +60,7 @@ class JmxBeanInfoManager {
         def operations = JmxOperationInfoManager.getOperationInfosFromMap(map.operations) ?: []
 
         //generate setters/getters operations for found attribs
-        attributes.each {info ->
+        attributes?.each {info ->
             MetaProperty prop = object.metaClass.getMetaProperty(JmxBuilderTools.uncapitalize(info.name))
             if (prop && info.isReadable()) {
                 operations << JmxOperationInfoManager.createGetterOperationInfoFromProperty(prop)

--- a/subprojects/groovy-jmx/src/main/groovy/groovy/jmx/builder/JmxEmitterFactory.groovy
+++ b/subprojects/groovy-jmx/src/main/groovy/groovy/jmx/builder/JmxEmitterFactory.groovy
@@ -69,7 +69,7 @@ class JmxEmitterFactory extends AbstractFactory {
             throw new JmxBuilderException("Listeners must be provided as a list [listener1,...,listenerN]")
         }
 
-        listeners.each {l ->
+        listeners?.each {l ->
             def listener = l
             try {
                 if (listener instanceof String) {

--- a/subprojects/groovy-swing/src/main/groovy/groovy/swing/SwingBuilder.groovy
+++ b/subprojects/groovy-swing/src/main/groovy/groovy/swing/SwingBuilder.groovy
@@ -500,7 +500,7 @@ public class SwingBuilder extends FactoryBuilderSupport {
 
     public static clientPropertyAttributeDelegate(def builder, def node, def attributes) {
         def clientPropertyMap = attributes.remove("clientProperties")
-        clientPropertyMap.each { key, value ->
+        clientPropertyMap?.each { key, value ->
            node.putClientProperty key, value
         }
         attributes.findAll { it.key =~ /clientProperty(\w)/ }.each { key, value ->


### PR DESCRIPTION
This is a pullrequest to show case the changes required to groovy-core if null.iterator() is supposed to throw a NPE. This is not thought as contribution for Groovy 2.4, more as a base of discussion. While this pull request goes by changing the places where the possibly null valued collections are used, a possible other solution is to change all groovy-core Object methods, that use iterator to know about null. 
