### PR TITLE
TempateServlet requires default constroctor at TemplateEngine

### DIFF
--- a/subprojects/groovy-templates/src/main/groovy/groovy/text/markup/MarkupTemplateEngine.java
+++ b/subprojects/groovy-templates/src/main/groovy/groovy/text/markup/MarkupTemplateEngine.java
@@ -72,6 +72,10 @@ public class MarkupTemplateEngine extends TemplateEngine {
     private final Map<String, GroovyCodeSource> codeSourceCache = new LinkedHashMap<String, GroovyCodeSource>();
     private final TemplateResolver templateResolver;
 
+    public MarkupTemplateEngine() {
+        this(new TemplateConfiguration());
+    }
+
     public MarkupTemplateEngine(final TemplateConfiguration tplConfig) {
         this(MarkupTemplateEngine.class.getClassLoader(), tplConfig);
     }


### PR DESCRIPTION
TemplateServlet requires template engine which have default constructor to run.
If it is, you can use MarkupTempateEngine with http request through TemplateServlet without even single code.
```
 <web-app>
   <servlet>
     <servlet-name>template</servlet-name>
     <servlet-class>groovy.servlet.TemplateServlet</servlet-class>
     <init-param>
         <param-name>template.engine</param-name>
         <param-value>groovy.text.markup.MarkupTemplateEngine</param-value>
     </init-param>
   </servlet>
```
Other siblings of groovy.text.TemplateEngines have default constructor.