### PR TITLE
Use the correct example for right currying

### DIFF
--- a/src/spec/doc/core-closures.adoc
+++ b/src/spec/doc/core-closures.adoc
@@ -453,7 +453,7 @@ Similarily to left currying, it is possible to set the right-most parameter of a
 
 [source,groovy]
 ----
-include::{projectdir}/src/spec/test/ClosuresSpecTest.groovy[tags=left_curry,indent=0]
+include::{projectdir}/src/spec/test/ClosuresSpecTest.groovy[tags=right_curry,indent=0]
 ----
 <1> the `nCopies` closure defines two parameters
 <2> `rcurry` will set the last parameter to `bla`, creating a new closure (function) which accepts a single `int`


### PR DESCRIPTION
I don't actually know how this tagged include system works, so whoever pulls this should probably verify its correctness before doing so.