### PR TITLE
fix swallowing of CompilationFailedException

### DIFF
--- a/src/main/org/codehaus/groovy/control/ClassNodeResolver.java
+++ b/src/main/org/codehaus/groovy/control/ClassNodeResolver.java
@@ -185,7 +185,7 @@ public class ClassNodeResolver {
             LookupResult lr = tryAsScript(name, compilationUnit, null);
             return lr;
         } catch (CompilationFailedException cfe) {
-            throw new GroovyBugError("The lookup for "+name+" caused a failed compilaton. There should not have been any compilation from this call.");
+            throw new GroovyBugError("The lookup for "+name+" caused a failed compilaton. There should not have been any compilation from this call.", cfe);
         }
         //TODO: the case of a NoClassDefFoundError needs a bit more research
         // a simple recompilation is not possible it seems. The current class


### PR DESCRIPTION
Hello,
could you please backport the fix to 2_x branches (or at least 2_4_x) as well? This bug really makes it hard to debug any non-trivial code and swallowing an exception can be hardly considered anything else but bad practice. Mistakes like this one can be prevented by using findbugs or similar tool.

Thanks,
Radek