### PR TITLE
GROOVY-7228 : Fixing typo in documentation for DefaultGroovyMethods.xor()

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -13848,7 +13848,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
     }
 
     /**
-     * Bitwise XOR together two Numbers.  Called when the '|' operator is used.
+     * Bitwise XOR together two Numbers.  Called when the '^' operator is used.
      *
      * @param left  a Number
      * @param right another Number to bitwse XOR


### PR DESCRIPTION
Hello,

Pull request for https://jira.codehaus.org/browse/GROOVY-7228

Minor documentation update from : 

`Called when the '|' operator is used.` to `Called when the '^' operator is used.`
