### PR TITLE
GROOVY-7239 implementation of static indy array access logic

### DIFF
--- a/src/main/org/codehaus/groovy/classgen/asm/BinaryBooleanExpressionHelper.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/BinaryBooleanExpressionHelper.java
@@ -27,23 +27,13 @@ import org.objectweb.asm.MethodVisitor;
 public class BinaryBooleanExpressionHelper extends BinaryIntExpressionHelper {
 
     public BinaryBooleanExpressionHelper(WriterController wc) {
-        super(wc);
+        super(wc, boolArraySet, boolArrayGet);
     }
     
     private static final MethodCaller 
         boolArrayGet = MethodCaller.newStatic(BytecodeInterface8.class, "zArrayGet"),
         boolArraySet = MethodCaller.newStatic(BytecodeInterface8.class, "zArraySet");
 
-    @Override
-    protected MethodCaller getArrayGetCaller() {
-        return boolArrayGet;
-    }
-    
-    @Override
-    protected MethodCaller getArraySetCaller() {
-        return boolArraySet;
-    }
-    
     @Override
     protected ClassNode getArrayGetResultType() {
         return ClassHelper.boolean_TYPE;

--- a/src/main/org/codehaus/groovy/classgen/asm/BinaryDoubleExpressionHelper.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/BinaryDoubleExpressionHelper.java
@@ -30,21 +30,13 @@ public class BinaryDoubleExpressionHelper extends BinaryLongExpressionHelper {
 
 
     public BinaryDoubleExpressionHelper(WriterController controller) {
-        super(controller);
+        super(controller, doubleArraySet, doubleArrayGet);
     }
 
     private static final MethodCaller 
         doubleArrayGet = MethodCaller.newStatic(BytecodeInterface8.class, "dArrayGet"),
         doubleArraySet = MethodCaller.newStatic(BytecodeInterface8.class, "dArraySet");
 
-    protected MethodCaller getArrayGetCaller() {
-        return doubleArrayGet;
-    }
-
-    protected MethodCaller getArraySetCaller() {
-        return doubleArraySet;
-    }
-    
     protected boolean writeBitwiseOp(int op, boolean simulate) {
         if (!simulate) throw new GroovyBugError("should not reach here");
         return false;   

--- a/src/main/org/codehaus/groovy/classgen/asm/BinaryExpressionMultiTypeDispatcher.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/BinaryExpressionMultiTypeDispatcher.java
@@ -44,38 +44,32 @@ public class BinaryExpressionMultiTypeDispatcher extends BinaryExpressionHelper 
     
     private static class BinaryCharExpressionHelper extends BinaryIntExpressionHelper {
         public BinaryCharExpressionHelper(WriterController wc) {
-            super(wc);
+            super(wc, charArraySet, charArrayGet);
         }
         private static final MethodCaller 
             charArrayGet = MethodCaller.newStatic(BytecodeInterface8.class, "cArrayGet"),
             charArraySet = MethodCaller.newStatic(BytecodeInterface8.class, "cArraySet");
-        @Override protected MethodCaller getArrayGetCaller() { return charArrayGet; }
         @Override protected ClassNode getArrayGetResultType() { return ClassHelper.char_TYPE; }
-        @Override protected MethodCaller getArraySetCaller() { return charArraySet; }    
     }
     
     private static class BinaryByteExpressionHelper extends BinaryIntExpressionHelper {
         public BinaryByteExpressionHelper(WriterController wc) {
-            super(wc);
+            super(wc, byteArraySet, byteArrayGet);
         }
         private static final MethodCaller 
             byteArrayGet = MethodCaller.newStatic(BytecodeInterface8.class, "bArrayGet"),
             byteArraySet = MethodCaller.newStatic(BytecodeInterface8.class, "bArraySet");
-        @Override protected MethodCaller getArrayGetCaller() { return byteArrayGet; }
         @Override protected ClassNode getArrayGetResultType() { return ClassHelper.byte_TYPE; }
-        @Override protected MethodCaller getArraySetCaller() { return byteArraySet; }    
     }
     
     private static class BinaryShortExpressionHelper extends BinaryIntExpressionHelper {
         public BinaryShortExpressionHelper(WriterController wc) {
-            super(wc);
+            super(wc, shortArraySet, shortArrayGet);
         }
         private static final MethodCaller 
             shortArrayGet = MethodCaller.newStatic(BytecodeInterface8.class, "sArrayGet"),
             shortArraySet = MethodCaller.newStatic(BytecodeInterface8.class, "sArraySet");
-        @Override protected MethodCaller getArrayGetCaller() { return shortArrayGet; }
         @Override protected ClassNode getArrayGetResultType() { return ClassHelper.short_TYPE; }
-        @Override protected MethodCaller getArraySetCaller() { return shortArraySet; }    
     }
     
     protected BinaryExpressionWriter[] binExpWriter = initializeDelegateHelpers();

--- a/src/main/org/codehaus/groovy/classgen/asm/BinaryExpressionWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/BinaryExpressionWriter.java
@@ -24,13 +24,26 @@ import org.objectweb.asm.Label;
 import org.objectweb.asm.MethodVisitor;
 
 /**
+ * Base class for writing primitive typed operations
  * @author <a href="mailto:blackdrag@gmx.org">Jochen "blackdrag" Theodorou</a>
  */
 public abstract class BinaryExpressionWriter {
     
     private WriterController controller;
-    public BinaryExpressionWriter(WriterController controller) {
+    private MethodCaller arraySet, arrayGet;
+
+    public BinaryExpressionWriter(WriterController controller, MethodCaller arraySet, MethodCaller arrayGet) {
         this.controller = controller;
+        this.arraySet = arraySet;
+        this.arrayGet = arrayGet;
+    }
+
+    /**
+     * return writer controller
+     * @since 2.5.0
+     */
+    public WriterController getController() {
+        return controller;
     }
     
     protected static final int[] stdCompareCodes = {
@@ -45,10 +58,9 @@ public abstract class BinaryExpressionWriter {
     };
     
     protected abstract int getCompareCode();
-    
+
     /**
-     * writes some int standard operations. type is one of IADD, ISUB, IMUL,
-     * IDIV or IREM
+     * writes some int standard operations for compares
      * @param type the token type
      * @return true if a successful std operator write
      */
@@ -66,7 +78,7 @@ public abstract class BinaryExpressionWriter {
             Label l1 = new Label();
             mv.visitJumpInsn(bytecode,l1);
             mv.visitInsn(ICONST_1);
-            Label l2 = new Label();;
+            Label l2 = new Label();
             mv.visitJumpInsn(GOTO, l2);
             mv.visitLabel(l1);
             mv.visitInsn(ICONST_0);
@@ -148,7 +160,7 @@ public abstract class BinaryExpressionWriter {
             // no jump, so -1, need to pop off surplus LL
             removeTwoOperands(mv);
             mv.visitInsn(ICONST_M1);
-            Label l2 = new Label();;
+            Label l2 = new Label();
             mv.visitJumpInsn(GOTO, l2);
             
             mv.visitLabel(l1);
@@ -201,7 +213,7 @@ public abstract class BinaryExpressionWriter {
     
     /**
      * writes some the bitwise operations. type is one of BITWISE_OR, 
-     * BITWISE_AND, BIWISE_XOR
+     * BITWISE_AND, BITWISE_XOR
      * @param type the token type
      * @return true if a successful bitwise operation write
      */
@@ -246,13 +258,22 @@ public abstract class BinaryExpressionWriter {
                 writeShiftOp(operation, simulate);
     }
     
-    protected abstract MethodCaller getArrayGetCaller();
+    protected MethodCaller getArrayGetCaller() {
+        return arrayGet;
+    }
 
     protected ClassNode getArrayGetResultType(){
         return getNormalOpResultType();
     }
     
-    protected abstract MethodCaller getArraySetCaller();
+    protected MethodCaller getArraySetCaller() {
+        return arraySet;
+    }
+
+    public void setArraySetAndGet(MethodCaller arraySet, MethodCaller arrayGet) {
+        this.arraySet = arraySet;
+        this.arrayGet = arrayGet;
+    }
     
     public boolean arrayGet(int operation, boolean simulate) {
         if (operation!=LEFT_SQUARE_BRACKET) return false;

--- a/src/main/org/codehaus/groovy/classgen/asm/BinaryFloatExpressionHelper.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/BinaryFloatExpressionHelper.java
@@ -29,7 +29,7 @@ import org.objectweb.asm.MethodVisitor;
 public class BinaryFloatExpressionHelper extends BinaryExpressionWriter {
 
     public BinaryFloatExpressionHelper(WriterController controller) {
-        super(controller);
+        super(controller, floatArraySet, floatArrayGet);
     }
     
     protected void doubleTwoOperands(MethodVisitor mv) {
@@ -40,15 +40,6 @@ public class BinaryFloatExpressionHelper extends BinaryExpressionWriter {
         floatArrayGet = MethodCaller.newStatic(BytecodeInterface8.class, "fArrayGet"),
         floatArraySet = MethodCaller.newStatic(BytecodeInterface8.class, "fArraySet");
 
-    
-    protected MethodCaller getArrayGetCaller() {
-        return floatArrayGet;
-    }
-    
-    protected MethodCaller getArraySetCaller() {
-        return floatArraySet;
-    }
-    
     protected boolean writeBitwiseOp(int type, boolean simulate) {
         if (!simulate) throw new GroovyBugError("should not reach here");
         return false;   

--- a/src/main/org/codehaus/groovy/classgen/asm/BinaryIntExpressionHelper.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/BinaryIntExpressionHelper.java
@@ -98,11 +98,17 @@ public class BinaryIntExpressionHelper extends BinaryExpressionWriter {
     public static final int BITWISE_NEGATION            = REGEX_PATTERN;    // ~
     */
     
-    private WriterController controller;
     public BinaryIntExpressionHelper(WriterController wc) {
-        super(wc);
-        controller = wc;
+        this(wc, intArraySet, intArrayGet);
     }
+
+    /**
+     * @since 2.5.0
+     */
+    public BinaryIntExpressionHelper(WriterController wc, MethodCaller arraySet, MethodCaller arrayGet) {
+        super(wc, arraySet, arrayGet);
+    }
+
     
     /**
      * writes a std compare. This involves the tokens IF_ICMPEQ, IF_ICMPNE, 
@@ -116,14 +122,14 @@ public class BinaryIntExpressionHelper extends BinaryExpressionWriter {
         if (type<0||type>7) return false;
 
         if (!simulate) {
-            MethodVisitor mv = controller.getMethodVisitor();
-            OperandStack operandStack = controller.getOperandStack();
+            MethodVisitor mv = getController().getMethodVisitor();
+            OperandStack operandStack = getController().getOperandStack();
             // operands are on the stack already
             int bytecode = stdCompareCodes[type];
             Label l1 = new Label();
             mv.visitJumpInsn(bytecode,l1);
             mv.visitInsn(ICONST_1);
-            Label l2 = new Label();;
+            Label l2 = new Label();
             mv.visitJumpInsn(GOTO, l2);
             mv.visitLabel(l1);
             mv.visitInsn(ICONST_0);
@@ -186,7 +192,7 @@ public class BinaryIntExpressionHelper extends BinaryExpressionWriter {
           
         */
         if (!simulate) {
-            MethodVisitor mv = controller.getMethodVisitor();
+            MethodVisitor mv = getController().getMethodVisitor();
             // duplicate int arguments
             mv.visitInsn(DUP2);
             
@@ -195,7 +201,7 @@ public class BinaryIntExpressionHelper extends BinaryExpressionWriter {
             // no jump, so -1, need to pop off surplus II
             mv.visitInsn(POP2);
             mv.visitInsn(ICONST_M1);
-            Label l2 = new Label();;
+            Label l2 = new Label();
             mv.visitJumpInsn(GOTO, l2);
             
             mv.visitLabel(l1);
@@ -206,22 +212,14 @@ public class BinaryIntExpressionHelper extends BinaryExpressionWriter {
             
             mv.visitLabel(l3);
             mv.visitInsn(ICONST_1);
-            
-            controller.getOperandStack().replace(ClassHelper.int_TYPE, 2);
+
+            getController().getOperandStack().replace(ClassHelper.int_TYPE, 2);
         }
         return true;
     }
 
     protected void doubleTwoOperands(MethodVisitor mv) {
         mv.visitInsn(DUP2);
-    }
-
-    protected MethodCaller getArrayGetCaller() {
-        return intArrayGet;
-    }
-
-    protected MethodCaller getArraySetCaller() {
-        return intArraySet;
     }
 
     protected int getBitwiseOperationBytecode(int type) {

--- a/src/main/org/codehaus/groovy/classgen/asm/BinaryLongExpressionHelper.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/BinaryLongExpressionHelper.java
@@ -27,8 +27,15 @@ import org.objectweb.asm.MethodVisitor;
  */
 public class BinaryLongExpressionHelper extends BinaryExpressionWriter {
 
+    /**
+     * @since 2.5.0
+     */
+    public BinaryLongExpressionHelper(WriterController controller, MethodCaller arraySet, MethodCaller arrayGet) {
+        super(controller, arraySet, arrayGet);
+    }
+
     public BinaryLongExpressionHelper(WriterController controller) {
-        super(controller);
+        this(controller, longArraySet, longArrayGet);
     }
 
     protected void doubleTwoOperands(MethodVisitor mv) {
@@ -58,14 +65,6 @@ public class BinaryLongExpressionHelper extends BinaryExpressionWriter {
         longArrayGet = MethodCaller.newStatic(BytecodeInterface8.class, "lArrayGet"),
         longArraySet = MethodCaller.newStatic(BytecodeInterface8.class, "lArraySet");
 
-    protected MethodCaller getArrayGetCaller() {
-        return longArrayGet;
-    }
-
-    protected MethodCaller getArraySetCaller() {
-        return longArraySet;
-    }
-    
     private static final int[] bitOp = {
         LOR,            //  BITWISE_OR / PIPE   340
         LAND,           //  BITWISE_AND         341

--- a/src/main/org/codehaus/groovy/classgen/asm/BinaryObjectExpressionHelper.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/BinaryObjectExpressionHelper.java
@@ -28,20 +28,8 @@ public class BinaryObjectExpressionHelper extends BinaryExpressionWriter {
     private static final MethodCaller arrayGet = MethodCaller.newStatic(BytecodeInterface8.class, "objectArrayGet");
     private static final MethodCaller arraySet = MethodCaller.newStatic(BytecodeInterface8.class, "objectArraySet");
 
-    
-//    private WriterController controller;
-    
     public BinaryObjectExpressionHelper(WriterController controller) {
-        super(controller);
-//        this.controller = controller;
-    }
-    
-    protected MethodCaller getArrayGetCaller() {
-        return arrayGet;
-    }
-    
-    protected MethodCaller getArraySetCaller() {
-        return arraySet;
+        super(controller, arraySet, arrayGet);
     }
     
     // dummy methods

--- a/src/main/org/codehaus/groovy/classgen/asm/MethodCaller.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/MethodCaller.java
@@ -48,6 +48,11 @@ public class MethodCaller implements Opcodes {
         return new MethodCaller(INVOKEVIRTUAL, theClass, name);
     }
 
+    /**
+     * @since 2.5.0
+     */
+    protected MethodCaller() {}
+
     public MethodCaller(int opcode, Class theClass, String name) {
         this.opcode = opcode;
         this.internalName = Type.getInternalName(theClass);

--- a/src/main/org/codehaus/groovy/classgen/asm/indy/sc/IndyStaticTypesMultiTypeDispatcher.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/indy/sc/IndyStaticTypesMultiTypeDispatcher.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2003-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.codehaus.groovy.classgen.asm.indy.sc;
+
+import org.codehaus.groovy.classgen.asm.BinaryExpressionWriter;
+import org.codehaus.groovy.classgen.asm.MethodCaller;
+import org.codehaus.groovy.classgen.asm.WriterController;
+import org.codehaus.groovy.classgen.asm.sc.StaticTypesBinaryExpressionMultiTypeDispatcher;
+import org.codehaus.groovy.vmplugin.v7.IndyInterface;
+import org.objectweb.asm.Handle;
+import org.objectweb.asm.MethodVisitor;
+
+import java.lang.invoke.CallSite;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+/**
+ * Multi type dispatcher for binary expression backend combining indy and static compilation
+ * @author Jochen Theodorou
+ * @since 2.5.0
+ */
+public class IndyStaticTypesMultiTypeDispatcher extends StaticTypesBinaryExpressionMultiTypeDispatcher {
+    public IndyStaticTypesMultiTypeDispatcher(WriterController wc) {
+        super(wc);
+
+    }
+
+    private static final String INDY_INTERFACE_NAME = IndyInterface.class.getName().replace('.', '/');
+    private static final String BSM_METHOD_TYPE_DESCRIPTOR =
+            MethodType.methodType(
+                    CallSite.class, MethodHandles.Lookup.class, String.class, MethodType.class
+            ).toMethodDescriptorString();
+    private static final Handle BSM =
+            new Handle(
+                    H_INVOKESTATIC,
+                    INDY_INTERFACE_NAME,
+                    "staticArrayAccess",
+                    BSM_METHOD_TYPE_DESCRIPTOR);
+    private static class GenericArrayAccess extends MethodCaller {
+        private final String name, signature;
+        public GenericArrayAccess(String name, String signature) {
+            this.name = name;
+            this.signature = signature;
+        }
+        @Override public void call(MethodVisitor mv) {
+            mv.visitInvokeDynamicInsn(name, signature, BSM);
+        }
+    }
+
+    protected BinaryExpressionWriter[] initializeDelegateHelpers() {
+        BinaryExpressionWriter[] bewArray = super.initializeDelegateHelpers();
+        /* 1: int    */
+        bewArray[1].setArraySetAndGet(  new GenericArrayAccess("set","([III)V"),
+                                        new GenericArrayAccess("get","([II)I"));
+        /* 2: long   */
+        bewArray[2].setArraySetAndGet(  new GenericArrayAccess("set","([LLL)V"),
+                                        new GenericArrayAccess("get","([LL)L"));
+        /* 3: double */
+        bewArray[3].setArraySetAndGet(  new GenericArrayAccess("set","([DDD)V"),
+                                        new GenericArrayAccess("get","([DD)D"));
+        /* 4: char   */
+        bewArray[4].setArraySetAndGet(  new GenericArrayAccess("set","([CCC)V"),
+                                        new GenericArrayAccess("get","([CC)C"));
+        /* 5: byte   */
+        bewArray[5].setArraySetAndGet(  new GenericArrayAccess("set","([BBB)V"),
+                                        new GenericArrayAccess("get","([BB)B"));
+        /* 6: short  */
+        bewArray[6].setArraySetAndGet(  new GenericArrayAccess("set","([SSS)V"),
+                                        new GenericArrayAccess("get","([SS)S"));
+        /* 7: float  */
+        bewArray[7].setArraySetAndGet(  new GenericArrayAccess("get","([FFF)V"),
+                                        new GenericArrayAccess("set","([FF)F"));
+        /* 8: bool   */
+        bewArray[8].setArraySetAndGet(  new GenericArrayAccess("get","([ZZZ)V"),
+                                        new GenericArrayAccess("set","([ZZ)Z"));
+        return bewArray;
+    }
+}

--- a/src/main/org/codehaus/groovy/classgen/asm/indy/sc/IndyStaticTypesMultiTypeDispatcher.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/indy/sc/IndyStaticTypesMultiTypeDispatcher.java
@@ -67,26 +67,26 @@ public class IndyStaticTypesMultiTypeDispatcher extends StaticTypesBinaryExpress
         bewArray[1].setArraySetAndGet(  new GenericArrayAccess("set","([III)V"),
                                         new GenericArrayAccess("get","([II)I"));
         /* 2: long   */
-        bewArray[2].setArraySetAndGet(  new GenericArrayAccess("set","([LLL)V"),
-                                        new GenericArrayAccess("get","([LL)L"));
+        bewArray[2].setArraySetAndGet(  new GenericArrayAccess("set","([JIJ)V"),
+                                        new GenericArrayAccess("get","([JI)J"));
         /* 3: double */
-        bewArray[3].setArraySetAndGet(  new GenericArrayAccess("set","([DDD)V"),
-                                        new GenericArrayAccess("get","([DD)D"));
+        bewArray[3].setArraySetAndGet(  new GenericArrayAccess("set","([DID)V"),
+                                        new GenericArrayAccess("get","([DI)D"));
         /* 4: char   */
-        bewArray[4].setArraySetAndGet(  new GenericArrayAccess("set","([CCC)V"),
-                                        new GenericArrayAccess("get","([CC)C"));
+        bewArray[4].setArraySetAndGet(  new GenericArrayAccess("set","([CIC)V"),
+                                        new GenericArrayAccess("get","([CI)C"));
         /* 5: byte   */
-        bewArray[5].setArraySetAndGet(  new GenericArrayAccess("set","([BBB)V"),
-                                        new GenericArrayAccess("get","([BB)B"));
+        bewArray[5].setArraySetAndGet(  new GenericArrayAccess("set","([BIB)V"),
+                                        new GenericArrayAccess("get","([BI)B"));
         /* 6: short  */
-        bewArray[6].setArraySetAndGet(  new GenericArrayAccess("set","([SSS)V"),
-                                        new GenericArrayAccess("get","([SS)S"));
+        bewArray[6].setArraySetAndGet(  new GenericArrayAccess("set","([SIS)V"),
+                                        new GenericArrayAccess("get","([SI)S"));
         /* 7: float  */
-        bewArray[7].setArraySetAndGet(  new GenericArrayAccess("get","([FFF)V"),
-                                        new GenericArrayAccess("set","([FF)F"));
+        bewArray[7].setArraySetAndGet(  new GenericArrayAccess("get","([FIF)V"),
+                                        new GenericArrayAccess("set","([FI)F"));
         /* 8: bool   */
-        bewArray[8].setArraySetAndGet(  new GenericArrayAccess("get","([ZZZ)V"),
-                                        new GenericArrayAccess("set","([ZZ)Z"));
+        bewArray[8].setArraySetAndGet(  new GenericArrayAccess("get","([ZIZ)V"),
+                                        new GenericArrayAccess("set","([ZI)Z"));
         return bewArray;
     }
 }

--- a/src/main/org/codehaus/groovy/vmplugin/v7/IndyArrayAccess.java
+++ b/src/main/org/codehaus/groovy/vmplugin/v7/IndyArrayAccess.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright 2003-2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.codehaus.groovy.vmplugin.v7;
+
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.HashMap;
+
+import org.codehaus.groovy.GroovyBugError;
+import org.codehaus.groovy.runtime.DefaultGroovyMethodsSupport;
+
+/**
+ * Class for handling array access through invokedynamic using static callsite information
+ * @author Jochen Theodorou
+ * @since 2.5.0
+ */
+public class IndyArrayAccess {
+
+    private static final MethodHandle notNegative,normalizeIndex;
+    static {
+        try {
+            notNegative = MethodHandles.lookup().findStatic(IndyArrayAccess.class, "notNegative", MethodType.methodType(boolean.class, int.class));
+            normalizeIndex = MethodHandles.lookup().findStatic(IndyArrayAccess.class, "normalizeIndex", MethodType.methodType(int.class, Object.class, int.class));
+        } catch (ReflectiveOperationException e) {
+            throw new GroovyBugError(e);
+        }
+    }
+
+    private static final HashMap<Class,MethodHandle> getterMap, setterMap;
+    static {
+        getterMap = new HashMap<Class,MethodHandle>();
+        Class[] classes = new Class[]{
+                int[].class, byte[].class, short[].class, long[].class,
+                double[].class, float[].class,
+                boolean[].class, char[].class, Object[].class};
+        for (Class arrayClass : classes) {
+            MethodHandle handle = buildGetter(arrayClass);
+            getterMap.put(arrayClass, handle);
+        }
+        setterMap = new HashMap<Class,MethodHandle>();
+        for (Class arrayClass : classes) {
+            MethodHandle handle = buildSetter(arrayClass);
+            setterMap.put(arrayClass, handle);
+        }
+    }
+
+    private static MethodHandle buildGetter(Class arrayClass) {
+        MethodHandle get = MethodHandles.arrayElementGetter(arrayClass);
+        MethodHandle fallback = MethodHandles.explicitCastArguments(get, get.type().changeParameterType(0, Object.class));
+
+        fallback = MethodHandles.dropArguments(fallback, 2, int.class);
+        MethodType reorderType = fallback.type().
+                                    insertParameterTypes(0, int.class).
+                                    dropParameterTypes(2,3);
+        fallback = MethodHandles.permuteArguments(fallback, reorderType, 1, 0, 0);
+
+        fallback = MethodHandles.foldArguments(fallback, normalizeIndex);
+        fallback = MethodHandles.explicitCastArguments(fallback, get.type());
+
+        MethodHandle guard = MethodHandles.dropArguments(notNegative, 0, arrayClass);
+        MethodHandle handle = MethodHandles.guardWithTest(guard, get, fallback);
+        return handle;
+    }
+
+    private static MethodHandle buildSetter(Class arrayClass){
+        MethodHandle set = MethodHandles.arrayElementSetter(arrayClass);
+        MethodHandle fallback = MethodHandles.explicitCastArguments(set, set.type().changeParameterType(0, Object.class));
+
+        fallback = MethodHandles.dropArguments(fallback, 3, int.class);
+        MethodType reorderType = fallback.type().
+                                    insertParameterTypes(0, int.class).
+                                    dropParameterTypes(4,5);
+        fallback = MethodHandles.permuteArguments(fallback, reorderType, 1, 0, 3, 0);
+
+        fallback = MethodHandles.foldArguments(fallback, normalizeIndex);
+        fallback = MethodHandles.explicitCastArguments(fallback, set.type());
+
+        MethodHandle guard = MethodHandles.dropArguments(notNegative, 0, arrayClass);
+        MethodHandle handle = MethodHandles.guardWithTest(guard, set, fallback);
+        return handle;
+    }
+
+    private static int getLength(Object array) {
+        if (array instanceof Object[]) return ((Object[])array).length;
+        if (array instanceof boolean[]) return ((boolean[])array).length;
+        if (array instanceof byte[]) return ((byte[])array).length;
+        if (array instanceof char[]) return ((char[])array).length;
+        if (array instanceof short[]) return ((short[])array).length;
+        if (array instanceof int[]) return ((int[])array).length;
+        if (array instanceof long[]) return ((long[])array).length;
+        if (array instanceof float[]) return ((float[])array).length;
+        if (array instanceof double[]) return ((double[])array).length;
+        return 0;
+    }
+
+    private static int normalizeIndex(Object array, int i) {
+        int temp = i;
+        int size = getLength(array);
+        i += size;
+        if (i < 0) {
+            throw new ArrayIndexOutOfBoundsException("Negative array index [" + temp + "] too large for array size " + size);
+        }
+        return i;
+    }
+
+    public static boolean notNegative(int index) {
+        return index>=0;
+    }
+
+    public static MethodHandle arrayGet(MethodType type) {
+        Class key = type.parameterType(0);
+        MethodHandle res = getterMap.get(key);
+        if (res!=null) return res;
+        res = buildGetter(key);
+        res = MethodHandles.explicitCastArguments(res, type);
+        return res;
+    }
+
+    public static MethodHandle arraySet(MethodType type) {
+        Class key = type.parameterType(0);
+        MethodHandle res = setterMap.get(key);
+        if (res!=null) return res;
+        res = buildSetter(key);
+        res = MethodHandles.explicitCastArguments(res, type);
+        return res;
+    }
+}

--- a/src/main/org/codehaus/groovy/vmplugin/v7/IndyInterface.java
+++ b/src/main/org/codehaus/groovy/vmplugin/v7/IndyInterface.java
@@ -214,4 +214,16 @@ public class IndyInterface {
             call = call.asType(MethodType.methodType(Object.class,Object[].class));
             return call.invokeExact(arguments);
         }
+
+        /**
+         * @since 2.5.0
+         */
+         public static CallSite staticArrayAccess(MethodHandles.Lookup lookup, String name, MethodType type) {
+            MethodHandle handle;
+            if (type.parameterCount()==2) {
+                return new ConstantCallSite(IndyArrayAccess.arrayGet(type));
+            } else {
+                return new ConstantCallSite(IndyArrayAccess.arraySet(type));
+            }
+         }
 }

--- a/src/test/org/codehaus/groovy/classgen/asm/sc/CombinedIndyAndStaticCompilationTest.groovy
+++ b/src/test/org/codehaus/groovy/classgen/asm/sc/CombinedIndyAndStaticCompilationTest.groovy
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2003-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.codehaus.groovy.classgen.asm.sc
+
+import org.codehaus.groovy.classgen.asm.AbstractBytecodeTestCase
+
+import static org.codehaus.groovy.control.CompilerConfiguration.DEFAULT as config
+
+/**
+ * Tests for combined static compilation and indy code
+ * @author Jochen Theodorou
+ */
+class CombinedIndyAndStaticCompilationTest extends AbstractBytecodeTestCase {
+    void testArrayAccess() {
+        if (!config.optimizationOptions.indy) return;
+        ["byte", "short", "int", "long", "float", "double", "boolean", "char"].each { type->
+            //array get
+            compile ("""
+                @groovy.transform.CompileStatic
+                def foo() {
+                    ${type}[] array = new ${type}[10]
+                    $type x = array[0]
+                }
+            """).hasSequence(["INVOKEDYNAMIC"])
+            //array set
+            compile ("""
+                @groovy.transform.CompileStatic
+                def foo() {
+                    ${type}[] array = new ${type}[10]
+                    array[0] = 1
+                }
+            """).hasSequence(["INVOKEDYNAMIC"])
+        }
+    }
+
+    void testNegativeAccess() {
+        ["byte", "short", "int", "long", "float", "double", "boolean", "char"].each { type ->
+            assertScript """
+                @groovy.transform.CompileStatic
+                def foo() {
+                    ${type}[] array = [0,1,2]
+                    assert array[0] == 0
+                    assert array[1] == 1
+                    assert array[2] == 2
+                    assert array[-1] == 2
+                    assert array[-2] == 1
+                    array[0] = 9
+                    assert array[0] == 9
+                    array[-1] = 8
+                    assert array[2] == 8
+            """
+        }
+    }
+}

--- a/src/test/org/codehaus/groovy/classgen/asm/sc/CombinedIndyAndStaticCompilationTest.groovy
+++ b/src/test/org/codehaus/groovy/classgen/asm/sc/CombinedIndyAndStaticCompilationTest.groovy
@@ -48,7 +48,7 @@ class CombinedIndyAndStaticCompilationTest extends AbstractBytecodeTestCase {
     }
 
     void testNegativeAccess() {
-        ["byte", "short", "int", "long", "float", "double", "boolean", "char"].each { type ->
+        ["byte", "short", "int", "long", "float", "double", "char"].each { type ->
             assertScript """
                 @groovy.transform.CompileStatic
                 def foo() {
@@ -62,7 +62,25 @@ class CombinedIndyAndStaticCompilationTest extends AbstractBytecodeTestCase {
                     assert array[0] == 9
                     array[-1] = 8
                     assert array[2] == 8
+                }
+                foo()
             """
         }
+        assertScript """
+                @groovy.transform.CompileStatic
+                def foo() {
+                    boolean[] array = [false, false, true]
+                    assert array[0] == false
+                    assert array[1] == false
+                    assert array[2] == true
+                    assert array[-1] == true
+                    assert array[-2] == false
+                    array[0] = true
+                    assert array[0] == true
+                    array[-1] = false
+                    assert array[2] == false
+                }
+                foo()
+            """
     }
 }

--- a/src/test/org/codehaus/groovy/classgen/asm/sc/StaticCompilationTest.groovy
+++ b/src/test/org/codehaus/groovy/classgen/asm/sc/StaticCompilationTest.groovy
@@ -4,6 +4,8 @@ import org.codehaus.groovy.classgen.asm.AbstractBytecodeTestCase
 import org.codehaus.groovy.control.CompilerConfiguration
 import org.codehaus.groovy.transform.stc.GroovyTypeCheckingExtensionSupport
 
+import static org.codehaus.groovy.control.CompilerConfiguration.DEFAULT as config
+
 class StaticCompilationTest extends AbstractBytecodeTestCase {
     void testEmptyMethod() {
         def bytecode = compile([method:'m'],'''
@@ -159,6 +161,8 @@ class StaticCompilationTest extends AbstractBytecodeTestCase {
     }
 
     void testArrayGet() {
+        if (config.optimizationOptions.indy) return;
+        // this test is done with indy in another tests case
         assert compile([method:'m'],'''
         @groovy.transform.CompileStatic
         void m(int[] arr) {
@@ -171,6 +175,8 @@ class StaticCompilationTest extends AbstractBytecodeTestCase {
     }
 
     void testArraySet() {
+        if (config.optimizationOptions.indy) return;
+        // this test is done with indy in another tests case
         assert compile([method:'m'],'''
         @groovy.transform.CompileStatic
         void m(int[] arr) {

--- a/src/test/org/codehaus/groovy/classgen/asm/sc/StaticCompileArrayLengthAndGet.groovy
+++ b/src/test/org/codehaus/groovy/classgen/asm/sc/StaticCompileArrayLengthAndGet.groovy
@@ -2,6 +2,8 @@ package org.codehaus.groovy.classgen.asm.sc
 
 import org.codehaus.groovy.classgen.asm.AbstractBytecodeTestCase
 
+import static org.codehaus.groovy.control.CompilerConfiguration.DEFAULT as config
+
 class StaticCompileArrayLengthAndGet extends AbstractBytecodeTestCase {
     void testShouldCompileArrayLengthStatically() {
         def bytecode = compile([method:'m'],'''
@@ -18,6 +20,8 @@ class StaticCompileArrayLengthAndGet extends AbstractBytecodeTestCase {
     }
 
     void testArrayGet1() {
+        if (config.optimizationOptions.indy) return;
+        // this test is done with indy in another tests case
         def bytecode = compile([method:'m'],'''
             @groovy.transform.CompileStatic
             int m(int[] arr) {
@@ -33,6 +37,8 @@ class StaticCompileArrayLengthAndGet extends AbstractBytecodeTestCase {
     }
 
     void testArraySet1() {
+        if (config.optimizationOptions.indy) return;
+        // this test is done with indy in another tests case
         def bytecode = compile([method:'m'],'''
             @groovy.transform.CompileStatic
             void m(int[] arr) {


### PR DESCRIPTION
This commit  thought for Groovy 2.5.0 and allows indy to support static compiled code for array access, since indy can do this much faster than current static code.