### PR TITLE
Fixes and tests for getting AST transforms relating to properties/fields to validate their includes/excludes lists.

### DIFF
--- a/src/main/groovy/transform/AutoClone.java
+++ b/src/main/groovy/transform/AutoClone.java
@@ -275,4 +275,9 @@ public @interface AutoClone {
      * Style to use when cloning.
      */
     AutoCloneStyle style() default AutoCloneStyle.CLONE;
+
+    /**
+     * Validate property/field names in excludes list actually exist.
+     */
+    boolean checkPropertyNames() default true;
 }

--- a/src/main/groovy/transform/Canonical.java
+++ b/src/main/groovy/transform/Canonical.java
@@ -126,4 +126,9 @@ public @interface Canonical {
      * the value of this attribute can be overridden within the more specific annotation.
      */
     String[] includes() default {};
+
+    /**
+     * Validate property/field names in includes or excludes list actually exist.
+     */
+    boolean checkPropertyNames() default true;
 }

--- a/src/main/groovy/transform/EqualsAndHashCode.java
+++ b/src/main/groovy/transform/EqualsAndHashCode.java
@@ -233,4 +233,9 @@ public @interface EqualsAndHashCode {
      * Generate a canEqual method to be used by equals.
      */
     boolean useCanEqual() default true;
+
+    /**
+     * Validate property/field names in includes or excludes list actually exist.
+     */
+    boolean checkPropertyNames() default true;
 }

--- a/src/main/groovy/transform/ExternalizeMethods.java
+++ b/src/main/groovy/transform/ExternalizeMethods.java
@@ -30,7 +30,7 @@ import java.lang.annotation.Target;
  * The {@code writeExternal()} method writes each property (and optionally field) of the class
  * while the {@code readExternal()} method will read each one back in the same order.
  * Properties or fields marked as {@code transient} are ignored.
- * This annotation is typically used in conjunction with the {@code @ExternalizeMethods} annotation but
+ * This annotation is typically used in conjunction with the {@code @ExternalizeVerifier} annotation but
  * most usually not directly but rather via {@code @AutoExternalizable} which is a shortcut for both annotations.
  * <p>
  * Example usage:
@@ -83,4 +83,9 @@ public @interface ExternalizeMethods {
      * Include fields as well as properties when externalizing.
      */
     boolean includeFields() default false;
+
+    /**
+     * Validate property/field names in excludes list actually exist.
+     */
+    boolean checkPropertyNames() default true;
 }

--- a/src/main/groovy/transform/ExternalizeVerifier.java
+++ b/src/main/groovy/transform/ExternalizeVerifier.java
@@ -57,4 +57,9 @@ public @interface ExternalizeVerifier {
      * but you can't turn on strict checking.
      */
     boolean checkPropertyTypes() default false;
+
+    /**
+     * Validate property/field names in excludes list actually exist.
+     */
+    boolean checkPropertyNames() default true;
 }

--- a/src/main/groovy/transform/Immutable.java
+++ b/src/main/groovy/transform/Immutable.java
@@ -199,4 +199,9 @@ public @interface Immutable {
      * @since 2.2.0
      */
     boolean copyWith() default false;
+
+    /**
+     * Validate property/field names in knownImmutables list actually exist.
+     */
+    boolean checkPropertyNames() default true;
 }

--- a/src/main/groovy/transform/Sortable.java
+++ b/src/main/groovy/transform/Sortable.java
@@ -64,4 +64,9 @@ public @interface Sortable {
      * Must not be used if 'includes' is used.
      */
     String[] excludes() default {};
+
+    /**
+     * Validate property/field names in includes or excludes list actually exist.
+     */
+    boolean checkPropertyNames() default true;
 }

--- a/src/main/groovy/transform/ToString.java
+++ b/src/main/groovy/transform/ToString.java
@@ -175,4 +175,8 @@ public @interface ToString {
      */
     boolean cache() default false;
 
+    /**
+     * Validate property/field names in includes or excludes list actually exist.
+     */
+    boolean checkPropertyNames() default true;
 }

--- a/src/main/groovy/transform/TupleConstructor.java
+++ b/src/main/groovy/transform/TupleConstructor.java
@@ -111,4 +111,9 @@ public @interface TupleConstructor {
      * whether existing constructors exist. It is up to you to avoid creating duplicate constructors.
      */
     boolean force() default false;
+
+    /**
+     * Validate property/field names in includes or excludes list actually exist.
+     */
+    boolean checkPropertyNames() default true;
 }

--- a/src/main/org/codehaus/groovy/ast/tools/GeneralUtils.java
+++ b/src/main/org/codehaus/groovy/ast/tools/GeneralUtils.java
@@ -360,12 +360,30 @@ public class GeneralUtils {
         return result;
     }
 
+    public static List<String> getInstanceNonPropertyFieldNames(ClassNode cNode) {
+        List<FieldNode> fList = getInstanceNonPropertyFields(cNode);
+        List<String> result = new ArrayList<String>(fList.size());
+        for (FieldNode fNode : fList) {
+            result.add(fNode.getName());
+        }
+        return result;
+    }
+
     public static List<PropertyNode> getInstanceProperties(ClassNode cNode) {
         final List<PropertyNode> result = new ArrayList<PropertyNode>();
         for (PropertyNode pNode : cNode.getProperties()) {
             if (!pNode.isStatic()) {
                 result.add(pNode);
             }
+        }
+        return result;
+    }
+
+    public static List<String> getInstancePropertyNames(ClassNode cNode) {
+        List<PropertyNode> pList = getInstanceProperties(cNode);
+        List<String> result = new ArrayList<String>(pList.size());
+        for (PropertyNode pNode : pList) {
+            result.add(pNode.getName());
         }
         return result;
     }

--- a/src/main/org/codehaus/groovy/transform/AbstractASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/AbstractASTTransformation.java
@@ -44,6 +44,8 @@ import java.util.List;
 import java.util.Map;
 
 import static groovy.transform.Undefined.isUndefined;
+import static org.codehaus.groovy.ast.tools.GeneralUtils.getInstanceNonPropertyFieldNames;
+import static org.codehaus.groovy.ast.tools.GeneralUtils.getInstancePropertyNames;
 
 public abstract class AbstractASTTransformation implements Opcodes, ASTTransformation {
     public static final ClassNode RETENTION_CLASSNODE = ClassHelper.makeWithoutCaching(Retention.class);
@@ -264,6 +266,32 @@ public abstract class AbstractASTTransformation implements Opcodes, ASTTransform
         if (found > 1) {
             addError("Error during " + typeName + " processing: Only one of 'includes', 'excludes', 'includeTypes' and 'excludeTypes' should be supplied.", node);
         }
+    }
+
+    protected boolean checkPropertyList(ClassNode cNode, List<String> propertyNameList, String listName, AnnotationNode anno, String typeName, boolean includeFields) {
+        if (propertyNameList == null || propertyNameList.isEmpty()) {
+            return true;
+        }
+        final List<String> pNames = getInstancePropertyNames(cNode);
+        boolean result = true;
+        if (includeFields) {
+            final List<String> fNames = getInstanceNonPropertyFieldNames(cNode);
+            for (String pName : propertyNameList) {
+                if (!pNames.contains(pName) && !fNames.contains(pName)) {
+                    addError("Error during " + typeName + " processing: '" + listName + "' property or field '" + pName + "' does not exist.", anno);
+                    result = false;
+                }
+            }
+        }
+        else {
+            for (String pName : propertyNameList) {
+                if (!pNames.contains(pName)) {
+                    addError("Error during " + typeName + " processing: '" + listName + "' property '" + pName + "' does not exist.", anno);
+                    result = false;
+                }
+            }
+        }
+        return result;
     }
 
     /**

--- a/src/main/org/codehaus/groovy/transform/AutoCloneASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/AutoCloneASTTransformation.java
@@ -81,6 +81,10 @@ public class AutoCloneASTTransformation extends AbstractASTTransformation {
             boolean includeFields = memberHasValue(anno, "includeFields", true);
             AutoCloneStyle style = getStyle(anno, "style");
             List<String> excludes = getMemberList(anno, "excludes");
+            boolean checkPropertyNames = !memberHasValue(anno, "checkPropertyNames", false);
+            if (checkPropertyNames) {
+                if (!checkPropertyList(cNode, excludes, "excludes", anno, MY_TYPE_NAME, includeFields)) return;
+            }
             List<FieldNode> list = getInstancePropertyFields(cNode);
             if (includeFields) {
                 list.addAll(getInstanceNonPropertyFields(cNode));

--- a/src/main/org/codehaus/groovy/transform/CanonicalASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/CanonicalASTTransformation.java
@@ -59,7 +59,12 @@ public class CanonicalASTTransformation extends AbstractASTTransformation {
             if (!checkNotInterface(cNode, MY_TYPE_NAME)) return;
             List<String> excludes = getMemberList(anno, "excludes");
             List<String> includes = getMemberList(anno, "includes");
+            boolean checkPropertyNames = !memberHasValue(anno, "checkPropertyNames", false);
             if (!checkIncludeExclude(anno, excludes, includes, MY_TYPE_NAME)) return;
+            if (checkPropertyNames) {
+                if (!checkPropertyList(cNode, includes, "includes", anno, MY_TYPE_NAME, false)) return;
+                if (!checkPropertyList(cNode, excludes, "excludes", anno, MY_TYPE_NAME, false)) return;
+            }
             if (!hasAnnotation(cNode, TupleConstructorASTTransformation.MY_TYPE)) {
                 createConstructor(cNode, false, true, false, false, false, false, excludes, includes);
             }

--- a/src/main/org/codehaus/groovy/transform/EqualsAndHashCodeASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/EqualsAndHashCodeASTTransformation.java
@@ -71,12 +71,17 @@ public class EqualsAndHashCodeASTTransformation extends AbstractASTTransformatio
             boolean includeFields = memberHasValue(anno, "includeFields", true);
             List<String> excludes = getMemberList(anno, "excludes");
             List<String> includes = getMemberList(anno, "includes");
+            boolean checkPropertyNames = !memberHasValue(anno, "checkPropertyNames", false);
             if (hasAnnotation(cNode, CanonicalASTTransformation.MY_TYPE)) {
                 AnnotationNode canonical = cNode.getAnnotations(CanonicalASTTransformation.MY_TYPE).get(0);
                 if (excludes == null || excludes.isEmpty()) excludes = getMemberList(canonical, "excludes");
                 if (includes == null || includes.isEmpty()) includes = getMemberList(canonical, "includes");
             }
             if (!checkIncludeExclude(anno, excludes, includes, MY_TYPE_NAME)) return;
+            if (checkPropertyNames) {
+                if (!checkPropertyList(cNode, includes, "includes", anno, MY_TYPE_NAME, includeFields)) return;
+                if (!checkPropertyList(cNode, excludes, "excludes", anno, MY_TYPE_NAME, includeFields)) return;
+            }
             createHashCode(cNode, cacheHashCode, includeFields, callSuper, excludes, includes);
             createEquals(cNode, includeFields, callSuper, useCanEqual, excludes, includes);
         }

--- a/src/main/org/codehaus/groovy/transform/ExternalizeMethodsASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/ExternalizeMethodsASTTransformation.java
@@ -72,6 +72,10 @@ public class ExternalizeMethodsASTTransformation extends AbstractASTTransformati
             cNode.addInterface(EXTERNALIZABLE_TYPE);
             boolean includeFields = memberHasValue(anno, "includeFields", true);
             List<String> excludes = getMemberList(anno, "excludes");
+            boolean checkPropertyNames = !memberHasValue(anno, "checkPropertyNames", false);
+            if (checkPropertyNames) {
+                if (!checkPropertyList(cNode, excludes, "excludes", anno, MY_TYPE_NAME, includeFields)) return;
+            }
             List<FieldNode> list = getInstancePropertyFields(cNode);
             if (includeFields) {
                 list.addAll(getInstanceNonPropertyFields(cNode));

--- a/src/main/org/codehaus/groovy/transform/ExternalizeVerifierASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/ExternalizeVerifierASTTransformation.java
@@ -60,6 +60,10 @@ public class ExternalizeVerifierASTTransformation extends AbstractASTTransformat
             boolean includeFields = memberHasValue(anno, "includeFields", true);
             boolean checkPropertyTypes = memberHasValue(anno, "checkPropertyTypes", true);
             List<String> excludes = getMemberList(anno, "excludes");
+            boolean checkPropertyNames = !memberHasValue(anno, "checkPropertyNames", false);
+            if (checkPropertyNames) {
+                if (!checkPropertyList(cNode, excludes, "excludes", anno, MY_TYPE_NAME, includeFields)) return;
+            }
             List<FieldNode> list = getInstancePropertyFields(cNode);
             if (includeFields) {
                 list.addAll(getInstanceNonPropertyFields(cNode));

--- a/src/main/org/codehaus/groovy/transform/ImmutableASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/ImmutableASTTransformation.java
@@ -139,11 +139,16 @@ public class ImmutableASTTransformation extends AbstractASTTransformation {
         if (parent instanceof ClassNode) {
             final List<String> knownImmutableClasses = getKnownImmutableClasses(node);
             final List<String> knownImmutables = getKnownImmutables(node);
+            boolean checkPropertyNames = !memberHasValue(node, "checkPropertyNames", false);
 
             ClassNode cNode = (ClassNode) parent;
             String cName = cNode.getName();
             if (!checkNotInterface(cNode, MY_TYPE_NAME)) return;
             makeClassFinal(cNode);
+
+            if (checkPropertyNames) {
+                if (!checkPropertyList(cNode, knownImmutables, "knownImmutables", node, MY_TYPE_NAME, false)) return;
+            }
 
             final List<PropertyNode> pList = getInstanceProperties(cNode);
             for (PropertyNode pNode : pList) {

--- a/src/main/org/codehaus/groovy/transform/SortableASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/SortableASTTransformation.java
@@ -200,9 +200,6 @@ public class SortableASTTransformation extends AbstractASTTransformation {
                     !includes.isEmpty() && !includes.contains(propertyName)) continue;
             properties.add(property);
         }
-//        for (String name : includes) {
-//            checkKnownProperty(annotation, name, properties);
-//        }
         for (PropertyNode pNode : properties) {
             checkComparable(pNode);
         }
@@ -225,13 +222,4 @@ public class SortableASTTransformation extends AbstractASTTransformation {
                 pNode.getName() + "' must be Comparable", pNode);
     }
 
-//    private void checkKnownProperty(AnnotationNode annotation, String name, List<PropertyNode> properties) {
-//        for (PropertyNode pNode: properties) {
-//            if (name.equals(pNode.getName())) {
-//                return;
-//            }
-//        }
-//        addError("Error during " + MY_TYPE_NAME + " processing: tried to include unknown property '" +
-//                name + "'", annotation);
-//    }
 }

--- a/src/main/org/codehaus/groovy/transform/SortableASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/SortableASTTransformation.java
@@ -79,7 +79,12 @@ public class SortableASTTransformation extends AbstractASTTransformation {
     private void createSortable(AnnotationNode annotation, ClassNode classNode) {
         List<String> includes = getMemberList(annotation, "includes");
         List<String> excludes = getMemberList(annotation, "excludes");
+        boolean checkPropertyNames = !memberHasValue(annotation, "checkPropertyNames", false);
         if (!checkIncludeExclude(annotation, excludes, includes, MY_TYPE_NAME)) return;
+        if (checkPropertyNames) {
+            if (!checkPropertyList(classNode, includes, "includes", annotation, MY_TYPE_NAME, false)) return;
+            if (!checkPropertyList(classNode, excludes, "excludes", annotation, MY_TYPE_NAME, false)) return;
+        }
         if (classNode.isInterface()) {
             addError(MY_TYPE_NAME + " cannot be applied to interface " + classNode.getName(), annotation);
         }
@@ -195,9 +200,9 @@ public class SortableASTTransformation extends AbstractASTTransformation {
                     !includes.isEmpty() && !includes.contains(propertyName)) continue;
             properties.add(property);
         }
-        for (String name : includes) {
-            checkKnownProperty(annotation, name, properties);
-        }
+//        for (String name : includes) {
+//            checkKnownProperty(annotation, name, properties);
+//        }
         for (PropertyNode pNode : properties) {
             checkComparable(pNode);
         }
@@ -220,13 +225,13 @@ public class SortableASTTransformation extends AbstractASTTransformation {
                 pNode.getName() + "' must be Comparable", pNode);
     }
 
-    private void checkKnownProperty(AnnotationNode annotation, String name, List<PropertyNode> properties) {
-        for (PropertyNode pNode: properties) {
-            if (name.equals(pNode.getName())) {
-                return;
-            }
-        }
-        addError("Error during " + MY_TYPE_NAME + " processing: tried to include unknown property '" +
-                name + "'", annotation);
-    }
+//    private void checkKnownProperty(AnnotationNode annotation, String name, List<PropertyNode> properties) {
+//        for (PropertyNode pNode: properties) {
+//            if (name.equals(pNode.getName())) {
+//                return;
+//            }
+//        }
+//        addError("Error during " + MY_TYPE_NAME + " processing: tried to include unknown property '" +
+//                name + "'", annotation);
+//    }
 }

--- a/src/main/org/codehaus/groovy/transform/ToStringASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/ToStringASTTransformation.java
@@ -96,6 +96,7 @@ public class ToStringASTTransformation extends AbstractASTTransformation {
             List<String> includes = getMemberList(anno, "includes");
             boolean ignoreNulls = memberHasValue(anno, "ignoreNulls", true);
             boolean includePackage = !memberHasValue(anno, "includePackage", false);
+            boolean checkPropertyNames = !memberHasValue(anno, "checkPropertyNames", false);
 
             if (hasAnnotation(cNode, CanonicalASTTransformation.MY_TYPE)) {
                 AnnotationNode canonical = cNode.getAnnotations(CanonicalASTTransformation.MY_TYPE).get(0);
@@ -103,6 +104,10 @@ public class ToStringASTTransformation extends AbstractASTTransformation {
                 if (includes == null || includes.isEmpty()) includes = getMemberList(canonical, "includes");
             }
             if (!checkIncludeExclude(anno, excludes, includes, MY_TYPE_NAME)) return;
+            if (checkPropertyNames) {
+                if (!checkPropertyList(cNode, includes, "includes", anno, MY_TYPE_NAME, includeFields)) return;
+                if (!checkPropertyList(cNode, excludes, "excludes", anno, MY_TYPE_NAME, includeFields)) return;
+            }
             createToString(cNode, includeSuper, includeFields, excludes, includes, includeNames, ignoreNulls, includePackage, cacheToString, includeSuperProperties);
         }
     }

--- a/src/main/org/codehaus/groovy/transform/TupleConstructorASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/TupleConstructorASTTransformation.java
@@ -107,12 +107,17 @@ public class TupleConstructorASTTransformation extends AbstractASTTransformation
             boolean force = memberHasValue(anno, "force", true);
             List<String> excludes = getMemberList(anno, "excludes");
             List<String> includes = getMemberList(anno, "includes");
+            boolean checkPropertyNames = !memberHasValue(anno, "checkPropertyNames", false);
             if (hasAnnotation(cNode, CanonicalASTTransformation.MY_TYPE)) {
                 AnnotationNode canonical = cNode.getAnnotations(CanonicalASTTransformation.MY_TYPE).get(0);
                 if (excludes == null || excludes.isEmpty()) excludes = getMemberList(canonical, "excludes");
                 if (includes == null || includes.isEmpty()) includes = getMemberList(canonical, "includes");
             }
             if (!checkIncludeExclude(anno, excludes, includes, MY_TYPE_NAME)) return;
+            if (checkPropertyNames) {
+                if (!checkPropertyList(cNode, includes, "includes", anno, MY_TYPE_NAME, includeFields)) return;
+                if (!checkPropertyList(cNode, excludes, "excludes", anno, MY_TYPE_NAME, includeFields)) return;
+            }
             createConstructor(cNode, includeFields, includeProperties, includeSuperFields, includeSuperProperties, callSuper, force, excludes, includes);
         }
     }

--- a/src/test/org/codehaus/groovy/transform/AutoCloneTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/AutoCloneTransformTest.groovy
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2008-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.groovy.transform
+
+/**
+ * @author John Hurst
+ */
+class AutoCloneTransformTest extends GroovyShellTestCase {
+
+    void testOk() {
+        assertScript """
+                import groovy.transform.AutoClone
+
+                @AutoClone
+                class Person {
+                    String first, last
+                    List favItems
+                    Date since
+                }
+
+                def p = new Person(first:'John', last:'Smith', favItems:['ipod', 'shiraz'], since:new Date())
+                def p2 = p.clone()
+
+                assert p instanceof Cloneable
+                assert p.favItems instanceof Cloneable
+                assert p.since instanceof Cloneable
+                assert !(p.first instanceof Cloneable)
+
+                assert !p.is(p2)
+                assert !p.favItems.is(p2.favItems)
+                assert !p.since.is(p2.since)
+                assert p.first.is(p2.first)
+            """
+    }
+
+    // Original behavior: If property names are not checked, and an invalid property name is given in 'excludes',
+    // the property is not excluded.
+    void testExcludesWithInvalidPropertyWithoutCheckIgnoresProperty() {
+        assertScript """
+                import groovy.transform.AutoClone
+
+                @AutoClone(excludes='sirName', checkPropertyNames=false)
+                class Person {
+                    String firstName
+                    String surName
+                }
+
+                def p = new Person(firstName: "John", surName: "Doe")
+                def p2 = p.clone()
+
+                assert p2.firstName == "John"
+                assert p2.surName == "Doe"
+            """
+    }
+
+    void testExcludesWithInvalidPropertyNameResultsInError() {
+        def message = shouldFail {
+            evaluate("""
+                    import groovy.transform.AutoClone
+
+                    @AutoClone(excludes='sirName')
+                    class Person {
+                        String firstName
+                        String surName
+                    }
+
+                    new Person(firstName: "John", surName: "Doe").clone()
+                """)
+        }
+        assert message.contains("Error during @AutoClone processing: 'excludes' property 'sirName' does not exist.")
+    }
+
+}

--- a/src/test/org/codehaus/groovy/transform/EqualsAndHashCodeTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/EqualsAndHashCodeTransformTest.groovy
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2008-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.groovy.transform
+
+/**
+ * @author John Hurst
+ */
+class EqualsAndHashCodeTransformTest extends GroovyShellTestCase {
+
+    void testOk() {
+        assertScript """
+                import groovy.transform.EqualsAndHashCode
+                @EqualsAndHashCode
+                class Person {
+                    String first, last
+                    int age
+                }
+
+                def p1 = new Person(first:'John', last:'Smith', age:21)
+                def p2 = new Person(first:'John', last:'Smith', age:21)
+                assert p1 == p2
+                def map = [:]
+                map[p1] = 45
+                assert map[p2] == 45
+            """
+    }
+
+    void testIncludesAndExcludesTogetherResultsInError() {
+        def message = shouldFail {
+            evaluate("""
+                    import groovy.transform.EqualsAndHashCode
+
+                    @EqualsAndHashCode(includes='surName', excludes='surName')
+                    class Person {
+                        String surName
+                    }
+
+                    new Person(surName: "Doe")
+                """)
+        }
+        assert message.contains("Error during @EqualsAndHashCode processing: Only one of 'includes' and 'excludes' should be supplied not both.")
+    }
+
+    // Original behavior: If property names are not checked, and an invalid property is given in 'includes',
+    // the property is not included.
+    void testIncludesWithInvalidPropertyWithoutCheckIgnoresProperty() {
+        assertScript """
+                import groovy.transform.EqualsAndHashCode
+
+                @EqualsAndHashCode(includes='sirName', checkPropertyNames=false)
+                class Person {
+                    String firstName
+                    String surName
+                }
+
+                assert new Person(firstName: "John", surName: "Doe") == new Person(firstName: "Jack", surName: "Smith")
+            """
+    }
+
+    // Original behavior: If property names are not checked, and an invalid property is given in 'excludes',
+    // the property is not excluded.
+    void testExcludesWithInvalidPropertyWithoutCheckIgnoresProperty() {
+        assertScript """
+                import groovy.transform.EqualsAndHashCode
+
+                @EqualsAndHashCode(excludes='sirName', checkPropertyNames=false)
+                class Person {
+                    String firstName
+                    String surName
+                }
+
+                assert new Person(firstName: "John", surName: "Doe") != new Person(firstName: "John", surName: "Smith")
+            """
+    }
+
+    void testIncludesWithInvalidPropertyNameResultsInError() {
+        def message = shouldFail {
+            evaluate("""
+                    import groovy.transform.EqualsAndHashCode
+
+                    @EqualsAndHashCode(includes='sirName')
+                    class Person {
+                        String surName
+                    }
+
+                    new Person(surName: "Doe")
+                """)
+        }
+        assert message.contains("Error during @EqualsAndHashCode processing: 'includes' property 'sirName' does not exist.")
+    }
+
+    void testExcludesWithInvalidPropertyNameResultsInError() {
+        def message = shouldFail {
+            evaluate("""
+                    import groovy.transform.EqualsAndHashCode
+
+                    @EqualsAndHashCode(excludes='sirName')
+                    class Person {
+                        String firstName
+                        String surName
+                    }
+
+                    new Person(firstName: "John", surName: "Doe")
+                """)
+        }
+        assert message.contains("Error during @EqualsAndHashCode processing: 'excludes' property 'sirName' does not exist.")
+    }
+
+
+}

--- a/src/test/org/codehaus/groovy/transform/ExternalizeMethodsTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/ExternalizeMethodsTransformTest.groovy
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2008-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.groovy.transform
+
+/**
+ * @author John Hurst
+ */
+class ExternalizeMethodsTransformTest extends GroovyShellTestCase {
+
+
+    void testOk() {
+        assertScript """
+                import groovy.transform.ExternalizeMethods
+                @ExternalizeMethods
+                class Person {
+                  String first, last
+                  List favItems
+                  Date since
+                }
+
+                def p = new Person(first: "John", last: "Doe", favItems: ["one", "two"], since: Date.parse("yyyy-MM-dd", "2014-12-28"))
+
+                def baos = new ByteArrayOutputStream()
+                p.writeExternal(new ObjectOutputStream(baos))
+
+                def p2 = new Person()
+                p2.readExternal(new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray())))
+
+                assert p2.first == "John"
+                assert p2.last == "Doe"
+                assert p2.favItems == ["one", "two"]
+                assert p2.since == Date.parse("yyyy-MM-dd", "2014-12-28")
+            """
+    }
+
+    // Original behavior: If property names are not checked, and an invalid property is given in 'excludes',
+    // the property is not excluded.
+    void testExcludesWithInvalidPropertyWithoutCheckIgnoresProperty() {
+        assertScript """
+                import groovy.transform.ExternalizeMethods
+
+                @ExternalizeMethods(excludes='sirName', checkPropertyNames=false)
+                class Person {
+                    String firstName
+                    String surName
+                }
+
+                def p = new Person(firstName: "John", surName: "Doe")
+
+                def baos = new ByteArrayOutputStream()
+                p.writeExternal(new ObjectOutputStream(baos))
+
+                def p2 = new Person()
+                p2.readExternal(new ObjectInputStream(new ByteArrayInputStream(baos.toByteArray())))
+
+                assert p2.firstName == "John"
+                assert p2.surName == "Doe"
+            """
+    }
+
+    void testExcludesWithInvalidPropertyNameResultsInError() {
+        def message = shouldFail {
+            evaluate("""
+                    import groovy.transform.ExternalizeMethods
+
+                    @ExternalizeMethods(excludes='sirName')
+                    class Person {
+                        String firstName
+                        String surName
+                    }
+
+                    new Person(firstName: "John", surName: "Doe")
+                """)
+        }
+        assert message.contains("Error during @ExternalizeMethods processing: 'excludes' property 'sirName' does not exist.")
+    }
+
+}

--- a/src/test/org/codehaus/groovy/transform/ExternalizeVerifierTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/ExternalizeVerifierTransformTest.groovy
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2008-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.groovy.transform
+
+/**
+ * @author John Hurst
+ */
+class ExternalizeVerifierTransformTest extends GroovyShellTestCase {
+
+    void testCheckPropertyTypes() {
+        def message = shouldFail {
+            evaluate("""
+                    import groovy.transform.ExternalizeVerifier
+
+                    class Foo {}
+
+                    @ExternalizeVerifier(checkPropertyTypes=true)
+                    class Person implements Externalizable {
+                        String firstName
+                        Foo foo
+
+                        void readExternal(ObjectInput inp) {}
+                        void writeExternal(ObjectOutput outp) {}
+                    }
+
+                    new Person()
+                """)
+        }
+        assert message.contains("@ExternalizeVerifier: strict type checking is enabled and the non-primitive property (or field) 'foo' in an Externalizable class has the type 'Foo' which isn't Externalizable or Serializable")
+    }
+
+    void testExcludes() {
+        assertScript """
+                import groovy.transform.ExternalizeVerifier
+
+                class Foo {}
+
+                @ExternalizeVerifier(excludes='foo', checkPropertyTypes=true)
+                class Person implements Externalizable {
+                    String firstName
+                    Foo foo
+
+                    void readExternal(ObjectInput inp) {}
+                    void writeExternal(ObjectOutput outp) {}
+                }
+
+                new Person()
+            """
+    }
+
+    // Original behavior: If property names are not checked, and an invalid property is given in 'excludes',
+    // the property is not excluded.
+    void testExcludesWithInvalidPropertyWithoutCheckIgnoresProperty() {
+        def message = shouldFail {
+            evaluate("""
+                    import groovy.transform.ExternalizeVerifier
+
+                    class Foo {}
+
+                    @ExternalizeVerifier(excludes='fu', checkPropertyNames=false, checkPropertyTypes=true)
+                    class Person implements Externalizable {
+                        String firstName
+                        Foo foo
+
+                        void readExternal(ObjectInput inp) {}
+                        void writeExternal(ObjectOutput outp) {}
+                    }
+
+                    new Person()
+                """)
+        }
+        assert message.contains("@ExternalizeVerifier: strict type checking is enabled and the non-primitive property (or field) 'foo' in an Externalizable class has the type 'Foo' which isn't Externalizable or Serializable")
+    }
+
+    void testExcludesWithInvalidPropertyNameResultsInError() {
+        def message = shouldFail {
+            evaluate("""
+                    import groovy.transform.ExternalizeVerifier
+
+                    @ExternalizeVerifier(excludes='sirName')
+                    class Person implements Externalizable {
+                        String firstName
+                        String surName
+
+                        void readExternal(ObjectInput inp) {}
+                        void writeExternal(ObjectOutput outp) {}
+                    }
+                """)
+        }
+        assert message.contains("Error during @ExternalizeVerifier processing: 'excludes' property 'sirName' does not exist.")
+    }
+
+}

--- a/src/test/org/codehaus/groovy/transform/ImmutableTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/ImmutableTransformTest.groovy
@@ -913,4 +913,36 @@ class ImmutableTransformTest extends GroovyShellTestCase {
         assert result.size() == 2
         assert result.first == [ 'tim', 'tim' ]
     }
+
+    // Original behavior: If property names are not checked, and an invalid property is given in 'knownImmutables',
+    // the property is ignored.
+    void testKnownImmutablesWithInvalidPropertyWithoutCheckIgnoresProperty() {
+        assertScript """
+                import groovy.transform.Immutable
+
+                @Immutable(knownImmutables=['sirName'], checkPropertyNames=false)
+                class Person {
+                    String surName
+                }
+
+                new Person(surName: "Doe")
+            """
+    }
+
+    void testKnownImmutablesWithInvalidPropertyNameResultsInError() {
+        def message = shouldFail {
+            evaluate("""
+                    import groovy.transform.Immutable
+
+                    @Immutable(knownImmutables=['sirName'])
+                    class Person {
+                        String surName
+                    }
+
+                    new Person(surName: "Doe")
+                """)
+        }
+        assert message.contains("Error during @Immutable processing: 'knownImmutables' property 'sirName' does not exist.")
+    }
+
 }

--- a/src/test/org/codehaus/groovy/transform/SortableTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/SortableTransformTest.groovy
@@ -133,7 +133,56 @@ class SortableTransformTest extends CompilableTestSupport {
               Integer born
             }
         '''
-        assert message.contains("Error during @Sortable processing: tried to include unknown property 'middle'")
+        assert message.contains("Error during @Sortable processing: 'includes' property 'middle' does not exist.")
+    }
+
+    void testBadExclude() {
+        def message = shouldFail '''
+            @groovy.transform.Sortable(excludes='first,middle') class Person {
+              String first
+              String last
+              Integer born
+            }
+        '''
+        assert message.contains("Error during @Sortable processing: 'excludes' property 'middle' does not exist.")
+    }
+
+    // If property names are not checked, and an invalid property is given in 'includes',
+    // the property is not included.
+    void testIncludesWithInvalidPropertyWithoutCheckIgnoresProperty() {
+        assertScript '''
+            @groovy.transform.Sortable(includes='first,middle', checkPropertyNames=false) class Person {
+              String first
+              String last
+              Integer born
+            }
+            def people = [
+              new Person(first: "Groovy", last: "Strachan"),
+              new Person(first: "Java", last: "Strachan"),
+              new Person(first: "Groovy", last: "McWhirter"),
+              new Person(first: "Java", last: "Gosling"),
+            ]
+            assert people.sort(false)*.first == ["Groovy", "Groovy", "Java", "Java"]
+        '''
+    }
+
+    // If property names are not checked, and an invalid property is given in 'excludes',
+    // the property is not excluded.
+    void testExcludesWithInvalidPropertyWithoutCheckIgnoresProperty() {
+        assertScript '''
+            @groovy.transform.Sortable(excludes='first,middle', checkPropertyNames=false) class Person {
+              String first
+              String last
+              Integer born
+            }
+            def people = [
+              new Person(first: "Groovy", last: "Strachan"),
+              new Person(first: "Java", last: "Strachan"),
+              new Person(first: "Groovy", last: "McWhirter"),
+              new Person(first: "Java", last: "Gosling")
+            ]
+            assert people.sort(false)*.last == ["Gosling", "McWhirter", "Strachan", "Strachan"]
+        '''
     }
 
     void testBadPropertyType() {

--- a/src/test/org/codehaus/groovy/transform/TupleConstructorTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/TupleConstructorTransformTest.groovy
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2008-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.codehaus.groovy.transform
+
+/**
+ * @author John Hurst
+ */
+class TupleConstructorTransformTest extends GroovyShellTestCase {
+
+    void testOk() {
+        assertScript """
+                import groovy.transform.TupleConstructor
+
+                @TupleConstructor
+                class Person {
+                    String firstName
+                    String lastName
+                }
+
+                def p = new Person("John", "Doe")
+                assert p.firstName == "John"
+                assert p.lastName == "Doe"
+            """
+    }
+
+    void testIncludesAndExcludesTogetherResultsInError() {
+        def message = shouldFail {
+            evaluate("""
+                    import groovy.transform.TupleConstructor
+
+                    @TupleConstructor(includes='surName', excludes='surName')
+                    class Person {
+                        String surName
+                    }
+
+                    new Person("Doe")
+                """)
+        }
+        assert message.contains("Error during @TupleConstructor processing: Only one of 'includes' and 'excludes' should be supplied not both.")
+    }
+
+    // Original behavior: If property names are not checked, and an invalid property name is given in 'includes',
+    // the property is not included.
+    void testIncludesWithInvalidPropertyWithoutCheckIgnoresProperty() {
+        assertScript """
+                import groovy.transform.TupleConstructor
+
+                @TupleConstructor(includes='sirName', checkPropertyNames=false)
+                class Person {
+                    String firstName
+                    String surName
+                }
+
+                new Person()
+            """
+    }
+
+    // Original behavior: If property names are not checked, and an invalid property is given in 'excludes',
+    // the property is not excluded.
+    void testExcludesWithInvalidPropertyWithoutCheckIgnoresProperty() {
+        assertScript """
+                import groovy.transform.TupleConstructor
+
+                @TupleConstructor(excludes='sirName', checkPropertyNames=false)
+                class Person {
+                    String firstName
+                    String surName
+                }
+
+                def p = new Person("John", "Doe")
+                assert p.firstName == "John"
+                assert p.surName == "Doe"
+            """
+    }
+
+    void testIncludesWithInvalidPropertyNameResultsInError() {
+        def message = shouldFail {
+            evaluate("""
+                    import groovy.transform.TupleConstructor
+
+                    @TupleConstructor(includes='sirName')
+                    class Person {
+                        String firstName
+                        String surName
+                    }
+
+                    def p = new Person("John", "Doe")
+                """)
+        }
+        assert message.contains("Error during @TupleConstructor processing: 'includes' property 'sirName' does not exist.")
+    }
+
+    void testExcludesWithInvalidPropertyNameResultsInError() {
+        def message = shouldFail {
+            evaluate("""
+                    import groovy.transform.TupleConstructor
+
+                    @TupleConstructor(excludes='sirName')
+                    class Person {
+                        String firstName
+                        String surName
+                    }
+
+                    def p = new Person("John", "Doe")
+                """)
+        }
+        assert message.contains("Error during @TupleConstructor processing: 'excludes' property 'sirName' does not exist.")
+    }
+
+}


### PR DESCRIPTION
I discussed this with Paul King and I believe I have implemented what we agreed.

The idea is that if there's a typo in a 'includes' or 'excludes' property list or the like, it should normally be a compile-time error. And consistent behavior should apply to all relevant AST transform annotations:
- AutoClone
- Canonical
- EqualsAndHashCode
- ExternalizeMethods
- ExternalizeVerifier
- Immutable
- Sortable
- ToString
- TupleConstructor

The current Groovy behavior ignores such errors, apart from @Sortable, which does check the 'includes' list but effectively not the 'excludes' list. 

In case there is some code out there that relies on the current lack of error checking, I added a checkPropertyNames attribute to the annotations too. This is named for compatibility with checkPropertyTypes in @ExternalVerifier. The default is to enable property name checking, but the user can suppress this by setting checkPropertyNames=false. I cannot think of any scenario where one would want to do this. Even if one is generating properties dynamically, specifying a property name in 'includes' or 'excludes' that doesn't exist when the annotation is processed will skip the property anyway. It appears that those attributes can only be used for properties (or fields) that are available at compile time. If people agree that the checkPropertyNames attribute is not necessary, I would be happy to remove it.

Paul said that there might be one or two JIRA tickets open relating to the current behavior. I could not find them. Please let me know if there are tickets, and what is the correct way to relate this Pull Request to existing tickets. 