### PR TITLE
GROOVY-7043: Correctly handle DefaultTypeTransformation#compareToWithEqualityCheck() method arguments if both are instance of CharSequence

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/typehandling/DefaultTypeTransformation.java
+++ b/src/main/org/codehaus/groovy/runtime/typehandling/DefaultTypeTransformation.java
@@ -575,8 +575,8 @@ public class DefaultTypeTransformation {
             else if (left instanceof String && right instanceof Character) {
                 return ((String) left).compareTo(right.toString());
             }
-            else if (left instanceof String && right instanceof GString) {
-                return ((String) left).compareTo(right.toString());
+            else if (left instanceof CharSequence && right instanceof CharSequence) {
+                return (left.toString()).compareTo(right.toString());
             }
             if (!equalityCheckOnly || left.getClass().isAssignableFrom(right.getClass())
                     || (right.getClass() != Object.class && right.getClass().isAssignableFrom(left.getClass())) //GROOVY-4046

--- a/src/test/groovy/GStringTest.groovy
+++ b/src/test/groovy/GStringTest.groovy
@@ -37,6 +37,18 @@ class GStringTest extends GroovyTestCase {
         assert 'FooBar' == g
     }
 
+    void testGStringTransitive() {
+        def w = 'world'
+        def str1 = "Hello $w"
+        str1 += "!"
+        def str2 = "Hello $w!"
+        def str3 = 'Hello world!'
+
+        assert str1 == str3
+        assert str2 == str3
+        assert str1 == str2
+    }
+
     void testWithOneVariable() {
         def name = "Bob"
         def teststr = "hello Bob how are you?"


### PR DESCRIPTION
If for org.codehaus.groovy.runtime.typehandling.DefaultTypeTransformation#compareToWithEqualityCheck method call both arguments are instance of CharSequence then compare them using left.toString().compareTo(right.toString())
