### PR TITLE
GROOVY-7083: PermGen memory leak in ConfigSlurper.parse(Script script, U...

### DIFF
--- a/src/main/groovy/util/ConfigSlurper.groovy
+++ b/src/main/groovy/util/ConfigSlurper.groovy
@@ -284,6 +284,8 @@ class ConfigSlurper {
         script.run()
 
         config.merge(overrides)
+        
+        GroovySystem.metaClassRegistry.removeMetaClass(script.class)
 
         return config
     }


### PR DESCRIPTION
...RL location)

Remove the meta class of the compiled config script class after parsing.

 I created a pull request out of Marcin Erdmanns suggestion in the jira ticket