### PR TITLE
Code cleanup for meta-class registry

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/metaclass/MetaClassRegistryImpl.java
+++ b/src/main/org/codehaus/groovy/runtime/metaclass/MetaClassRegistryImpl.java
@@ -118,7 +118,7 @@ public class MetaClassRegistryImpl implements MetaClassRegistry{
         final MetaClass emcMetaClass = metaClassCreationHandle.create(ExpandoMetaClass.class, this);
         emcMetaClass.initialize();
         ClassInfo.getClassInfo(ExpandoMetaClass.class).setStrongMetaClass(emcMetaClass);
-        
+
 
         addNonRemovableMetaClassRegistryChangeEventListener(new MetaClassRegistryChangeEventListener(){
             public void updateConstantMetaClass(MetaClassRegistryChangeEvent cmcu) {
@@ -316,7 +316,6 @@ public class MetaClassRegistryImpl implements MetaClassRegistry{
         return useAccessible;
     }
 
-    // the following is experimental code, not intended for stable use yet
     private volatile MetaClassCreationHandle metaClassCreationHandle = new MetaClassCreationHandle();
     
     /**
@@ -397,10 +396,11 @@ public class MetaClassRegistryImpl implements MetaClassRegistry{
      */
     public MetaClassRegistryChangeEventListener[] getMetaClassRegistryChangeEventListeners() {
         synchronized (changeListenerList) {
-            ArrayList<MetaClassRegistryChangeEventListener> ret = new ArrayList(changeListenerList.size()+nonRemoveableChangeListenerList.size());
+            ArrayList<MetaClassRegistryChangeEventListener> ret =
+                    new ArrayList<MetaClassRegistryChangeEventListener>(changeListenerList.size()+nonRemoveableChangeListenerList.size());
             ret.addAll(nonRemoveableChangeListenerList);
             ret.addAll(changeListenerList);
-            return (MetaClassRegistryChangeEventListener[]) ret.toArray(new MetaClassRegistryChangeEventListener[ret.size()]);
+            return ret.toArray(new MetaClassRegistryChangeEventListener[ret.size()]);
         }
     }
     


### PR DESCRIPTION
This PR includes several changes to the metaclass registry aimed at making it safer, cleaner and faster (in that order). For inclusion in 2.5 only.
  
 - fix synchronization on non final fields
   - replace "hash" with a dummy value because the field is unused
   - removed unnecessary casts
   - fix a potential issue with "version" field increment which is not atomic
   - removed caching of elements in LocalMap, not proved to be faster