### PR TITLE
GROOVY-7257: groovydoc's help option is misleading

### DIFF
--- a/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/SimpleGroovyClassDocAssembler.java
+++ b/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/SimpleGroovyClassDocAssembler.java
@@ -259,8 +259,51 @@ public class SimpleGroovyClassDocAssembler extends VisitorAdapter implements Gro
                 }
             }
             SimpleGroovyMethodDoc currentMethodDoc = createMethod(t, currentClassDoc);
-            currentClassDoc.add(currentMethodDoc);
+
+
+            if(!isIgnorePackageFieldsMethods(t, currentClassDoc))
+                currentClassDoc.add(currentMethodDoc);
         }
+    }
+
+
+    private List<String> getAnnotationName(GroovySourceAST t, SimpleGroovyProgramElementDoc node) {
+
+        GroovySourceAST modifiers = t.childOfType(MODIFIERS);
+
+        List<GroovySourceAST> annotations = null ;
+        if(modifiers != null)
+            annotations =  modifiers.childrenOfType(ANNOTATION);
+
+
+        List<String> annotationNames = null;
+        if(annotations != null) {
+            annotationNames = new ArrayList<String>();
+            for (GroovySourceAST annotation : annotations) {
+                GroovySourceAST classNode = annotation.childOfType(IDENT);
+                if (classNode != null) {
+                    annotationNames.add(extractName(classNode));
+                }
+            }
+        }
+
+        return annotationNames;
+    }
+
+
+    private boolean isIgnorePackageFieldsMethods(GroovySourceAST t, SimpleGroovyClassDoc currentClassDoc)
+    {
+        boolean ignoreProctectedFields = false;
+        if(getAnnotationName(t,currentClassDoc) != null && getAnnotationName(t, currentClassDoc).contains("PackageScope")) {
+
+            if ((this.properties.getProperty("publicScope") != null && this.properties.getProperty("publicScope").equalsIgnoreCase("true")))
+            {
+                ignoreProctectedFields = true;
+            }
+
+        }
+
+        return ignoreProctectedFields;
     }
 
     private SimpleGroovyMethodDoc createMethod(GroovySourceAST t, SimpleGroovyClassDoc currentClassDoc) {
@@ -309,6 +352,7 @@ public class SimpleGroovyClassDocAssembler extends VisitorAdapter implements Gro
                 currentFieldDoc.setPublic(true);
             }
             if (defaultText != null) {
+                
                 currentFieldDoc.setConstantValueExpression(defaultText);
                 String orig = currentFieldDoc.getRawCommentText();
                 currentFieldDoc.setRawCommentText(orig + "\n* @default " + defaultText);
@@ -338,17 +382,24 @@ public class SimpleGroovyClassDocAssembler extends VisitorAdapter implements Gro
         if (visit == OPENING_VISIT && !insideAnonymousInnerClass() && isFieldDefinition()) {
             SimpleGroovyClassDoc currentClassDoc = getCurrentClassDoc();
             if (currentClassDoc != null) {
+
                 String fieldName = getIdentFor(t);
                 currentFieldDoc = new SimpleGroovyFieldDoc(fieldName, currentClassDoc);
                 currentFieldDoc.setRawCommentText(getJavaDocCommentsBeforeNode(t));
                 boolean isProp = processModifiers(t, currentFieldDoc);
                 currentFieldDoc.setType(new SimpleGroovyType(getTypeOrDefault(t)));
                 processAnnotations(t, currentFieldDoc);
-                if (isProp) {
-                    currentClassDoc.addProperty(currentFieldDoc);
-                } else {
-                    currentClassDoc.add(currentFieldDoc);
+
+
+                if(!isIgnorePackageFieldsMethods(t, currentClassDoc))
+                {
+                    if (isProp) {
+                        currentClassDoc.addProperty(currentFieldDoc);
+                    } else {
+                        currentClassDoc.add(currentFieldDoc);
+                    }
                 }
+
             }
         }
     }
@@ -455,6 +506,8 @@ public class SimpleGroovyClassDocAssembler extends VisitorAdapter implements Gro
             node.addAnnotationRef(new SimpleGroovyAnnotationRef(extractName(classNode), getChildTextFromSource(t).trim()));
         }
     }
+
+
 
     private void addAnnotationRef(SimpleGroovyParameter node, GroovySourceAST t) {
         GroovySourceAST classNode = t.childOfType(IDENT);


### PR DESCRIPTION
Fix of this issue: https://jira.codehaus.org/browse/GROOVY-7257?jql=project%20%3D%20GROOVY%20AND%20resolution%20%3D%20Unresolved%20AND%20priority%20%3D%20Trivial%20ORDER%20BY%20key%20DESC. 

Major issue was, if the field was annoated with `@PackageScope` and while document generation asks only for `public`, still the package field is coming up in the documentation.  Added the fix in AST Visitor class to check if thats the case and ignore those annoated fields. 