### PR TITLE
GROOVY-7047: Static inner class crashes compiler when it references pare...

### DIFF
--- a/src/main/org/codehaus/groovy/control/ResolveVisitor.java
+++ b/src/main/org/codehaus/groovy/control/ResolveVisitor.java
@@ -889,7 +889,7 @@ public class ResolveVisitor extends ClassCodeExpressionTransformer {
                         currentClass.getName() + "' when using '.this' or '.super'.", expression);
             }
             if ((currentClass.getModifiers() & Opcodes.ACC_STATIC) == 0) return;
-            if (!currentScope.isInStaticContext()) return;
+            if (currentScope != null && !currentScope.isInStaticContext()) return;
             addError("The usage of 'Class.this' and 'Class.super' within static nested class '" +
                     currentClass.getName() + "' is not allowed in a static context.", expression);
         }

--- a/src/test/groovy/StaticThisTest.groovy
+++ b/src/test/groovy/StaticThisTest.groovy
@@ -128,4 +128,17 @@ class StaticThisTest extends CompilableTestSupport {
             """
     }
 
+    /**
+     * GROOVY-7047: Static inner class crashes compiler when it references parent's this
+     */
+    void testParentThisShouldNotBeReferredInsideStaticClass() {
+        shouldNotCompile """
+            class Foo {
+                static class Bar {
+                    def parent = Foo.this
+                }
+            }
+        """
+    }
+
 }


### PR DESCRIPTION
Added null check, which solves this issue. 