### PR TITLE
GROOVY-7277 Make TemplateResource cope with paths will multiple dots

### DIFF
--- a/subprojects/groovy-templates/src/main/groovy/groovy/text/markup/MarkupTemplateEngine.java
+++ b/subprojects/groovy-templates/src/main/groovy/groovy/text/markup/MarkupTemplateEngine.java
@@ -59,7 +59,7 @@ public class MarkupTemplateEngine extends TemplateEngine {
     static final ClassNode MARKUPTEMPLATEENGINE_CLASSNODE = ClassHelper.make(MarkupTemplateEngine.class);
     static final String MODELTYPES_ASTKEY = "MTE.modelTypes";
 
-    private static final Pattern LOCALIZED_RESOURCE_PATTERN = Pattern.compile("(.+?)(?:_([a-z]{2}(?:_[A-Z]{2,3})))?\\.(\\p{Alnum}+)");
+    private static final Pattern LOCALIZED_RESOURCE_PATTERN = Pattern.compile("(.+?)(?:_([a-z]{2}(?:_[A-Z]{2,3})))?\\.([\\p{Alnum}.]+)$");
 
     private static final AtomicLong counter = new AtomicLong();
 

--- a/subprojects/groovy-templates/src/test/groovy/groovy/text/markup/TemplateResourceTest.groovy
+++ b/subprojects/groovy-templates/src/test/groovy/groovy/text/markup/TemplateResourceTest.groovy
@@ -1,0 +1,35 @@
+package groovy.text.markup
+
+import groovy.text.markup.MarkupTemplateEngine.TemplateResource;
+
+class TemplateResourceTest extends GroovyTestCase {
+	
+	void testSimplePath() {
+		def resource = TemplateResource.parse("simple.foo")
+		assertFalse(resource.hasLocale())
+		assertEquals("simple.foo", resource.toString())
+		assertEquals("simple_fr_FR.foo", resource.withLocale("fr_FR").toString())
+	}
+	
+	void testPathWithLocale() {
+		def resource = TemplateResource.parse("simple_fr_FR.foo")
+		assertTrue(resource.hasLocale())
+		assertEquals("simple_fr_FR.foo", resource.toString())
+		assertEquals("simple.foo", resource.withLocale(null).toString())
+	}
+	
+	void testPathWithMultipleDots() {
+		def resource = TemplateResource.parse("simple.foo.bar")
+		assertFalse(resource.hasLocale())
+		assertEquals("simple.foo.bar", resource.toString())
+		assertEquals("simple_fr_FR.foo.bar", resource.withLocale("fr_FR").toString())
+	}
+	
+	void testPathWithLocaleAndMultipleDots() {
+		def resource = TemplateResource.parse("simple_fr_FR.foo.bar")
+		assertTrue(resource.hasLocale())
+		assertEquals("simple_fr_FR.foo.bar", resource.toString())
+		assertEquals("simple.foo.bar", resource.withLocale(null).toString())
+	}
+
+}


### PR DESCRIPTION
Prior to this commit TemplateResource.parse would truncate the path
at the second dot. For example, foo.html.tpl would be parsed into
foo.html. This commit updates the regular expression used for parsing
such that foo.html.tpl is parsed into foo.html.tpl with foo being
the base name of html.tpl being the extension.