### PR TITLE
GROOVY-1628: Final variable inference

### DIFF
--- a/src/main/org/codehaus/groovy/classgen/FinalVariableAnalyzer.java
+++ b/src/main/org/codehaus/groovy/classgen/FinalVariableAnalyzer.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2003-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.groovy.classgen;
+
+import org.codehaus.groovy.ast.ClassCodeVisitorSupport;
+import org.codehaus.groovy.ast.Parameter;
+import org.codehaus.groovy.ast.Variable;
+import org.codehaus.groovy.ast.expr.BinaryExpression;
+import org.codehaus.groovy.ast.expr.DeclarationExpression;
+import org.codehaus.groovy.ast.expr.EmptyExpression;
+import org.codehaus.groovy.ast.expr.Expression;
+import org.codehaus.groovy.ast.expr.VariableExpression;
+import org.codehaus.groovy.control.SourceUnit;
+import org.codehaus.groovy.transform.stc.StaticTypeCheckingSupport;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class FinalVariableAnalyzer extends ClassCodeVisitorSupport {
+
+    private final SourceUnit sourceUnit;
+
+    private static enum VariableState {
+        is_uninitialized,
+        is_final,
+        is_var;
+
+        public VariableState getNext() {
+            switch (this) {
+                case is_uninitialized: return is_final;
+                default:
+                    return is_var;
+            }
+        }
+
+        public boolean isFinal() {
+            return this == is_final || this == is_uninitialized;
+        }
+    }
+
+    private final Map<Variable, VariableState> assignmentCount = new HashMap<Variable, VariableState>();
+
+    public FinalVariableAnalyzer(final SourceUnit sourceUnit) {
+        this.sourceUnit = sourceUnit;
+    }
+
+    @Override
+    protected SourceUnit getSourceUnit() {
+        return sourceUnit;
+    }
+
+    public boolean isEffectivelyFinal(Variable v) {
+        if (v instanceof VariableExpression) {
+            v = ((VariableExpression) v).getAccessedVariable();
+        }
+        VariableState state = assignmentCount.get(v);
+        return state == null || state.isFinal();
+    }
+
+    @Override
+    public void visitBinaryExpression(final BinaryExpression expression) {
+        super.visitBinaryExpression(expression);
+        if (StaticTypeCheckingSupport.isAssignment(expression.getOperation().getType())) {
+            Expression leftExpression = expression.getLeftExpression();
+            if (leftExpression instanceof Variable) {
+                boolean isDeclaration = expression instanceof DeclarationExpression;
+                boolean uninitialized =
+                        isDeclaration &&
+                        expression.getRightExpression() == EmptyExpression.INSTANCE;
+                recordAssignment((Variable) leftExpression, isDeclaration, uninitialized);
+                if (leftExpression instanceof VariableExpression) {
+                    Variable accessed = ((VariableExpression) leftExpression).getAccessedVariable();
+                    if (accessed!=leftExpression) {
+                        recordAssignment(accessed, isDeclaration, uninitialized);
+                    }
+                }
+            }
+        }
+    }
+
+    private void recordAssignment(final Variable var, boolean isDeclaration, boolean uninitialized) {
+        if (!isDeclaration && var.isClosureSharedVariable()) {
+            assignmentCount.put(var, VariableState.is_var);
+        }
+        VariableState count = assignmentCount.get(var);
+        if (count==null) {
+            count = uninitialized?VariableState.is_uninitialized:VariableState.is_final;
+            if (var instanceof Parameter) {
+                count = VariableState.is_var;
+            }
+            assignmentCount.put(var, count);
+        } else {
+            assignmentCount.put(var, count.getNext());
+        }
+    }
+}

--- a/src/main/org/codehaus/groovy/classgen/FinalVariableAnalyzer.java
+++ b/src/main/org/codehaus/groovy/classgen/FinalVariableAnalyzer.java
@@ -118,11 +118,9 @@ public class FinalVariableAnalyzer extends ClassCodeVisitorSupport {
     }
 
     public boolean isEffectivelyFinal(Variable v) {
-        if (v instanceof VariableExpression) {
-            v = ((VariableExpression) v).getAccessedVariable();
-        }
         VariableState state = getState().get(v);
-        return state == null || state.isFinal();
+        return (v instanceof Parameter && state == null)
+                || (state != null && state.isFinal());
     }
 
     @Override

--- a/src/main/org/codehaus/groovy/classgen/Verifier.java
+++ b/src/main/org/codehaus/groovy/classgen/Verifier.java
@@ -202,6 +202,27 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
         node.visitContents(this);
         checkForDuplicateMethods(node);
         addCovariantMethods(node);
+
+        checkFinalVariables(node);
+    }
+
+    private void checkFinalVariables(ClassNode node) {
+        FinalVariableAnalyzer analyzer = new FinalVariableAnalyzer(null, new FinalVariableAnalyzer.VariableNotFinalCallback() {
+            @Override
+            public void variableNotFinal(Variable var, BinaryExpression bexp) {
+                if (var instanceof VariableExpression) {
+                    var = ((VariableExpression) var).getAccessedVariable();
+                }
+                if (var instanceof VariableExpression && Modifier.isFinal(var.getModifiers())) {
+                    throw new RuntimeParserException("The variable ["+var.getName()+"] is declared final but is reassigned",bexp);
+                }
+                if (var instanceof Parameter && Modifier.isFinal(var.getModifiers())) {
+                    throw new RuntimeParserException("The parameter ["+var.getName()+"] is declared final but is reassigned",bexp);
+                }
+            }
+        });
+        analyzer.visitClass(node);
+
     }
 
     private void checkForDuplicateMethods(ClassNode cn) {

--- a/src/main/org/codehaus/groovy/classgen/Verifier.java
+++ b/src/main/org/codehaus/groovy/classgen/Verifier.java
@@ -207,7 +207,13 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
     }
 
     private void checkFinalVariables(ClassNode node) {
-        FinalVariableAnalyzer analyzer = new FinalVariableAnalyzer(null, new FinalVariableAnalyzer.VariableNotFinalCallback() {
+        FinalVariableAnalyzer analyzer = new FinalVariableAnalyzer(null, getFinalVariablesCallback());
+        analyzer.visitClass(node);
+
+    }
+
+    protected FinalVariableAnalyzer.VariableNotFinalCallback getFinalVariablesCallback() {
+        return new FinalVariableAnalyzer.VariableNotFinalCallback() {
             @Override
             public void variableNotFinal(Variable var, Expression bexp) {
                 if (var instanceof VariableExpression) {
@@ -225,9 +231,7 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
             public void variableNotAlwaysInitialized(final VariableExpression var) {
                 throw new RuntimeParserException("The variable ["+var.getName()+"] may be uninitialized", var);
             }
-        });
-        analyzer.visitClass(node);
-
+        };
     }
 
     private void checkForDuplicateMethods(ClassNode cn) {

--- a/src/main/org/codehaus/groovy/classgen/Verifier.java
+++ b/src/main/org/codehaus/groovy/classgen/Verifier.java
@@ -220,6 +220,11 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
                     throw new RuntimeParserException("The parameter ["+var.getName()+"] is declared final but is reassigned",bexp);
                 }
             }
+
+            @Override
+            public void variableNotAlwaysInitialized(final VariableExpression var) {
+                throw new RuntimeParserException("The variable ["+var.getName()+"] may be uninitialized", var);
+            }
         });
         analyzer.visitClass(node);
 

--- a/src/main/org/codehaus/groovy/classgen/Verifier.java
+++ b/src/main/org/codehaus/groovy/classgen/Verifier.java
@@ -209,7 +209,7 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
     private void checkFinalVariables(ClassNode node) {
         FinalVariableAnalyzer analyzer = new FinalVariableAnalyzer(null, new FinalVariableAnalyzer.VariableNotFinalCallback() {
             @Override
-            public void variableNotFinal(Variable var, BinaryExpression bexp) {
+            public void variableNotFinal(Variable var, Expression bexp) {
                 if (var instanceof VariableExpression) {
                     var = ((VariableExpression) var).getAccessedVariable();
                 }

--- a/src/main/org/codehaus/groovy/tools/javac/JavaStubGenerator.java
+++ b/src/main/org/codehaus/groovy/tools/javac/JavaStubGenerator.java
@@ -28,6 +28,7 @@ import org.codehaus.groovy.ast.expr.ClosureExpression;
 import org.codehaus.groovy.ast.stmt.BlockStatement;
 import org.codehaus.groovy.ast.stmt.ExpressionStatement;
 import org.codehaus.groovy.ast.stmt.Statement;
+import org.codehaus.groovy.classgen.FinalVariableAnalyzer;
 import org.codehaus.groovy.classgen.Verifier;
 import org.codehaus.groovy.control.ResolveVisitor;
 import org.codehaus.groovy.tools.Utilities;
@@ -136,6 +137,11 @@ public class JavaStubGenerator {
                     List<Statement> savedStatements = new ArrayList<Statement>(node.getObjectInitializerStatements());
                     super.visitClass(node);
                     node.getObjectInitializerStatements().addAll(savedStatements);
+                }
+
+                @Override
+                protected FinalVariableAnalyzer.VariableNotFinalCallback getFinalVariablesCallback() {
+                    return null;
                 }
 
                 public void addCovariantMethods(ClassNode cn) {}

--- a/src/main/org/codehaus/groovy/transform/tailrec/AstHelper.groovy
+++ b/src/main/org/codehaus/groovy/transform/tailrec/AstHelper.groovy
@@ -46,7 +46,7 @@ class AstHelper {
 	}
 
 	static ExpressionStatement createVariableAlias(String aliasName, ClassNode variableType, String variableName ) {
-		createVariableDefinition(aliasName, variableType, varX(variableName, variableType), true)
+		createVariableDefinition(aliasName, variableType, varX(variableName, variableType))
 	}
 
     static VariableExpression createVariableReference(Map variableSpec) {

--- a/src/test/org/codehaus/groovy/classgen/FinalVariableAnalyzerTest.groovy
+++ b/src/test/org/codehaus/groovy/classgen/FinalVariableAnalyzerTest.groovy
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2003-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.codehaus.groovy.classgen
+
+import groovy.transform.CompileStatic
+import org.codehaus.groovy.ast.ClassNode
+import org.codehaus.groovy.ast.Variable
+import org.codehaus.groovy.ast.expr.VariableExpression
+import org.codehaus.groovy.control.CompilerConfiguration
+import org.codehaus.groovy.control.SourceUnit
+import org.codehaus.groovy.control.customizers.builder.CompilerCustomizationBuilder
+
+class FinalVariableAnalyzerTest extends GroovyTestCase {
+
+    protected void assertFinals(final Map<String,Boolean> expectations, final String script) throws Exception {
+        def cc = new CompilerConfiguration()
+        CompilerCustomizationBuilder.withConfig(cc) {
+            inline(phase: 'SEMANTIC_ANALYSIS') { source, context, classNode ->
+                def analyzer = new AssertionFinalVariableAnalyzer(source, expectations)
+                analyzer.visitClass(classNode)
+            }
+        }
+        def shell = new GroovyShell(cc)
+        shell.parse(script)
+    }
+
+    void testVariableShouldBeEffectivelyFinal() {
+        assertFinals x:true, 'def x = 1'
+    }
+
+    void testVariableDeclaredAsFinal() {
+        assertFinals x: true, '''
+            final x = 1
+        '''
+    }
+
+    void testReassignedVarShouldNotBeFinal() {
+        assertFinals x: false, '''
+            def x = 1
+            x = 2
+        '''
+    }
+
+    void testUnassignedVarShouldBeConsideredFinal() {
+        assertFinals x:true, '''def x'''
+    }
+
+    void testVariableReassignedInClosureShouldNotBeFinal() {
+        assertFinals x:false, '''
+            def x
+            cl = { x=1 }
+            cl()
+        '''
+    }
+
+    void testVariableNotReassignedInClosureShouldBeFinal() {
+        assertFinals x:true, '''
+            def x = 1
+            cl = { x }
+            cl()
+        '''
+    }
+
+    void testVariableInitializedInTwoStepsShouldBeFinal() {
+        assertFinals x:true, '''
+            def x
+            x=1
+        '''
+    }
+
+    void testVariableDeclaredInsideClosureShouldBeFinal() {
+        assertFinals x:true, '''
+            def cl = { def x = 1 }
+        '''
+    }
+
+    void testParameterShouldBeConsideredFinal() {
+        assertFinals x:true, '''
+            def foo(int x) { x+1 }
+       '''
+    }
+
+    void testParameterShouldNotBeConsideredFinal() {
+        assertFinals x:false, '''
+            def foo(int x) { x = x+1 }
+       '''
+    }
+
+    void testPlusEqualsShouldBeConsideredNotFinal() {
+        assertFinals x:false, '''
+            final x = []
+            x += [1]
+        '''
+    }
+
+    @CompileStatic
+    private static class AssertionFinalVariableAnalyzer extends FinalVariableAnalyzer {
+
+        private final Set<Variable> variablesToCheck = []
+        private final Map<String,Boolean> assertionsToCheck
+
+        AssertionFinalVariableAnalyzer(final SourceUnit sourceUnit, final Map<String,Boolean> assertions) {
+            super(sourceUnit)
+            assertionsToCheck = assertions
+        }
+
+        @Override
+        void visitVariableExpression(final VariableExpression expression) {
+            super.visitVariableExpression(expression)
+            if (assertionsToCheck.containsKey(expression.name)) {
+                variablesToCheck << expression
+                variablesToCheck << expression.accessedVariable
+            }
+        }
+
+        @Override
+        void visitClass(final ClassNode node) {
+            super.visitClass(node)
+            checkAssertions()
+        }
+
+        private void checkAssertions() {
+            variablesToCheck.each { var ->
+                def expectedValue = assertionsToCheck[var.name]
+                assert isEffectivelyFinal(var) == expectedValue
+            }
+        }
+    }
+}

--- a/src/test/org/codehaus/groovy/classgen/FinalVariableAnalyzerTest.groovy
+++ b/src/test/org/codehaus/groovy/classgen/FinalVariableAnalyzerTest.groovy
@@ -201,6 +201,32 @@ class FinalVariableAnalyzerTest extends GroovyTestCase {
         '''
     }
 
+    void testPrePostfixShouldMakeVarNotFinal() {
+        assertFinals x:false, y:false, z:false, o:false, '''
+            def x = 0
+            def y = 0
+            def z = 0
+            def o = 0
+            x++
+            ++y
+            z--
+            --o
+        '''
+    }
+
+    void testPrePostfixShouldMakeUninitializedVarNotFinal() {
+        assertFinals x:false, y:false, z:false, o:false, '''
+            def x
+            def y
+            def z
+            def o
+            x++
+            ++y
+            z--
+            --o
+        '''
+    }
+
     @CompileStatic
     private static class AssertionFinalVariableAnalyzer extends FinalVariableAnalyzer {
 

--- a/src/test/org/codehaus/groovy/classgen/FinalVariableAnalyzerTest.groovy
+++ b/src/test/org/codehaus/groovy/classgen/FinalVariableAnalyzerTest.groovy
@@ -130,6 +130,77 @@ class FinalVariableAnalyzerTest extends GroovyTestCase {
         ''')
     }
 
+    void testFinalVariableAssignedInIfBranchesShouldStillBeFinal() {
+        assertFinals x:true,'''
+            int x
+            if (t) {
+                x = 1
+            }
+        '''
+    }
+
+    void testFinalVariableAssignedInElseBranchesShouldStillBeFinal() {
+        assertFinals x:true,'''
+            int x
+            if (t) {
+                // nothing
+            } else {
+                x = 1
+            }
+        '''
+    }
+
+    void testFinalVariableAssignedInIfElseBranchesShouldStillBeFinal() {
+        assertFinals x:true,'''
+            int x
+            if (t) {
+                x = 1
+            } else {
+                x = 2
+            }
+        '''
+    }
+
+    void testFinalVariableAssignedInIfElseBranchesShouldNotBeFinal() {
+        assertFinals x:false,'''
+            int x
+            if (t) {
+                x = 1
+                x = 2
+            } else {
+                x = 2
+            }
+        '''
+    }
+
+    void testFinalVariableAssignedInIfElseBranchesShouldNotBeFinal2() {
+        assertFinals x:false,'''
+            int x
+            if (t) {
+                x = 1
+            } else {
+                x = 1
+                x = 2
+            }
+        '''
+    }
+
+    void testNestedIfShouldNotBeFinal() {
+        assertFinals x:false,'''
+            int x
+            if (t1) {
+                if (t2) {
+                    x = 1
+                }
+            }
+            if (t2) {
+                if (t3) {
+                    x = 1
+                }
+            }
+        '''
+    }
+
     @CompileStatic
     private static class AssertionFinalVariableAnalyzer extends FinalVariableAnalyzer {
 

--- a/src/test/org/codehaus/groovy/classgen/FinalVariableAnalyzerTest.groovy
+++ b/src/test/org/codehaus/groovy/classgen/FinalVariableAnalyzerTest.groovy
@@ -227,6 +227,16 @@ class FinalVariableAnalyzerTest extends GroovyTestCase {
         '''
     }
 
+    void testAssignmentInIfBooleanExpressionShouldFailCompilation() {
+        assertFinalCompilationErrors(['a'], '''
+            final a = 3
+
+            if ((a = 4) == 4) {
+              assert a == 3
+            }
+        ''')
+    }
+
     @CompileStatic
     private static class AssertionFinalVariableAnalyzer extends FinalVariableAnalyzer {
 

--- a/src/test/org/codehaus/groovy/classgen/FinalVariableAnalyzerTest.groovy
+++ b/src/test/org/codehaus/groovy/classgen/FinalVariableAnalyzerTest.groovy
@@ -316,6 +316,20 @@ class FinalVariableAnalyzerTest extends GroovyTestCase {
         ''', true)
     }
 
+    void testShouldNotSayThatListIsNotInitialized() {
+        assertScript '''
+                final List<String> list = ['a','b'].collect { it.toUpperCase() }
+                def result
+                if (true) {
+                    result = list[0]
+                } else {
+                    result = list[1]
+                }
+                result
+
+        '''
+    }
+
     @CompileStatic
     private static class AssertionFinalVariableAnalyzer extends FinalVariableAnalyzer {
 

--- a/src/test/org/codehaus/groovy/transform/tailrec/RecursiveListExamples.groovy
+++ b/src/test/org/codehaus/groovy/transform/tailrec/RecursiveListExamples.groovy
@@ -87,7 +87,7 @@ class RecursiveList {
     static int count(Map rlist, int result = 0) {
         if (!rlist)
             return result
-        count(tail(rlist), ++result)
+        count(tail(rlist), result+1)
     }
 
     @TailRecursive

--- a/src/test/org/codehaus/groovy/transform/tailrec/TailRecursiveExamples.groovy
+++ b/src/test/org/codehaus/groovy/transform/tailrec/TailRecursiveExamples.groovy
@@ -114,7 +114,7 @@ class DynamicTargetClass {
     def stringSize(aString, int size = 0) {
         if (!aString)
             return size
-        stringSize(aString.substring(1), ++size)
+        stringSize(aString.substring(1), 1+size)
     }
 
     @TailRecursive

--- a/src/test/org/codehaus/groovy/transform/tailrec/TailRecursiveTransformationTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/tailrec/TailRecursiveTransformationTest.groovy
@@ -226,7 +226,7 @@ class TailRecursiveTransformationTest extends GroovyShellTestCase {
 				@TailRecursive
 				int stringSize(String s, int size = 0) {
 				    if (s)
-				        return stringSize(s.substring(1), ++size)
+				        return stringSize(s.substring(1), 1+size)
 				    return size
 				}
 			}
@@ -246,7 +246,7 @@ class TailRecursiveTransformationTest extends GroovyShellTestCase {
 				int stringSize(String s, int size = 0) {
 				    if (!s)
 				        return size
-				    return stringSize(s.substring(1), ++size)
+				    return stringSize(s.substring(1), 1+size)
 				}
 			}
 			new TargetClass()

--- a/subprojects/groovy-nio/src/test/groovy/org/codehaus/groovy/runtime/NioGroovyMethodsTest.groovy
+++ b/subprojects/groovy-nio/src/test/groovy/org/codehaus/groovy/runtime/NioGroovyMethodsTest.groovy
@@ -117,7 +117,7 @@ class NioGroovyMethodsTest extends Specification {
     def testNewReader() {
 
         setup:
-        final str = 'Hello world!'
+        def str = 'Hello world!'
         def file = new File('test_new_reader')
         file.text = str
 
@@ -362,10 +362,10 @@ class NioGroovyMethodsTest extends Specification {
     def testAppendUTF16LE() {
 
         setup:
-        final temp = Files.createTempDirectory('utf-test')
-        final path = temp.resolve('path_UTF-16LE.txt')
-        final file = new File( temp.toFile(), 'file_UTF-LE.txt')
-        final HELLO = 'Hello world!'
+        def temp = Files.createTempDirectory('utf-test')
+        def path = temp.resolve('path_UTF-16LE.txt')
+        def file = new File( temp.toFile(), 'file_UTF-LE.txt')
+        def HELLO = 'Hello world!'
 
         // save using a File, thus uses ResourcesGroovyMethods
         when:
@@ -395,9 +395,9 @@ class NioGroovyMethodsTest extends Specification {
     def testWriteUTF16BE() {
 
         setup:
-        final temp = Files.createTempDirectory('utf-test')
-        final path = temp.resolve('path_UTF-16BE.txt')
-        final HELLO = 'Hello world!'
+        def temp = Files.createTempDirectory('utf-test')
+        def path = temp.resolve('path_UTF-16BE.txt')
+        def HELLO = 'Hello world!'
 
         when:
         path.write(HELLO, 'UTF-16BE')
@@ -412,7 +412,7 @@ class NioGroovyMethodsTest extends Specification {
     def testWithCloseable() {
 
         setup:
-        final closeable = new DummyCloseable()
+        def closeable = new DummyCloseable()
 
         when:
         def closeableParam = null
@@ -430,7 +430,7 @@ class NioGroovyMethodsTest extends Specification {
     def testWithCloseableAndException() {
 
         setup:
-        final closeable = new ExceptionDummyCloseable()
+        def closeable = new ExceptionDummyCloseable()
 
         when:
         closeable.close()


### PR DESCRIPTION
This PR should not be merged as is because work is incomplete. It is intended to start the discussion. The idea is to have a visitor which performs final variable inference. That is to say that it is not only capable of checking that a final variable should not be reassigned, but also that a variable is effectively final.

The latter is important for bytecode and performance optimizations (like not wrapping closure shared variables in case they can be passed directly).