### PR TITLE
added findbugs to build

### DIFF
--- a/gradle/quality.gradle
+++ b/gradle/quality.gradle
@@ -2,7 +2,7 @@ import groovy.text.markup.MarkupTemplateEngine
 import groovy.text.markup.TemplateConfiguration
 
 /*
- * Copyright 2003-2014 the original author or authors.
+ * Copyright 2003-2015 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import groovy.text.markup.TemplateConfiguration
 allprojects {
     apply plugin: 'checkstyle'
     apply plugin: 'codenarc'
+    apply plugin: 'findbugs'
 
     // don't fail build on CodeNarc tasks
     tasks.withType(CodeNarc) {
@@ -84,6 +85,17 @@ allprojects {
         finalizedBy "${name}Report"
     }
 
+    findbugs {
+        // continue build despite findbug warnings
+        ignoreFailures = true
+        sourceSets = [sourceSets.main]
+    }
+    tasks.withType(FindBugs) {
+        reports {
+            xml.enabled = false
+            html.enabled = true
+        }
+    }
 }
 
 apply from: 'gradle/jacoco/jacoco.gradle'


### PR DESCRIPTION
The report contains some warnings that seem worth looking at, e.g.:

* Sequence of calls to java.util.concurrent.ConcurrentHashMap may not be atomic in groovy.lang.ExpandoMetaClass.registerSubclassInstanceMethod(MetaMethod)
* Sequence of calls to java.util.concurrent.ConcurrentHashMap may not be atomic in org.codehaus.groovy.runtime.ConversionHandler.invoke(Object, Method, Object[])
* Inconsistent synchronization of org.codehaus.groovy.runtime.metaclass.ConcurrentReaderHashMap.table; locked 69% of time
* Inconsistent synchronization of org.codehaus.groovy.runtime.metaclass.ThreadManagedMetaBeanProperty.initialValueCreator; locked 66% of time
* Inconsistent synchronization of org.codehaus.groovy.transform.tailrec.VariableExpressionReplacer.transformer; locked 50% of time
* Incorrect lazy initialization of static field org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.classMetaClass in org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.resetCachedMetaClasses()
* Incorrect lazy initialization of static field org.codehaus.groovy.runtime.metaclass.MetaClassRegistryImpl.instanceExclude in org.codehaus.groovy.runtime.metaclass.MetaClassRegistryImpl.getInstance(int)
* Incorrect lazy initialization of static field org.codehaus.groovy.runtime.metaclass.MetaClassRegistryImpl.instanceInclude in org.codehaus.groovy.runtime.metaclass.MetaClassRegistryImpl.getInstance(int)
* groovy.lang.ExpandoMetaClass.performOperationOnMetaClass(ExpandoMetaClass$Callable) does not release lock on all exception paths