### PR TITLE
GROOVY-7298: Test case for NPE in TypeResolver

### DIFF
--- a/src/test/groovy/bugs/Groovy7298Bug.groovy
+++ b/src/test/groovy/bugs/Groovy7298Bug.groovy
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2003-2015 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package groovy.bugs
+
+import org.junit.Ignore
+
+class Groovy7298Bug extends GroovyTestCase {
+    @Ignore
+    void testCallingSafeSuperShouldNotThrowVerifyError() {
+        assertScript '''import groovy.transform.CompileStatic
+            @CompileStatic
+            class Foo {
+                public <T> T tryToExecuteWithFreePort(Closure<T> closure) {
+                    [1].each {
+                        return executeLogicForAvailablePort(closure)
+                    }
+                }
+                private <T> T executeLogicForAvailablePort(Closure<T> closure) {
+                    return closure.call()
+                }
+            }
+            new Foo().executeLogicForAvailablePort { }
+        '''
+    }
+}


### PR DESCRIPTION
Test case for an error when with `@CompileStatic` used generic method with
Closure's execution fails with NPE in TypeResolver ([GROOVY-7298](https://jira.codehaus.org/browse/GROOVY-7298)).