### PR TITLE
Class section in the documentation

### DIFF
--- a/src/spec/doc/core-object-orientation.adoc
+++ b/src/spec/doc/core-object-orientation.adoc
@@ -28,7 +28,7 @@ include::{projectdir}/src/spec/test/ClassTest.groovy[tags=class_definition,inden
 <3> method definition
 
 
-==== Normal class (MichaelSchuenck)
+==== Normal class
 
 Normal classes refer to classes which are top level and concrete. This means they can be instantiated whithout restrictions from any other classes or scripts. This way, they can only be public (even though the `public` keyword may be supressed). Classes are instantiated by calling their constructors, using the `new` keywork.
 
@@ -37,12 +37,47 @@ Normal classes refer to classes which are top level and concrete. This means the
 include::{projectdir}/src/spec/test/ClassTest.groovy[tags=class_instantiation,indent=0]
 ----
 
-==== Static class (MichaelSchuenck)
+==== Inner class
 
-If a class contains only static members (fields
+Inner classes are defined within another classes. The enclosing class can use the inner class as usual. On the other side, an inner class have the power to access members of its enclosing class, even if they are private. Here is an example:
 
-==== Inner class (MichaelSchuenck)
+[source,groovy]
+----
+include::{projectdir}/src/spec/test/ClassTest.groovy[tags=inner_class,indent=0]
+----
+<1> the inner class is instantiated and its method gets called
+<2> inner class definition, inside its enclosing class
+<3> a private field of the enclosing class is accessed
+
+There are some reasons for using inner classes:
+
+ * They increase encapsulation by hiding the inner class from other classes, which does not need to know about it. This also leads to cleaner packages and workspaces.
+ * They provide a good organization, by grouping classes that are used by only one class.
+ * They lead to more mantainable codes, since inner classes are near the classes that use them.
+
+In several cases, inner classes are implementation of interfaces whose methods are needed by the outer class. The code below illustrates this.
+
+[source,groovy]
+----
+include::{projectdir}/src/spec/test/ClassTest.groovy[tags=inner_class2,indent=0]
+----
+
+Note that the class `Inner2` is defined whith the only purpose of providing an implementation of the method `run` to class `Outer2`. Anonymous inner classes help to eliminate verbosity in this case.
+
+
 ===== Anonymous inner class (MichaelSchuenck)
+
+The last example of inner class can be simplified with an anonymous inner class. The same functionality can be achieved with the following code.
+
+[source,groovy]
+----
+include::{projectdir}/src/spec/test/ClassTest.groovy[tags=anonymous_inner_class,indent=0]
+----
+<1> comparing with the last example of previous section, the `new Inner2()` was replaced by `new Runnable()` along with all its implementation.
+<2> the method `start` is invoked normally.
+
+Thus, there was no need to define a new class to be used just once.
+
 ==== Abstract class (MichaelSchuenck)
 
 === Interface (TBD)

--- a/src/spec/doc/core-object-orientation.adoc
+++ b/src/spec/doc/core-object-orientation.adoc
@@ -10,9 +10,9 @@ This chapter covers the object orientation of the Groovy programming language.
 
 Groovy classes are very similar to Java classes, being compatible to those ones at JVM level. They may have methods and fields/properties, which can have the same modifiers (public, protected, private, static, etc) as Java classes.
 
-Here are key differences between Groovy and Java classes:
+Here are key aspects of Groovy classes, that are different from their Java counterparts:
 
- * Fields are turned into properties automatically, which results in less verbose codes, whithout so many getters and setter methods. More on this aspect will be covered in the Section "Fields and properties".
+ * Public fields are turned into properties automatically, which results in less verbose codes, whithout so many getter and setter methods. More on this aspect will be covered in the Section "Fields and properties".
  * Their declarations and any property or method without an access modifier are public.
  * Classes do not need to have the same name of the files where they are defined.
  * One file may contain one or more classes (but if a file contains no classes, it is considered a script).
@@ -23,14 +23,14 @@ The following code presents an example class.
 ----
 include::{projectdir}/src/spec/test/ClassTest.groovy[tags=class_definition,indent=0]
 ----
-<1> class opening, with the name `Person`
+<1> class beginning, with the name `Person`
 <2> string field and property named `name`
 <3> method definition
 
 
 ==== Normal class
 
-Normal classes refer to classes which are top level and concrete. This means they can be instantiated whithout restrictions from any other classes or scripts. This way, they can only be public (even though the `public` keyword may be supressed). Classes are instantiated by calling their constructors, using the `new` keywork.
+Normal classes refer to classes which are top level and concrete. This means they can be instantiated whithout restrictions from any other classes or scripts. This way, they can only be public (even though the `public` keyword may be supressed). Classes are instantiated by calling their constructors, using the `new` keywork, as in the following snippet.
 
 [source,groovy]
 ----
@@ -40,7 +40,7 @@ include::{projectdir}/src/spec/test/ClassTest.groovy[tags=class_instantiation,in
 
 ==== Inner class
 
-Inner classes are defined within another classes. The enclosing class can use the inner class as usual. On the other side, an inner class have the power to access members of its enclosing class, even if they are private. Here is an example:
+Inner classes are defined within another classes. The enclosing class can use the inner class as usual. On the other side, an inner class have the power to access members of its enclosing class, even if they are private. Classes other than the enclosing class are not allowed to access inner classes. Here is an example:
 
 [source,groovy]
 ----
@@ -48,7 +48,7 @@ include::{projectdir}/src/spec/test/ClassTest.groovy[tags=inner_class,indent=0]
 ----
 <1> the inner class is instantiated and its method gets called
 <2> inner class definition, inside its enclosing class
-<3> a private field of the enclosing class is accessed
+<3> even being private, a field of the enclosing class is accessed by the inner class
 
 There are some reasons for using inner classes:
 
@@ -56,7 +56,7 @@ There are some reasons for using inner classes:
  * They provide a good organization, by grouping classes that are used by only one class.
  * They lead to more mantainable codes, since inner classes are near the classes that use them.
 
-In several cases, inner classes are implementation of interfaces whose methods are needed by the outer class. The code below illustrates this.
+In several cases, inner classes are implementation of interfaces whose methods are needed by the outer class. The code below illustrates this with the usage of threads, which are very common.
 
 [source,groovy]
 ----
@@ -66,7 +66,7 @@ include::{projectdir}/src/spec/test/ClassTest.groovy[tags=inner_class2,indent=0]
 Note that the class `Inner2` is defined whith the only purpose of providing an implementation of the method `run` to class `Outer2`. Anonymous inner classes help to eliminate verbosity in this case.
 
 
-===== Anonymous inner class (MichaelSchuenck)
+===== Anonymous inner class
 
 The last example of inner class can be simplified with an anonymous inner class. The same functionality can be achieved with the following code.
 
@@ -80,20 +80,18 @@ include::{projectdir}/src/spec/test/ClassTest.groovy[tags=anonymous_inner_class,
 Thus, there was no need to define a new class to be used just once.
 
 
-==== Abstract class (MichaelSchuenck)
+==== Abstract class
 
-Abstract classes represent generic concepts, thus, they cannot be instantiated, being created to be subclassed. Their members incluide fields/properties and abstract or concrete methods. Abstract methods do not have implementation.
+Abstract classes represent generic concepts, thus, they cannot be instantiated, being created to be subclassed. Their members incluide fields/properties and abstract or concrete methods. Abstract methods do not have implementation, and must be implemented by concrete subclasses.
 
 [source,groovy]
 ----
 include::{projectdir}/src/spec/test/ClassTest.groovy[tags=abstract_class,indent=0]
 ----
 <1> abstract classes must be declared with `abstract` keyword
-<2> abstract methods also must be declared with `abstract` keyword
+<2> abstract methods must also be declared with `abstract` keyword
 
-Subclasses of an abstract classes must implement all their abstract methods.
-
-Abstract classes are commonly compared to interfaces. But there are at least two important differences of choosing one or another. First, while abstract classes may contain fields/properties and concrete methods, interfaces may contain only abstract methods (method signatures). Moreover, one classe can implement several interfaces, whereas it can extend just one class, abstract or not. 
+Abstract classes are commonly compared to interfaces. But there are at least two important differences of choosing one or another. First, while abstract classes may contain fields/properties and concrete methods, interfaces may contain only abstract methods (method signatures). Moreover, one class can implement several interfaces, whereas it can extend just one class, abstract or not. 
 
 === Interface (TBD)
 

--- a/src/spec/doc/core-object-orientation.adoc
+++ b/src/spec/doc/core-object-orientation.adoc
@@ -12,7 +12,7 @@ Groovy classes are very similar to Java classes, being compatible to those ones 
 
 Here are key aspects of Groovy classes, that are different from their Java counterparts:
 
- * Public fields are turned into properties automatically, which results in less verbose codes, whithout so many getter and setter methods. More on this aspect will be covered in the Section "Fields and properties".
+ * Public fields are turned into properties automatically, which results in less verbose code, whithout so many getter and setter methods. More on this aspect will be covered in the Section "Fields and properties".
  * Their declarations and any property or method without an access modifier are public.
  * Classes do not need to have the same name of the files where they are defined.
  * One file may contain one or more classes (but if a file contains no classes, it is considered a script).
@@ -40,7 +40,7 @@ include::{projectdir}/src/spec/test/ClassTest.groovy[tags=class_instantiation,in
 
 ==== Inner class
 
-Inner classes are defined within another classes. The enclosing class can use the inner class as usual. On the other side, an inner class have the power to access members of its enclosing class, even if they are private. Classes other than the enclosing class are not allowed to access inner classes. Here is an example:
+Inner classes are defined within another classes. The enclosing class can use the inner class as usual. On the other side, a inner class can access members of its enclosing class, even if they are private. Classes other than the enclosing class are not allowed to access inner classes. Here is an example:
 
 [source,groovy]
 ----
@@ -52,7 +52,7 @@ include::{projectdir}/src/spec/test/ClassTest.groovy[tags=inner_class,indent=0]
 
 There are some reasons for using inner classes:
 
- * They increase encapsulation by hiding the inner class from other classes, which does not need to know about it. This also leads to cleaner packages and workspaces.
+ * They increase encapsulation by hiding the inner class from other classes, which do not need to know about it. This also leads to cleaner packages and workspaces.
  * They provide a good organization, by grouping classes that are used by only one class.
  * They lead to more mantainable codes, since inner classes are near the classes that use them.
 

--- a/src/spec/doc/core-object-orientation.adoc
+++ b/src/spec/doc/core-object-orientation.adoc
@@ -37,6 +37,7 @@ Normal classes refer to classes which are top level and concrete. This means the
 include::{projectdir}/src/spec/test/ClassTest.groovy[tags=class_instantiation,indent=0]
 ----
 
+
 ==== Inner class
 
 Inner classes are defined within another classes. The enclosing class can use the inner class as usual. On the other side, an inner class have the power to access members of its enclosing class, even if they are private. Here is an example:
@@ -73,12 +74,26 @@ The last example of inner class can be simplified with an anonymous inner class.
 ----
 include::{projectdir}/src/spec/test/ClassTest.groovy[tags=anonymous_inner_class,indent=0]
 ----
-<1> comparing with the last example of previous section, the `new Inner2()` was replaced by `new Runnable()` along with all its implementation.
-<2> the method `start` is invoked normally.
+<1> comparing with the last example of previous section, the `new Inner2()` was replaced by `new Runnable()` along with all its implementation
+<2> the method `start` is invoked normally
 
 Thus, there was no need to define a new class to be used just once.
 
+
 ==== Abstract class (MichaelSchuenck)
+
+Abstract classes represent generic concepts, thus, they cannot be instantiated, being created to be subclassed. Their members incluide fields/properties and abstract or concrete methods. Abstract methods do not have implementation.
+
+[source,groovy]
+----
+include::{projectdir}/src/spec/test/ClassTest.groovy[tags=abstract_class,indent=0]
+----
+<1> abstract classes must be declared with `abstract` keyword
+<2> abstract methods also must be declared with `abstract` keyword
+
+Subclasses of an abstract classes must implement all their abstract methods.
+
+Abstract classes are commonly compared to interfaces. But there are at least two important differences of choosing one or another. First, while abstract classes may contain fields/properties and concrete methods, interfaces may contain only abstract methods (method signatures). Moreover, one classe can implement several interfaces, whereas it can extend just one class, abstract or not. 
 
 === Interface (TBD)
 

--- a/src/spec/doc/core-object-orientation.adoc
+++ b/src/spec/doc/core-object-orientation.adoc
@@ -6,7 +6,15 @@ This chapter covers the object orientation of the Groovy programming language.
 
 === Primitive types (TBD)
 
-=== Class (MichaelSchuenck)
+=== Class
+
+Groovy classes are very similar to Java classes. Thus, they may have methods and fields/properties, are compatible with Java classes at JVM level, their elements can have the same modifiers (public, protected, private, static, synchronized, etc), and the imports and package declarations have the same syntax.
+
+The first difference is the verbosity eliminated by turning fields into properties automatically. More on this aspect will be presented in the Section "Fields and properties". The second difference is that any property or method without an access modifier is public.
+
+The following code presents an example class.
+
+
 ==== Normal class (MichaelSchuenck)
 ==== Static class (MichaelSchuenck)
 ==== Inner class (MichaelSchuenck)

--- a/src/spec/doc/core-object-orientation.adoc
+++ b/src/spec/doc/core-object-orientation.adoc
@@ -8,15 +8,39 @@ This chapter covers the object orientation of the Groovy programming language.
 
 === Class
 
-Groovy classes are very similar to Java classes. Thus, they may have methods and fields/properties, are compatible with Java classes at JVM level, their elements can have the same modifiers (public, protected, private, static, synchronized, etc), and the imports and package declarations have the same syntax.
+Groovy classes are very similar to Java classes, being compatible to those ones at JVM level. They may have methods and fields/properties, which can have the same modifiers (public, protected, private, static, etc) as Java classes.
 
-The first difference is the verbosity eliminated by turning fields into properties automatically. More on this aspect will be presented in the Section "Fields and properties". The second difference is that any property or method without an access modifier is public.
+Here are key differences between Groovy and Java classes:
+
+ * Fields are turned into properties automatically, which results in less verbose codes, whithout so many getters and setter methods. More on this aspect will be covered in the Section "Fields and properties".
+ * Their declarations and any property or method without an access modifier are public.
+ * Classes do not need to have the same name of the files where they are defined.
+ * One file may contain one or more classes (but if a file contains no classes, it is considered a script).
 
 The following code presents an example class.
 
+[source,groovy]
+----
+include::{projectdir}/src/spec/test/ClassTest.groovy[tags=class_definition,indent=0]
+----
+<1> class opening, with the name `Person`
+<2> string field and property named `name`
+<3> method definition
+
 
 ==== Normal class (MichaelSchuenck)
+
+Normal classes refer to classes which are top level and concrete. This means they can be instantiated whithout restrictions from any other classes or scripts. This way, they can only be public (even though the `public` keyword may be supressed). Classes are instantiated by calling their constructors, using the `new` keywork.
+
+[source,groovy]
+----
+include::{projectdir}/src/spec/test/ClassTest.groovy[tags=class_instantiation,indent=0]
+----
+
 ==== Static class (MichaelSchuenck)
+
+If a class contains only static members (fields
+
 ==== Inner class (MichaelSchuenck)
 ===== Anonymous inner class (MichaelSchuenck)
 ==== Abstract class (MichaelSchuenck)

--- a/src/spec/test/ClassTest.groovy
+++ b/src/spec/test/ClassTest.groovy
@@ -27,7 +27,7 @@ class Outer {
 
     class Inner {                   //<2>
         def methodA() {
-            return "${privateStr}." //<3>
+            println "${privateStr}." //<3>
         }
     }
 }

--- a/src/spec/test/ClassTest.groovy
+++ b/src/spec/test/ClassTest.groovy
@@ -63,6 +63,19 @@ class Outer3 {
 }
 // end::anonymous_inner_class[]
 
+// tag::abstract_class[]
+abstract class Abstract {         //<1>
+    String name
+
+    abstract def abstractMethod() //<2>
+
+    def concreteMethod() {
+        println 'concrete'
+    }
+}
+// end::abstract_class[]
+
+
 assert p != null
 '''
     }

--- a/src/spec/test/ClassTest.groovy
+++ b/src/spec/test/ClassTest.groovy
@@ -17,6 +17,52 @@ class Person {                       //<1>
 def p = new Person()
 // end::class_instantiation[]
 
+// tag::inner_class[]
+class Outer {
+    private String privateStr
+
+    def callInnerMethod() {
+        new Inner().methodA()       //<1>
+    }
+
+    class Inner {                   //<2>
+        def methodA() {
+            return "${privateStr}." //<3>
+        }
+    }
+}
+// end::inner_class[]
+
+// tag::inner_class2[]
+class Outer2 {
+    private String privateStr = 'some string'
+
+    def startThread() {
+       new Thread(new Inner2()).start()
+    }
+
+    class Inner2 implements Runnable {
+        void run() {
+            println "${privateStr}."
+        }
+    }
+}
+// end::inner_class2[]
+
+// tag::anonymous_inner_class[]
+class Outer3 {
+    private String privateStr = 'some string'
+
+    def startThread() {
+        new Thread(new Runnable() {      //<1>
+            void run() {
+                println "${privateStr}."
+            }
+        }).start()                       //<2>
+    }
+}
+// end::anonymous_inner_class[]
+
 assert p != null
 '''
     }

--- a/src/spec/test/ClassTest.groovy
+++ b/src/spec/test/ClassTest.groovy
@@ -1,0 +1,23 @@
+class ClassTest extends GroovyTestCase {
+
+    void testClass() {
+        assertScript '''// tag::class_definition[]
+class Person {                       //<1>
+
+    String name                      //<2>
+    Integer age
+
+    def increaseAge(Integer years) { //<3>
+        this.age += years
+    }
+}
+// end::class_definition[]
+
+// tag::class_instantiation[]
+def p = new Person()
+// end::class_instantiation[]
+
+assert p != null
+'''
+    }
+}


### PR DESCRIPTION
Since the keyword 'static' is no longer available for classes, I supressed the 'Static class' section. As far as I know, the closest construct to static class is class with all members static, which I don't think deserves a specific section.