### PR TITLE
GROOVY-7008 correctly escape special chars in map keys when generating JSON

### DIFF
--- a/subprojects/groovy-json/src/main/java/groovy/json/JsonBuilder.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/JsonBuilder.java
@@ -135,7 +135,7 @@ public class JsonBuilder extends GroovyObjectSupport implements Writable {
      * assert result instanceof List
      * assert json.toString() == "[1,2,3]"
      * </code></pre>
-
+     *
      * @param args an array of values
      * @return a list of values
      */
@@ -274,7 +274,7 @@ public class JsonBuilder extends GroovyObjectSupport implements Writable {
                 } else if (arr[0] instanceof Map) {
                     return setAndGetContent(name, arr[0]);
                 }
-            } else if (arr.length == 2)  {
+            } else if (arr.length == 2) {
                 if (arr[0] instanceof Map && arr[1] instanceof Closure) {
                     Map subMap = new LinkedHashMap();
                     subMap.putAll((Map) arr[0]);

--- a/subprojects/groovy-json/src/main/java/groovy/json/JsonLexer.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/JsonLexer.java
@@ -31,6 +31,7 @@ import java.util.regex.Pattern;
  * @since 1.8.0
  */
 public class JsonLexer implements Iterator<JsonToken> {
+
     private static final char SPACE    = ' ';
     private static final char DOT      = '.';
     private static final char MINUS    = '-';
@@ -55,7 +56,6 @@ public class JsonLexer implements Iterator<JsonToken> {
 
     private JsonToken currentToken = null;
 
-
     /**
      * Instanciates a lexer with a reader from which to read JSON tokens.
      * Under the hood, the reader is wrapped in a <code>LineColumnReader</code>,
@@ -64,7 +64,7 @@ public class JsonLexer implements Iterator<JsonToken> {
      * @param reader underlying reader
      */
     public JsonLexer(Reader reader) {
-        this.reader = reader instanceof LineColumnReader ? (LineColumnReader)reader : new LineColumnReader(reader);
+        this.reader = reader instanceof LineColumnReader ? (LineColumnReader) reader : new LineColumnReader(reader);
     }
 
     /**
@@ -186,7 +186,7 @@ public class JsonLexer implements Iterator<JsonToken> {
      */
     private JsonToken readingConstant(JsonTokenType type, JsonToken token) {
         try {
-            int numCharsToRead = ((String)type.getValidator()).length();
+            int numCharsToRead = ((String) type.getValidator()).length();
             char[] chars = new char[numCharsToRead];
             reader.read(chars);
             String stringRead = new String(chars);
@@ -211,10 +211,10 @@ public class JsonLexer implements Iterator<JsonToken> {
         try {
             int readChar = 20;
             char c = SPACE;
-            while(Character.isWhitespace(c)) {
+            while (Character.isWhitespace(c)) {
                 reader.mark(1);
                 readChar = reader.read();
-                c = (char)readChar;
+                c = (char) readChar;
             }
             reader.reset();
             return readChar;
@@ -251,5 +251,4 @@ public class JsonLexer implements Iterator<JsonToken> {
     public void remove() {
         throw new UnsupportedOperationException("The method remove() is not supported on this lexer.");
     }
-
 }

--- a/subprojects/groovy-json/src/main/java/groovy/json/JsonOutput.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/JsonOutput.java
@@ -250,7 +250,7 @@ public class JsonOutput {
         } else {
             Class<?> objectClass = object.getClass();
 
-            if (CharSequence.class.isAssignableFrom(objectClass)) { // Handle String, StringBuilder, GString and other CharSequence implemenations
+            if (CharSequence.class.isAssignableFrom(objectClass)) { // Handle String, StringBuilder, GString and other CharSequence implementations
                 writeCharSequence((CharSequence) object, buffer);
             } else if (objectClass == Boolean.class) {
                 buffer.addBoolean((Boolean) object);

--- a/subprojects/groovy-json/src/main/java/groovy/json/JsonParser.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/JsonParser.java
@@ -29,13 +29,13 @@ import java.io.Reader;
  */
 public interface JsonParser {
 
-    Object parse(  String jsonString );
-    Object parse(  byte[] bytes );
-    Object parse(  byte[] bytes, String charset );
-    Object parse(  CharSequence charSequence );
-    Object parse(  char[] chars );
-    Object parse(  Reader reader );
-    Object parse(  InputStream input );
-    Object parse(  InputStream input, String charset );
-    Object parse(  File file, String charset);
+    Object parse(String jsonString);
+    Object parse(byte[] bytes);
+    Object parse(byte[] bytes, String charset);
+    Object parse(CharSequence charSequence);
+    Object parse(char[] chars);
+    Object parse(Reader reader);
+    Object parse(InputStream input);
+    Object parse(InputStream input, String charset);
+    Object parse(File file, String charset);
 }

--- a/subprojects/groovy-json/src/main/java/groovy/json/JsonParserType.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/JsonParserType.java
@@ -21,7 +21,7 @@ package groovy.json;
  * To enable the INDEX_OVERLAY parser do this:
  *
  * <code><pre>
- *             parser = new JsonSlurper().setType( JsonParserType.INDEX_OVERLAY );
+ *             parser = new JsonSlurper().setType(JsonParserType.INDEX_OVERLAY);
  * </pre></code>
  *
  * INDEX_OVERLAY should be your parser of choice.
@@ -54,7 +54,8 @@ package groovy.json;
  */
 public enum JsonParserType {
 
-    /** Fastest parser, but has pointers (indexes really) to original char buffer.
+    /**
+     * Fastest parser, but has pointers (indexes really) to original char buffer.
      * Care must be used if putting parse maps into a long term cache as members of map
      * maybe index overlay objects pointing to original buffer.
      * You can mitigate these risks by using chop and lazy chop.
@@ -66,7 +67,7 @@ public enum JsonParserType {
      * You do not need chop or lazy chop if you are not putting the map into a long term cache.
      * You do not need chop or lazy chop if you are doing object de-serialization.
      * Recommendation is to use this for JSON buffers under 2MB.
-     * */
+     */
     INDEX_OVERLAY,
     /**
      * Parser uses an abstraction that allows it to handle any size file by using a char [] windowing,

--- a/subprojects/groovy-json/src/main/java/groovy/json/JsonSlurper.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/JsonSlurper.java
@@ -76,7 +76,7 @@ import java.util.*;
  * To enable the INDEX_OVERLAY parser do this:
  *
  * <code><pre>
- *             parser = new JsonSlurper().setType( JsonParserType.INDEX_OVERLAY );
+ *             parser = new JsonSlurper().setType(JsonParserType.INDEX_OVERLAY);
  * </pre></code>
  *
  * @see groovy.json.JsonParserType
@@ -86,7 +86,6 @@ import java.util.*;
  * @since 1.8.0
  */
 public class JsonSlurper {
-
 
     private int maxSizeForInMemory = 2000000;
     private boolean chop = false;
@@ -104,13 +103,12 @@ public class JsonSlurper {
         return maxSizeForInMemory;
     }
 
-
     /**
      * Max size before Slurper starts to use windowing buffer parser.
      * @since 2.3
      * @return JsonSlurper
      */
-    public JsonSlurper setMaxSizeForInMemory( int maxSizeForInMemory ) {
+    public JsonSlurper setMaxSizeForInMemory(int maxSizeForInMemory) {
         this.maxSizeForInMemory = maxSizeForInMemory;
         return this;
     }
@@ -124,13 +122,12 @@ public class JsonSlurper {
         return type;
     }
 
-
     /** Parser type.
      * @since 2.3
      * @see groovy.json.JsonParserType
      * @return  JsonSlurper
      */
-    public JsonSlurper setType( JsonParserType type ) {
+    public JsonSlurper setType(JsonParserType type) {
         this.type = type;
         return this;
     }
@@ -149,11 +146,10 @@ public class JsonSlurper {
      * @see groovy.json.JsonParserType
      * @return  JsonSlurper
      */
-    public JsonSlurper setChop( boolean chop ) {
+    public JsonSlurper setChop(boolean chop) {
         this.chop = chop;
         return this;
     }
-
 
     /** Turns on buffer lazy chopping for index overlay.
      * @see groovy.json.JsonParserType
@@ -164,13 +160,12 @@ public class JsonSlurper {
         return lazyChop;
     }
 
-
     /** Turns on buffer lazy chopping for index overlay.
      * @see groovy.json.JsonParserType
      * @return  JsonSlurper
      * @since 2.3
      */
-    public JsonSlurper setLazyChop( boolean lazyChop ) {
+    public JsonSlurper setLazyChop(boolean lazyChop) {
         this.lazyChop = lazyChop;
         return this;
     }
@@ -184,13 +179,12 @@ public class JsonSlurper {
         return checkDates;
     }
 
-
     /**
      * Determine if slurper will automatically parse strings it recognizes as dates. Index overlay only.
      * @return on or off
      * @since 2.3
      */
-    public JsonSlurper setCheckDates( boolean checkDates ) {
+    public JsonSlurper setCheckDates(boolean checkDates) {
         this.checkDates = checkDates;
         return this;
     }
@@ -202,10 +196,10 @@ public class JsonSlurper {
      * @return a data structure of lists and maps
      */
     public Object parseText(String text) {
-        if (text == null || "".equals ( text )) {
-            throw new IllegalArgumentException ( "Text must not be null"  );
+        if (text == null || "".equals(text)) {
+            throw new IllegalArgumentException("Text must not be null");
         }
-        return createParser().parse( text );
+        return createParser().parse(text);
     }
 
     /**
@@ -215,8 +209,8 @@ public class JsonSlurper {
      * @return a data structure of lists and maps
      */
     public Object parse(Reader reader) {
-        if (reader == null ) {
-            throw new IllegalArgumentException ( "Reader must not be null"  );
+        if (reader == null) {
+            throw new IllegalArgumentException("Reader must not be null");
         }
 
         Object content;
@@ -224,8 +218,6 @@ public class JsonSlurper {
         content = parser.parse(reader);
         return content;
     }
-
-
 
     /**
      * Parse a JSON data structure from content from an inputStream
@@ -235,13 +227,13 @@ public class JsonSlurper {
      * @since 2.3
      */
     public Object parse(InputStream inputStream) {
-        if (inputStream == null ) {
-            throw new IllegalArgumentException ( "inputStream must not be null"  );
+        if (inputStream == null) {
+            throw new IllegalArgumentException("inputStream must not be null");
         }
 
         Object content;
         JsonParser parser = createParser();
-        content = parser.parse( inputStream );
+        content = parser.parse(inputStream);
         return content;
     }
 
@@ -254,18 +246,17 @@ public class JsonSlurper {
      * @since 2.3
      */
     public Object parse(InputStream inputStream, String charset) {
-        if (inputStream == null ) {
-            throw new IllegalArgumentException ( "inputStream must not be null"  );
+        if (inputStream == null) {
+            throw new IllegalArgumentException("inputStream must not be null");
         }
-        if ( charset == null ) {
-            throw new IllegalArgumentException ( "charset must not be null"  );
+        if (charset == null) {
+            throw new IllegalArgumentException("charset must not be null");
         }
 
         Object content;
         content = createParser().parse(inputStream, charset);
         return content;
     }
-
 
     /**
      * Parse a JSON data structure from content from a byte array.
@@ -276,20 +267,18 @@ public class JsonSlurper {
      * @since 2.3
      */
     public Object parse(byte [] bytes, String charset) {
-        if ( bytes == null ) {
-            throw new IllegalArgumentException ( "bytes must not be null"  );
+        if (bytes == null) {
+            throw new IllegalArgumentException("bytes must not be null");
         }
 
-        if ( charset == null ) {
-            throw new IllegalArgumentException ( "charset must not be null"  );
+        if (charset == null) {
+            throw new IllegalArgumentException("charset must not be null");
         }
-
 
         Object content;
         content = createParser().parse(bytes, charset);
         return content;
     }
-
 
     /**
      * Parse a JSON data structure from content from a byte array.
@@ -299,8 +288,8 @@ public class JsonSlurper {
      * @since 2.3
      */
     public Object parse(byte [] bytes) {
-        if ( bytes == null ) {
-            throw new IllegalArgumentException ( "bytes must not be null"  );
+        if (bytes == null) {
+            throw new IllegalArgumentException("bytes must not be null");
         }
 
         Object content;
@@ -316,8 +305,8 @@ public class JsonSlurper {
      * @since 2.3
      */
     public Object parse(char [] chars) {
-        if ( chars == null ) {
-            throw new IllegalArgumentException ( "chars must not be null"  );
+        if (chars == null) {
+            throw new IllegalArgumentException("chars must not be null");
         }
 
         Object content;
@@ -325,10 +314,8 @@ public class JsonSlurper {
         return content;
     }
 
-
     private JsonParser createParser() {
         switch (type) {
-
             case LAX:
                 return new JsonParserLax(false, chop, lazyChop, checkDates);
 
@@ -371,11 +358,10 @@ public class JsonSlurper {
     }
 
     private Object parseFile(File file, String charset) {
-
-        if (file.length() < maxSizeForInMemory)  {
+        if (file.length() < maxSizeForInMemory) {
             return createParser().parse(file, charset);
         } else {
-            return new JsonParserUsingCharacterSource().parse ( file, charset );
+            return new JsonParserUsingCharacterSource().parse(file, charset);
         }
     }
 
@@ -422,8 +408,8 @@ public class JsonSlurper {
             } else {
                 reader = ResourceGroovyMethods.newReader(url, params);
             }
-            return createParser ().parse ( reader );
-        } catch(IOException ioe) {
+            return createParser().parse(reader);
+        } catch (IOException ioe) {
             throw new JsonException("Unable to process url: " + url.toString(), ioe);
         } finally {
             if (reader != null) {
@@ -479,7 +465,7 @@ public class JsonSlurper {
                 reader = ResourceGroovyMethods.newReader(url, params, charset);
             }
             return parse(reader);
-        } catch(IOException ioe) {
+        } catch (IOException ioe) {
             throw new JsonException("Unable to process url: " + url.toString(), ioe);
         } finally {
             if (reader != null) {

--- a/subprojects/groovy-json/src/main/java/groovy/json/JsonSlurperClassic.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/JsonSlurperClassic.java
@@ -72,7 +72,7 @@ public class JsonSlurperClassic {
             throw new IllegalArgumentException("The JSON input text should neither be null nor empty.");
         }
 
-        return parse(new LineColumnReader (new StringReader (text)));
+        return parse(new LineColumnReader(new StringReader(text)));
     }
 
     /**
@@ -131,16 +131,16 @@ public class JsonSlurperClassic {
         Reader reader = null;
         try {
             if (charset == null || charset.length() == 0) {
-                reader = ResourceGroovyMethods.newReader ( file );
+                reader = ResourceGroovyMethods.newReader(file);
             } else {
                 reader = ResourceGroovyMethods.newReader(file, charset);
             }
             return parse(reader);
-        } catch(IOException ioe) {
+        } catch (IOException ioe) {
             throw new JsonException("Unable to process file: " + file.getPath(), ioe);
         } finally {
             if (reader != null) {
-                DefaultGroovyMethodsSupport.closeWithWarning ( reader );
+                DefaultGroovyMethodsSupport.closeWithWarning(reader);
             }
         }
     }
@@ -189,7 +189,7 @@ public class JsonSlurperClassic {
                 reader = ResourceGroovyMethods.newReader(url, params);
             }
             return parse(reader);
-        } catch(IOException ioe) {
+        } catch (IOException ioe) {
             throw new JsonException("Unable to process url: " + url.toString(), ioe);
         } finally {
             if (reader != null) {
@@ -245,7 +245,7 @@ public class JsonSlurperClassic {
                 reader = ResourceGroovyMethods.newReader(url, params, charset);
             }
             return parse(reader);
-        } catch(IOException ioe) {
+        } catch (IOException ioe) {
             throw new JsonException("Unable to process url: " + url.toString(), ioe);
         } finally {
             if (reader != null) {
@@ -261,7 +261,7 @@ public class JsonSlurperClassic {
      * @return a list of JSON values
      */
     private List parseArray(JsonLexer lexer) {
-        List content = new ArrayList ();
+        List content = new ArrayList();
 
         JsonToken currentToken;
 
@@ -329,7 +329,7 @@ public class JsonSlurperClassic {
      * @return a Map representing a JSON object
      */
     private Map parseObject(JsonLexer lexer) {
-        Map content = new HashMap ();
+        Map content = new HashMap();
 
         JsonToken previousToken = null;
         JsonToken currentToken = null;
@@ -378,7 +378,7 @@ public class JsonSlurperClassic {
                         "Expected " + COLON.getLabel() + " " +
                                 "on line: " + currentToken.getStartLine() + ", " +
                                 "column: " + currentToken.getStartColumn() + ".\n" +
-                                "But got '" + currentToken.getText() +  "' instead."
+                                "But got '" + currentToken.getText() + "' instead."
                 );
             }
 

--- a/subprojects/groovy-json/src/main/java/groovy/json/JsonToken.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/JsonToken.java
@@ -27,6 +27,7 @@ import static groovy.json.JsonTokenType.*;
  * @since 1.8.0
  */
 public class JsonToken {
+
     private static final BigInteger MAX_LONG    = BigInteger.valueOf(Long.MAX_VALUE);
     private static final BigInteger MIN_LONG    = BigInteger.valueOf(Long.MIN_VALUE);
     private static final BigInteger MAX_INTEGER = BigInteger.valueOf(Integer.MAX_VALUE);
@@ -72,9 +73,9 @@ public class JsonToken {
             } else {
                 // an integer number
                 BigInteger v = new BigInteger(text);
-                if(v.compareTo(MAX_INTEGER) <= 0 && v.compareTo(MIN_INTEGER) >= 0 ) {
+                if (v.compareTo(MAX_INTEGER) <= 0 && v.compareTo(MIN_INTEGER) >= 0) {
                     return v.intValue();
-                } else if (v.compareTo(MAX_LONG) <= 0 && v.compareTo(MIN_LONG) >= 0 ) {
+                } else if (v.compareTo(MAX_LONG) <= 0 && v.compareTo(MIN_LONG) >= 0) {
                     return v.longValue();
                 } else {
                     return v;

--- a/subprojects/groovy-json/src/main/java/groovy/json/JsonTokenType.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/JsonTokenType.java
@@ -88,10 +88,10 @@ public enum JsonTokenType {
      */
     public boolean matching(String input) {
         if (validator instanceof Pattern) {
-            Matcher matcher = ((Pattern)validator).matcher(input);
+            Matcher matcher = ((Pattern) validator).matcher(input);
             return matcher.matches();
         } else if (validator instanceof Closure) {
-            return (Boolean)((Closure) validator).call(input);
+            return (Boolean) ((Closure) validator).call(input);
         } else if (validator instanceof String) {
             return input.equals(validator);
         } else {

--- a/subprojects/groovy-json/src/main/java/groovy/json/StreamingJsonBuilder.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/StreamingJsonBuilder.java
@@ -39,7 +39,7 @@ import java.util.*;
  * Example:
  * <pre class="groovyTestCase">
  *     new StringWriter().with { w ->
- *         def builder = new groovy.json.StreamingJsonBuilder( w )
+ *         def builder = new groovy.json.StreamingJsonBuilder(w)
  *         builder.people {
  *             person {
  *                 firstName 'Tim'
@@ -95,7 +95,7 @@ public class StreamingJsonBuilder extends GroovyObjectSupport {
      * Example:
      * <pre class="groovyTestCase">
      * new StringWriter().with { w ->
-     *   def json = new groovy.json.StreamingJsonBuilder( w )
+     *   def json = new groovy.json.StreamingJsonBuilder(w)
      *   json name: "Tim", age: 31
      *
      *   assert w.toString() == '{"name":"Tim","age":31}'
@@ -117,7 +117,7 @@ public class StreamingJsonBuilder extends GroovyObjectSupport {
      * Example:
      * <pre class="groovyTestCase">
      * new StringWriter().with { w ->
-     *   def json = new groovy.json.StreamingJsonBuilder( w )
+     *   def json = new groovy.json.StreamingJsonBuilder(w)
      *   def result = json([1, 2, 3])
      *
      *   assert result == [ 1, 2, 3 ]
@@ -140,7 +140,7 @@ public class StreamingJsonBuilder extends GroovyObjectSupport {
      * Example:
      * <pre class="groovyTestCase">
      * new StringWriter().with { w ->
-     *   def json = new groovy.json.StreamingJsonBuilder( w )
+     *   def json = new groovy.json.StreamingJsonBuilder(w)
      *   def result = json 1, 2, 3
      *
      *   assert result instanceof List
@@ -167,7 +167,7 @@ public class StreamingJsonBuilder extends GroovyObjectSupport {
      * def authors = [new Author (name: "Guillaume"), new Author (name: "Jochen"), new Author (name: "Paul")]
      *
      * new StringWriter().with { w ->
-     *     def json = new groovy.json.StreamingJsonBuilder( w )
+     *     def json = new groovy.json.StreamingJsonBuilder(w)
      *     json authors, { Author author ->
      *         name author.name
      *     }
@@ -190,7 +190,7 @@ public class StreamingJsonBuilder extends GroovyObjectSupport {
      * Example:
      * <pre class="groovyTestCase">
      * new StringWriter().with { w ->
-     *   def json = new groovy.json.StreamingJsonBuilder( w )
+     *   def json = new groovy.json.StreamingJsonBuilder(w)
      *   json {
      *      name "Tim"
      *      age 39
@@ -224,7 +224,7 @@ public class StreamingJsonBuilder extends GroovyObjectSupport {
      * Example with a classicala builder-style:
      * <pre class="groovyTestCase">
      * new StringWriter().with { w ->
-     *     def json = new groovy.json.StreamingJsonBuilder( w )
+     *     def json = new groovy.json.StreamingJsonBuilder(w)
      *     json.person {
      *         name "Tim"
      *          age 28
@@ -237,7 +237,7 @@ public class StreamingJsonBuilder extends GroovyObjectSupport {
      * Or alternatively with a method call taking named arguments:
      * <pre class="groovyTestCase">
      * new StringWriter().with { w ->
-     *     def json = new groovy.json.StreamingJsonBuilder( w )
+     *     def json = new groovy.json.StreamingJsonBuilder(w)
      *     json.person name: "Tim", age: 32
      *
      *     assert w.toString() == '{"person":{"name":"Tim","age":32}}'
@@ -252,7 +252,7 @@ public class StreamingJsonBuilder extends GroovyObjectSupport {
      * in case the same key is used.
      * <pre class="groovyTestCase">
      * new StringWriter().with { w ->
-     *     def json = new groovy.json.StreamingJsonBuilder( w )
+     *     def json = new groovy.json.StreamingJsonBuilder(w)
      *     json.person(name: "Tim", age: 35) { town "Manchester" }
      *
      *     assert w.toString() == '{"person":{"name":"Tim","age":35,"town":"Manchester"}}'
@@ -262,7 +262,7 @@ public class StreamingJsonBuilder extends GroovyObjectSupport {
      * The empty args call will create a key whose value will be an empty JSON object:
      * <pre class="groovyTestCase">
      * new StringWriter().with { w ->
-     *     def json = new groovy.json.StreamingJsonBuilder( w )
+     *     def json = new groovy.json.StreamingJsonBuilder(w)
      *     json.person()
      *
      *     assert w.toString() == '{"person":{}}'
@@ -333,7 +333,6 @@ public class StreamingJsonBuilder extends GroovyObjectSupport {
             throw new JsonException("Expected no arguments, a single map, a single closure, or a map and closure as arguments.");
         }
     }
-
 }
 
 class StreamingJsonDelegate extends GroovyObjectSupport {
@@ -419,5 +418,4 @@ class StreamingJsonDelegate extends GroovyObjectSupport {
         curried.setResolveStrategy(Closure.DELEGATE_FIRST);
         curried.call();
     }
-
 }

--- a/subprojects/groovy-json/src/main/java/groovy/json/StringEscapeUtils.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/StringEscapeUtils.java
@@ -54,7 +54,7 @@ public class StringEscapeUtils {
      * instance to operate.
      */
     public StringEscapeUtils() {
-      super();
+        super();
     }
 
     // Java and JavaScript
@@ -191,27 +191,27 @@ public class StringEscapeUtils {
                 out.write("\\u00" + hex(ch));
             } else if (ch < 32) {
                 switch (ch) {
-                    case '\b' :
+                    case '\b':
                         out.write('\\');
                         out.write('b');
                         break;
-                    case '\n' :
+                    case '\n':
                         out.write('\\');
                         out.write('n');
                         break;
-                    case '\t' :
+                    case '\t':
                         out.write('\\');
                         out.write('t');
                         break;
-                    case '\f' :
+                    case '\f':
                         out.write('\\');
                         out.write('f');
                         break;
-                    case '\r' :
+                    case '\r':
                         out.write('\\');
                         out.write('r');
                         break;
-                    default :
+                    default:
                         if (ch > 0xf) {
                             out.write("\\u00" + hex(ch));
                         } else {
@@ -221,27 +221,27 @@ public class StringEscapeUtils {
                 }
             } else {
                 switch (ch) {
-                    case '\'' :
+                    case '\'':
                         if (escapeSingleQuote) {
                             out.write('\\');
                         }
                         out.write('\'');
                         break;
-                    case '"' :
+                    case '"':
                         out.write('\\');
                         out.write('"');
                         break;
-                    case '\\' :
+                    case '\\':
                         out.write('\\');
                         out.write('\\');
                         break;
-                    case '/' :
+                    case '/':
                         if (escapeForwardSlash) {
                             out.write('\\');
                         }
                         out.write('/');
                         break;
-                    default :
+                    default:
                         out.write(ch);
                         break;
                 }
@@ -252,7 +252,7 @@ public class StringEscapeUtils {
     /**
      * Returns an upper case hexadecimal <code>String</code> for the given
      * character.
-     * 
+     *
      * @param ch The character to convert.
      * @return An upper case hexadecimal <code>String</code>
      */
@@ -416,6 +416,4 @@ public class StringEscapeUtils {
     public static void unescapeJavaScript(Writer out, String str) throws IOException {
         unescapeJava(out, str);
     }
-
-
 }

--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/BaseJsonParser.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/BaseJsonParser.java
@@ -120,10 +120,8 @@ public abstract class BaseJsonParser implements JsonParser {
     }
 
     public Object parse(Reader reader) {
-
         fileInputBuf = IO.read(reader, fileInputBuf, bufSize);
         return parse(fileInputBuf.readForRecycle());
-
     }
 
     public Object parse(InputStream input) {
@@ -141,7 +139,6 @@ public abstract class BaseJsonParser implements JsonParser {
     private final CharBuf builder = CharBuf.create(20);
 
     public Object parse(File file, String charset) {
-
         Reader reader = null;
         try {
             if (charset == null || charset.length() == 0) {
@@ -157,7 +154,6 @@ public abstract class BaseJsonParser implements JsonParser {
                 DefaultGroovyMethodsSupport.closeWithWarning(reader);
             }
         }
-
     }
 
     protected static boolean isDecimalChar(int currentChar) {
@@ -170,11 +166,9 @@ public abstract class BaseJsonParser implements JsonParser {
                 return true;
         }
         return false;
-
     }
 
     protected static boolean isDelimiter(int c) {
-
         return c == COMMA || c == CLOSED_CURLY || c == CLOSED_BRACKET;
     }
 
@@ -201,7 +195,6 @@ public abstract class BaseJsonParser implements JsonParser {
                 indexHolder[0] = index;
                 return true;
             }
-
         }
 
         indexHolder[0] = index;
@@ -233,5 +226,4 @@ public abstract class BaseJsonParser implements JsonParser {
         }
         return index;
     }
-
 }

--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/ByteScanner.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/ByteScanner.java
@@ -31,7 +31,6 @@ public class ByteScanner {
      * @return the encoded nibble (1/2 byte).
      */
     protected static int encodeNibbleToHexAsciiCharByte(final int nibble) {
-
         switch (nibble) {
             case 0x00:
             case 0x01:
@@ -64,9 +63,7 @@ public class ByteScanner {
      * @param encoded the array to which each encoded nibbles are now ascii hex representations.
      */
     public static void encodeByteIntoTwoAsciiCharBytes(final int decoded, final byte[] encoded) {
-
         encoded[0] = (byte) encodeNibbleToHexAsciiCharByte((decoded >> 4) & 0x0F);
         encoded[1] = (byte) encodeNibbleToHexAsciiCharByte(decoded & 0x0F);
     }
-
 }

--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/Cache.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/Cache.java
@@ -25,6 +25,7 @@ package groovy.json.internal;
  * @author Rick Hightower
  */
 public interface Cache<KEY, VALUE> {
+
     void put(KEY key, VALUE value);
 
     VALUE get(KEY key);

--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/CharBuf.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/CharBuf.java
@@ -29,6 +29,7 @@ import java.math.BigInteger;
  * @author Rick Hightower
  */
 public class CharBuf extends Writer implements CharSequence {
+
     protected int capacity = 16;
     protected int location = 0;
 
@@ -81,14 +82,12 @@ public class CharBuf extends Writer implements CharSequence {
     }
 
     public void write(char[] cbuf, int off, int len) {
-
         if (off == 0 && cbuf.length == len) {
             this.add(cbuf);
         } else {
             char[] buffer = ArrayUtils.copyRange(cbuf, off, off + len);
             this.add(buffer);
         }
-
     }
 
     public void flush() throws IOException {
@@ -112,7 +111,6 @@ public class CharBuf extends Writer implements CharSequence {
     }
 
     public final CharBuf add(int i) {
-
         add(Integer.toString(i));
         return this;
     }
@@ -138,7 +136,6 @@ public class CharBuf extends Writer implements CharSequence {
     }
 
     public final CharBuf addInt(Integer key) {
-
         if (icache == null) {
             icache = new SimpleCache<Integer, char[]>(20, CacheType.LRU);
         }
@@ -163,31 +160,26 @@ public class CharBuf extends Writer implements CharSequence {
     }
 
     public final CharBuf addBoolean(boolean b) {
-
         add(Boolean.toString(b));
         return this;
     }
 
     public final CharBuf add(byte i) {
-
         add(Byte.toString(i));
         return this;
     }
 
     public final CharBuf addByte(byte i) {
-
         addInt(i);
         return this;
     }
 
     public final CharBuf add(short i) {
-
         add(Short.toString(i));
         return this;
     }
 
     public final CharBuf addShort(short i) {
-
         addInt(i);
         return this;
     }
@@ -210,7 +202,6 @@ public class CharBuf extends Writer implements CharSequence {
     }
 
     public final CharBuf addDouble(Double key) {
-
         if (dcache == null) {
             dcache = new SimpleCache<Double, char[]>(20, CacheType.LRU);
         }
@@ -239,7 +230,6 @@ public class CharBuf extends Writer implements CharSequence {
     }
 
     public final CharBuf addFloat(Float key) {
-
         if (fcache == null) {
             fcache = new SimpleCache<Float, char[]>(20, CacheType.LRU);
         }
@@ -272,7 +262,6 @@ public class CharBuf extends Writer implements CharSequence {
     }
 
     public final CharBuf addChar(final char ch) {
-
         int _location = location;
         char[] _buffer = buffer;
         int _capacity = capacity;
@@ -280,7 +269,6 @@ public class CharBuf extends Writer implements CharSequence {
         if (1 + _location > _capacity) {
             _buffer = Chr.grow(_buffer);
             _capacity = _buffer.length;
-
         }
 
         _buffer[_location] = ch;
@@ -327,7 +315,6 @@ public class CharBuf extends Writer implements CharSequence {
     }
 
     public final CharBuf addQuoted(char[] chars) {
-
         int _location = location;
         char[] _buffer = buffer;
         int _capacity = capacity;
@@ -355,7 +342,6 @@ public class CharBuf extends Writer implements CharSequence {
     public final CharBuf addJsonEscapedString(String jsonString) {
         char[] charArray = FastStringUtils.toCharArray(jsonString);
         return addJsonEscapedString(charArray);
-
     }
 
     private static boolean hasAnyJSONControlOrUnicodeChars(int c) {
@@ -375,7 +361,6 @@ public class CharBuf extends Writer implements CharSequence {
     }
 
     private static boolean hasAnyJSONControlChars(final char[] charArray) {
-
         int index = 0;
         char c;
         while (true) {
@@ -385,7 +370,6 @@ public class CharBuf extends Writer implements CharSequence {
             }
             if (++index >= charArray.length) return false;
         }
-
     }
 
     public final CharBuf addJsonEscapedString(final char[] charArray) {
@@ -402,7 +386,6 @@ public class CharBuf extends Writer implements CharSequence {
     final byte[] charTo = new byte[2];
 
     private final CharBuf doAddJsonEscapedString(char[] charArray) {
-
         char[] _buffer = buffer;
         int _location = this.location;
 
@@ -414,7 +397,6 @@ public class CharBuf extends Writer implements CharSequence {
 
         int sizeNeeded = (ensureThisMuch) + _location;
         if (sizeNeeded > capacity) {
-
             int growBy = (_buffer.length * 2) < sizeNeeded ? sizeNeeded : (_buffer.length * 2);
             _buffer = Chr.grow(buffer, growBy);
             capacity = _buffer.length;
@@ -425,11 +407,9 @@ public class CharBuf extends Writer implements CharSequence {
 
         int index = 0;
         while (true) {
-
             char c = charArray[index];
 
             if (hasAnyJSONControlOrUnicodeChars(c)) {
-
                    /* We are covering our bet with a safety net.
                       otherwise we would have to have 5x buffer
                       allocated for control chars */
@@ -482,14 +462,12 @@ public class CharBuf extends Writer implements CharSequence {
                         _buffer[_location] = 'r';
                         _location++;
                         break;
-
                     case '\t':
                         _buffer[_location] = '\\';
                         _location++;
                         _buffer[_location] = 't';
                         _location++;
                         break;
-
                     default:
                         _buffer[_location] = '\\';
                         _location++;
@@ -504,7 +482,6 @@ public class CharBuf extends Writer implements CharSequence {
                             for (int b : _encoded) {
                                 _buffer[_location] = (char) b;
                                 _location++;
-
                             }
                         } else {
                             Byt.charTo(_charTo, c);
@@ -516,19 +493,14 @@ public class CharBuf extends Writer implements CharSequence {
                                     _location++;
                                 }
                             }
-
                         }
-
                 }
             } else {
-
                 _buffer[_location] = c;
                 _location++;
-
             }
 
             if (++index >= charArray.length) break;
-
         }
         _buffer[_location] = '"';
         _location++;
@@ -549,7 +521,6 @@ public class CharBuf extends Writer implements CharSequence {
         int _capacity = capacity;
 
         try {
-
             int sizeNeeded = chars.length + 3 + _location;
             if (sizeNeeded > _capacity) {
                 _buffer = Chr.grow(_buffer, sizeNeeded * 2);
@@ -607,13 +578,10 @@ public class CharBuf extends Writer implements CharSequence {
 
     private static final void sysstemarraycopy(final char[] src, final int srcPos, final char[] dest, final int destPos, final int length) {
         System.arraycopy(src, srcPos, dest, destPos, length);
-
     }
 
     private static final void arraycopy(final char[] src, final int srcPos, final char[] dest, final int destPos, final int length) {
-
         sysstemarraycopy(src, srcPos, dest, destPos, length);
-
     }
 
     public CharBuf add(byte[] bytes, int start, int end) {
@@ -663,7 +631,6 @@ public class CharBuf extends Writer implements CharSequence {
     }
 
     public String toStringAndRecycle() {
-
         String str = new String(buffer, 0, location);
         location = 0;
         return str;
@@ -715,13 +682,11 @@ public class CharBuf extends Writer implements CharSequence {
     }
 
     public Number toIntegerWrapper() {
-
         if (CharScanner.isInteger(buffer, 0, location)) {
             return intValue();
         } else {
             return longValue();
         }
-
     }
 
     static final char[] nullChars = "null".toCharArray();
@@ -751,7 +716,6 @@ public class CharBuf extends Writer implements CharSequence {
         add(chars);
 
         return this;
-
     }
 
     private Cache<BigInteger, char[]> bigICache;
@@ -771,19 +735,16 @@ public class CharBuf extends Writer implements CharSequence {
         add(chars);
 
         return this;
-
     }
 
     private Cache<Long, char[]> lcache;
 
     public final CharBuf addLong(long l) {
-
         addLong(Long.valueOf(l));
         return this;
     }
 
     public final CharBuf addLong(Long key) {
-
         if (lcache == null) {
             lcache = new SimpleCache<Long, char[]>(20, CacheType.LRU);
         }
@@ -856,7 +817,6 @@ public class CharBuf extends Writer implements CharSequence {
                             break;
 
                         case 'u':
-
                             if (index + 4 < to) {
                                 String hex = new String(chars, index + 1, 4);
                                 char unicode = (char) Integer.parseInt(hex, 16);
@@ -864,6 +824,7 @@ public class CharBuf extends Writer implements CharSequence {
                                 index += 4;
                             }
                             break;
+
                         default:
                             throw new JsonException("Unable to decode string");
                     }
@@ -877,9 +838,7 @@ public class CharBuf extends Writer implements CharSequence {
         this.location = location;
 
         return this;
-
     }
-
 }
 
 

--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/CharBuf.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/CharBuf.java
@@ -515,35 +515,16 @@ public class CharBuf extends Writer implements CharSequence {
         return addJsonFieldName(FastStringUtils.toCharArray(str));
     }
 
+    private static final char[] EMPTY_STRING_CHARS = Chr.array('"', '"');
+
     public final CharBuf addJsonFieldName(char[] chars) {
-        int _location = location;
-        char[] _buffer = buffer;
-        int _capacity = capacity;
-
-        try {
-            int sizeNeeded = chars.length + 3 + _location;
-            if (sizeNeeded > _capacity) {
-                _buffer = Chr.grow(_buffer, sizeNeeded * 2);
-                _capacity = _buffer.length;
-            }
-            _buffer[_location] = '"';
-            _location++;
-
-            arraycopy(chars, 0, _buffer, _location, chars.length);
-
-            _location += (chars.length);
-            _buffer[_location] = '"';
-            _location++;
-            _buffer[_location] = ':';
-            _location++;
-
-            location = _location;
-            buffer = _buffer;
-            capacity = _capacity;
-            return this;
-        } catch (Exception ex) {
-            return Exceptions.handle(CharBuf.class, Exceptions.sputs(toDebugString(), new String(chars), "_location", _location), ex);
+        if (chars.length > 0) {
+            addJsonEscapedString(chars);
+        } else {
+            addChars(EMPTY_STRING_CHARS);
         }
+        addChar(':');
+        return this;
     }
 
     public final CharBuf addQuoted(String str) {

--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/CharScanner.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/CharScanner.java
@@ -26,6 +26,7 @@ import static groovy.json.internal.Exceptions.handle;
  * @author Richard Hightower
  */
 public class CharScanner {
+
     protected static final int COMMA = ',';
     protected static final int CLOSED_CURLY = '}';
     protected static final int CLOSED_BRACKET = ']';
@@ -46,10 +47,12 @@ public class CharScanner {
     protected static final int PLUS = '+';
     protected static final int DOUBLE_QUOTE = '"';
     protected static final int ESCAPE = '\\';
+
     static final String MIN_LONG_STR_NO_SIGN = String.valueOf(Long.MIN_VALUE);
     static final String MAX_LONG_STR = String.valueOf(Long.MAX_VALUE);
     static final String MIN_INT_STR_NO_SIGN = String.valueOf(Integer.MIN_VALUE);
     static final String MAX_INT_STR = String.valueOf(Integer.MAX_VALUE);
+
     private static double powersOf10[] = {
             1.0,
             10.0,
@@ -70,7 +73,6 @@ public class CharScanner {
             10000000000000000.0,
             100000000000000000.0,
             1000000000000000000.0,
-
     };
 
     public static boolean isDigit(int c) {
@@ -109,7 +111,6 @@ public class CharScanner {
             }
         }
         return false;
-
     }
 
     public static boolean isDigits(final char[] inputArray) {
@@ -149,7 +150,6 @@ public class CharScanner {
         }
 
         if (c != split) {
-
             results[resultIndex] = Chr.copy(
                     inputArray, startCurrentLineIndex, currentLineLength - 1);
             resultIndex++;
@@ -183,8 +183,8 @@ public class CharScanner {
             inner:
             for (j = 0; j < delims.length; j++) {
                 split = delims[j];
-                if (c == split) {
 
+                if (c == split) {
                     results[resultIndex] = Chr.copy(
                             inputArray, startCurrentLineIndex, currentLineLength - 1);
                     startCurrentLineIndex = index + 1; //skip the char
@@ -197,7 +197,6 @@ public class CharScanner {
         }
 
         if (!Chr.in(c, delims)) {
-
             results[resultIndex] = Chr.copy(
                     inputArray, startCurrentLineIndex, currentLineLength - 1);
             resultIndex++;
@@ -226,9 +225,7 @@ public class CharScanner {
         for (; index < inputArray.length; index++, currentLineLength++) {
             c = inputArray[index];
             if (c == split) {
-
                 if (resultIndex == results.length) {
-
                     results = _grow(results);
                 }
 
@@ -242,7 +239,6 @@ public class CharScanner {
         }
 
         if (c != split) {
-
             results[resultIndex] = Chr.copy(
                     inputArray, startCurrentLineIndex, currentLineLength - 1);
             resultIndex++;
@@ -271,16 +267,13 @@ public class CharScanner {
         char split;
 
         for (; index < inputArray.length; index++, currentLineLength++) {
-
             c = inputArray[index];
 
             inner:
             for (j = 0; j < delims.length; j++) {
                 split = delims[j];
                 if (c == split) {
-
                     if (resultIndex == results.length) {
-
                         results = _grow(results);
                     }
 
@@ -296,7 +289,6 @@ public class CharScanner {
         }
 
         if (!Chr.in(c, delims)) {
-
             results[resultIndex] = Chr.copy(
                     inputArray, startCurrentLineIndex, currentLineLength - 1);
             resultIndex++;
@@ -327,16 +319,13 @@ public class CharScanner {
         char split;
 
         for (; index < length; index++, currentLineLength++) {
-
             c = inputArray[index];
 
             inner:
             for (j = 0; j < delims.length; j++) {
                 split = delims[j];
                 if (c == split) {
-
                     if (resultIndex == results.length) {
-
                         results = _grow(results);
                     }
 
@@ -352,7 +341,6 @@ public class CharScanner {
         }
 
         if (!Chr.in(c, delims)) {
-
             results[resultIndex] = Chr.copy(
                     inputArray, startCurrentLineIndex, currentLineLength - 1);
             resultIndex++;
@@ -381,10 +369,8 @@ public class CharScanner {
     }
 
     public static char[][] compact(char[][] array) {
-
         int nullCount = 0;
         for (char[] ch : array) {
-
             if (ch == null || ch.length == 0) {
                 nullCount++;
             }
@@ -393,7 +379,6 @@ public class CharScanner {
 
         int j = 0;
         for (char[] ch : array) {
-
             if (ch == null || ch.length == 0) {
                 continue;
             }
@@ -405,7 +390,6 @@ public class CharScanner {
     }
 
     private static char[][] _grow(char[][] array) {
-
         char[][] newArray = new char[array.length * 2][];
         System.arraycopy(array, 0, newArray, 0, array.length);
         return newArray;
@@ -413,7 +397,6 @@ public class CharScanner {
 
     private static char[][] __shrink(char[][] array, int size) {
         char[][] newArray = new char[array.length - size][];
-
         System.arraycopy(array, 0, (char[][]) newArray, 0, array.length - size);
         return newArray;
     }
@@ -422,8 +405,7 @@ public class CharScanner {
         return isLong(digitChars, 0, digitChars.length);
     }
 
-    public static boolean isLong(char[] digitChars, int offset, int len
-    ) {
+    public static boolean isLong(char[] digitChars, int offset, int len) {
         String cmpStr = digitChars[offset] == '-' ? MIN_LONG_STR_NO_SIGN : MAX_LONG_STR;
         int cmpLen = cmpStr.length();
         if (len < cmpLen) return true;
@@ -443,7 +425,6 @@ public class CharScanner {
     }
 
     public static boolean isInteger(char[] digitChars, int offset, int len) {
-
         String cmpStr = (digitChars[offset] == '-') ? MIN_INT_STR_NO_SIGN : MAX_INT_STR;
         int cmpLen = cmpStr.length();
         if (len < cmpLen) return true;
@@ -463,9 +444,7 @@ public class CharScanner {
     }
 
     public static int parseIntFromTo(char[] digitChars, int offset, int to) {
-
         try {
-
             int num;
             boolean negative = false;
             char c = digitChars[offset];
@@ -540,7 +519,6 @@ public class CharScanner {
     }
 
     public static int parseIntFromToIgnoreDot(char[] digitChars, int offset, int to) {
-
         int num;
         boolean negative = false;
         char c = digitChars[offset];
@@ -558,14 +536,12 @@ public class CharScanner {
             if (c != '.') {
                 num = (num * 10) + (c - '0');
             }
-
         }
 
         return negative ? num * -1 : num;
     }
 
     public static long parseLongFromToIgnoreDot(char[] digitChars, int offset, int to) {
-
         long num;
         boolean negative = false;
         char c = digitChars[offset];
@@ -583,14 +559,12 @@ public class CharScanner {
             if (c != '.') {
                 num = (num * 10) + (c - '0');
             }
-
         }
 
         return negative ? num * -1 : num;
     }
 
     public static long parseLongFromTo(char[] digitChars, int offset, int to) {
-
         long num;
         boolean negative = false;
         char c = digitChars[offset];
@@ -612,7 +586,6 @@ public class CharScanner {
         }
 
         return negative ? num * -1 : num;
-
     }
 
     public static long parseLong(char[] digitChars) {
@@ -632,7 +605,6 @@ public class CharScanner {
     }
 
     protected static boolean isDelimiter(int c) {
-
         return c == COMMA || c == CLOSED_CURLY || c == CLOSED_BRACKET;
     }
 
@@ -651,7 +623,6 @@ public class CharScanner {
         for (; index < max; index++) {
             char ch = buffer[index];
             if (isNumberDigit(ch)) {
-
                 if (foundDot == true) {
                     digitsPastPoint++;
                 }
@@ -682,7 +653,6 @@ public class CharScanner {
             BigDecimal lvalue;
 
             if (length < powersOf10.length) {
-
                 if (isInteger(buffer, from, length)) {
                     lvalue = new BigDecimal(parseIntFromToIgnoreDot(buffer, from, index));
                 } else {
@@ -691,12 +661,9 @@ public class CharScanner {
 
                 BigDecimal power = new BigDecimal(powersOf10[digitsPastPoint]);
                 value = lvalue.divide(power);
-
             } else {
                 value = new BigDecimal(new String(buffer, from, length));
-
             }
-
         } else {
             value = new BigDecimal(new String(buffer, from, index - from));
         }
@@ -739,7 +706,6 @@ public class CharScanner {
         for (; index < to; index++) {
             char ch = buffer[index];
             if (isNumberDigit(ch)) {
-
                 if (foundDot == true) {
                     digitsPastPoint++;
                 }
@@ -768,7 +734,6 @@ public class CharScanner {
             long lvalue;
 
             if (length < powersOf10.length) {
-
                 if (isInteger(buffer, from, length)) {
                     lvalue = parseIntFromToIgnoreDot(buffer, from, index);
                 } else {
@@ -777,12 +742,9 @@ public class CharScanner {
 
                 double power = powersOf10[digitsPastPoint];
                 value = lvalue / power;
-
             } else {
                 value = Double.parseDouble(new String(buffer, from, length));
-
             }
-
         } else {
             value = Double.parseDouble(new String(buffer, from, index - from));
         }
@@ -795,7 +757,6 @@ public class CharScanner {
         for (; index < array.length; index++) {
             c = array[index];
             if (c > 32) {
-
                 return index;
             }
         }
@@ -807,7 +768,6 @@ public class CharScanner {
         for (; index < length; index++) {
             c = array[index];
             if (c > 32) {
-
                 return index;
             }
         }
@@ -827,7 +787,6 @@ public class CharScanner {
         }
 
         return ArrayUtils.copyRange(array, startIndex, idx);
-
     }
 
     public static char[] readNumber(char[] array, int idx, final int len) {
@@ -843,7 +802,6 @@ public class CharScanner {
         }
 
         return ArrayUtils.copyRange(array, startIndex, idx);
-
     }
 
     public static int skipWhiteSpaceFast(char[] array) {
@@ -852,7 +810,6 @@ public class CharScanner {
         for (; index < array.length; index++) {
             c = array[index];
             if (c > 32) {
-
                 return index;
             }
         }
@@ -864,7 +821,6 @@ public class CharScanner {
         for (; index < array.length; index++) {
             c = array[index];
             if (c > 32) {
-
                 return index;
             }
         }
@@ -905,7 +861,6 @@ public class CharScanner {
         try {
             buf.addLine(new String(array, lastLineIndex, count));
         } catch (Exception ex) {
-
             try {
                 int start = index = (index - 10 < 0) ? 0 : index - 10;
 
@@ -928,10 +883,8 @@ public class CharScanner {
             charString = "[SPACE]";
         } else if (c == '\t') {
             charString = "[TAB]";
-
         } else if (c == '\n') {
             charString = "[NEWLINE]";
-
         } else {
             charString = "'" + (char) c + "'";
         }
@@ -939,5 +892,4 @@ public class CharScanner {
         charString = charString + " with an int value of " + ((int) c);
         return charString;
     }
-
 }

--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/CharSequenceValue.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/CharSequenceValue.java
@@ -57,7 +57,6 @@ public class CharSequenceValue implements Value, CharSequence {
             this.startIndex = 0;
             this.endIndex = this.buffer.length;
             this.chopped = true;
-
         } else {
             this.startIndex = startIndex;
             this.endIndex = endIndex;
@@ -78,7 +77,6 @@ public class CharSequenceValue implements Value, CharSequence {
     }
 
     public <T extends Enum> T toEnum(Class<T> cls) {
-
         switch (type) {
             case STRING:
                 return toEnum(cls, stringValue());
@@ -100,7 +98,6 @@ public class CharSequenceValue implements Value, CharSequence {
     }
 
     public static <T extends Enum> T toEnum(Class<T> cls, int value) {
-
         T[] enumConstants = cls.getEnumConstants();
         for (T e : enumConstants) {
             if (e.ordinal() == value) {
@@ -116,12 +113,10 @@ public class CharSequenceValue implements Value, CharSequence {
     }
 
     private final Object doToValue() {
-
         switch (type) {
             case DOUBLE:
                 return doubleValue();
             case INTEGER:
-
                 if (isInteger(buffer, startIndex, endIndex - startIndex)) {
                     return intValue();
                 } else {
@@ -209,7 +204,6 @@ public class CharSequenceValue implements Value, CharSequence {
     }
 
     public Date dateValue() {
-
         if (type == Type.STRING) {
 
             if (Dates.isISO8601QuickCheck(buffer, startIndex, endIndex)) {
@@ -223,11 +217,9 @@ public class CharSequenceValue implements Value, CharSequence {
                     throw new JsonException("Unable to convert " + stringValue() + " to date ");
                 }
             } else {
-
                 throw new JsonException("Unable to convert " + stringValue() + " to date ");
             }
         } else {
-
             return new Date(Dates.utc(longValue()));
         }
     }
@@ -237,13 +229,11 @@ public class CharSequenceValue implements Value, CharSequence {
         if (buffer[startIndex] == '-') {
             startIndex++;
             sign = -1;
-
         }
         return parseIntFromTo(buffer, startIndex, endIndex) * sign;
     }
 
     public long longValue() {
-
         if (isInteger(buffer, startIndex, endIndex - startIndex)) {
             return parseIntFromTo(buffer, startIndex, endIndex);
         } else {
@@ -268,7 +258,6 @@ public class CharSequenceValue implements Value, CharSequence {
     }
 
     public float floatValue() {
-
         return CharScanner.parseFloat(this.buffer, startIndex, endIndex);
     }
 
@@ -285,4 +274,3 @@ public class CharSequenceValue implements Value, CharSequence {
         return buffer[startIndex];
     }
 }
-

--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/Chr.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/Chr.java
@@ -124,7 +124,6 @@ public class Chr {
     }
 
     public static char[] lpad(final char[] in, final int size, char pad) {
-
         if (in.length >= size) {
             return in;
         }
@@ -165,7 +164,6 @@ public class Chr {
 
     public static void _idx(final char[] array, int startIndex, char[] input) {
         try {
-
             arraycopy(input, 0, array, startIndex, input.length);
         } catch (Exception ex) {
             Exceptions.handle(String.format("array size %d, startIndex %d, input length %d",
@@ -179,7 +177,6 @@ public class Chr {
 
     public static void _idx(final char[] array, int startIndex, char[] input, final int inputLength) {
         try {
-
             arraycopy(input, 0, array, startIndex, inputLength);
         } catch (Exception ex) {
             Exceptions.handle(String.format("array size %d, startIndex %d, input length %d",
@@ -188,13 +185,11 @@ public class Chr {
     }
 
     public static void _idx(char[] buffer, int location, byte[] chars, int start, int end) {
-
         int index2 = start;
         int endLocation = (location + (end - start));
         for (int index = location; index < endLocation; index++, index2++) {
             buffer[index] = (char) chars[index2];
         }
-
     }
 
     public static char[] add(char[]... strings) {

--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/Dates.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/Dates.java
@@ -37,7 +37,6 @@ public class Dates {
     }
 
     private static Date internalDate(TimeZone tz, int year, int month, int day, int hour, int minute, int second) {
-
         Calendar calendar = Calendar.getInstance();
 
         calendar.set(Calendar.YEAR, year);
@@ -84,7 +83,6 @@ public class Dates {
     public static final int JSON_TIME_LENGTH = "2013-12-14T01:55:33.412Z".length();
 
     public static Date fromISO8601(char[] charArray, int from, int to) {
-
         try {
             if (isISO8601(charArray, from, to)) {
                 int year = CharScanner.parseIntFromTo(charArray, from + 0, from + 4);
@@ -98,27 +96,21 @@ public class Dates {
                 TimeZone tz = null;
 
                 if (charArray[from + 19] == 'Z') {
-
                     tz = TimeZone.getTimeZone("GMT");
-
                 } else {
-
                     StringBuilder builder = new StringBuilder(9);
                     builder.append("GMT");
                     builder.append(charArray, from + 19, 6);
                     String tzStr = builder.toString();
                     tz = TimeZone.getTimeZone(tzStr);
-
                 }
                 return toDate(tz, year, month, day, hour, minute, second);
-
             } else {
                 return null;
             }
         } catch (Exception ex) {
             return null;
         }
-
     }
 
     public static Date fromJsonDate(char[] charArray, int from, int to) {
@@ -138,14 +130,12 @@ public class Dates {
                 TimeZone tz = TimeZone.getTimeZone("GMT");
 
                 return toDate(tz, year, month, day, hour, minute, second, miliseconds);
-
             } else {
                 return null;
             }
         } catch (Exception ex) {
             return null;
         }
-
     }
 
     public static boolean isISO8601(char[] charArray, int start, int to) {
@@ -154,11 +144,9 @@ public class Dates {
 
         if (length == SHORT_ISO_8601_TIME_LENGTH) {
             valid &= (charArray[start + 19] == 'Z');
-
         } else if (length == LONG_ISO_8601_TIME_LENGTH) {
             valid &= (charArray[start + 19] == '-' || charArray[start + 19] == '+');
             valid &= (charArray[start + 22] == ':');
-
         } else {
             return false;
         }
@@ -179,7 +167,6 @@ public class Dates {
         final int length = to - start;
 
         try {
-
             if (length == JSON_TIME_LENGTH || length == LONG_ISO_8601_TIME_LENGTH
                     || length == SHORT_ISO_8601_TIME_LENGTH || (length >= 17 && (charArray[start + 16] == ':'))
                     ) {
@@ -191,7 +178,6 @@ public class Dates {
             ex.printStackTrace();
             return false;
         }
-
     }
 
     public static boolean isJsonDate(char[] charArray, int start, int to) {
@@ -216,5 +202,4 @@ public class Dates {
 
         return valid;
     }
-
 }

--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/Exceptions.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/Exceptions.java
@@ -46,7 +46,6 @@ public class Exceptions {
     }
 
     public static <T> T handle(Class<T> clazz, java.lang.Exception e) {
-
         if (e instanceof JsonInternalException) {
             throw (JsonInternalException) e;
         }
@@ -54,7 +53,6 @@ public class Exceptions {
     }
 
     public static <T> T handle(Class<T> clazz, String message, Throwable e) {
-
         throw new JsonInternalException(message, e);
     }
 
@@ -77,7 +75,6 @@ public class Exceptions {
         }
 
         public void printStackTrace(PrintStream s) {
-
             s.println(this.getMessage());
             if (getCause() != null) {
                 s.println("This Exception was wrapped, the original exception\n" +
@@ -86,7 +83,6 @@ public class Exceptions {
             } else {
                 super.printStackTrace(s);
             }
-
         }
 
         public String getMessage() {
@@ -109,7 +105,6 @@ public class Exceptions {
             } else {
                 return super.getStackTrace();
             }
-
         }
 
         public Throwable getCause() {
@@ -117,7 +112,6 @@ public class Exceptions {
         }
 
         public void printStackTrace(PrintWriter s) {
-
             s.println(this.getMessage());
 
             if (getCause() != null) {
@@ -130,7 +124,6 @@ public class Exceptions {
         }
 
         public void printStackTrace() {
-
             System.err.println(this.getMessage());
 
             if (getCause() != null) {
@@ -155,11 +148,9 @@ public class Exceptions {
         }
 
         return buffer.toString();
-
     }
 
     public static String sputs(CharBuf buf, Object... messages) {
-
         int index = 0;
         for (Object message : messages) {
             if (index != 0) {
@@ -178,13 +169,10 @@ public class Exceptions {
         buf.add('\n');
 
         return buf.toString();
-
     }
 
     public static String sputs(Object... messages) {
         CharBuf buf = CharBuf.create(100);
         return sputs(buf, messages);
     }
-
 }
-

--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/FastStringUtils.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/FastStringUtils.java
@@ -32,6 +32,7 @@ public class FastStringUtils {
     public static final long STRING_OFFSET_FIELD_OFFSET;
     public static final long STRING_COUNT_FIELD_OFFSET;
     public static final boolean ENABLED;
+
     private static final boolean WRITE_TO_FINAL_FIELDS = Boolean.parseBoolean(System.getProperty("groovy.json.faststringutils.write.to.final.fields", "false"));
     private static final boolean DISABLE = Boolean.parseBoolean(System.getProperty("groovy.json.faststringutils.disable", "false"));
 
@@ -151,11 +152,9 @@ public class FastStringUtils {
      * @return correct string implementation
      */
     private static StringImplementation computeStringImplementation() {
-
         if (STRING_VALUE_FIELD_OFFSET != -1L) {
             if (STRING_OFFSET_FIELD_OFFSET != -1L && STRING_COUNT_FIELD_OFFSET != -1L) {
                 return StringImplementation.OFFSET;
-
             } else if (STRING_OFFSET_FIELD_OFFSET == -1L && STRING_COUNT_FIELD_OFFSET == -1L) {
                 return StringImplementation.DIRECT_CHARS;
             } else {
@@ -173,7 +172,6 @@ public class FastStringUtils {
      */
     public static char[] toCharArray(final String string) {
         return STRING_IMPLEMENTATION.toCharArray(string);
-
     }
 
     /**

--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/IO.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/IO.java
@@ -31,7 +31,6 @@ public class IO {
     private static final int DEFAULT_BUFFER_SIZE = 1024 * 4;
 
     public static CharBuf read(Reader input, CharBuf charBuf, final int bufSize) {
-
         if (charBuf == null) {
             charBuf = CharBuf.create(bufSize);
         } else {
@@ -39,18 +38,16 @@ public class IO {
         }
 
         try {
-
             char[] buffer = charBuf.toCharArray();
             int size = input.read(buffer);
             if (size != -1) {
                 charBuf._len(size);
             }
-            if (size < 0 ) {
+            if (size < 0) {
                 return charBuf;
             }
 
             copy(input, charBuf);
-
         } catch (IOException e) {
             Exceptions.handle(e);
         } finally {
@@ -62,7 +59,6 @@ public class IO {
         }
 
         return charBuf;
-
     }
 
     public static int copy(Reader input, Writer output) {
@@ -91,5 +87,4 @@ public class IO {
         }
         return count;
     }
-
 }

--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/JsonFastParser.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/JsonFastParser.java
@@ -57,7 +57,6 @@ public class JsonFastParser extends JsonParserCharArray {
     }
 
     protected final Value decodeJsonObjectLazyFinalParse() {
-
         char[] array = charArray;
 
         if (__currentChar == '{')
@@ -102,7 +101,6 @@ public class JsonFastParser extends JsonParserCharArray {
 
                     complain(
                             "expecting '}' or ',' but got current char " + charDescription(__currentChar));
-
             }
         }
         return value;
@@ -113,11 +111,9 @@ public class JsonFastParser extends JsonParserCharArray {
     }
 
     private Value decodeValueOverlay() {
-
         skipWhiteSpace();
 
         switch (__currentChar) {
-
             case '"':
                 return decodeStringOverlay();
 
@@ -159,7 +155,6 @@ public class JsonFastParser extends JsonParserCharArray {
     }
 
     private final Value decodeNumberOverlay(final boolean minus) {
-
         char[] array = charArray;
 
         final int startIndex = __index;
@@ -197,7 +192,6 @@ public class JsonFastParser extends JsonParserCharArray {
     }
 
     private Value decodeStringOverlay() {
-
         char[] array = charArray;
         int index = __index;
         char currentChar = charArray[index];
@@ -226,7 +220,6 @@ public class JsonFastParser extends JsonParserCharArray {
     }
 
     private Value decodeJsonArrayOverlay() {
-
         char[] array = charArray;
         if (__currentChar == '[') {
             __index++;

--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/JsonParserCharArray.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/JsonParserCharArray.java
@@ -66,11 +66,9 @@ public class JsonParserCharArray extends BaseJsonParser {
             this.__currentChar = this.charArray[ix];
             __index = ix;
         }
-
     }
 
     protected final char nextChar() {
-
         try {
             if (hasMore()) {
                 __index++;
@@ -93,7 +91,6 @@ public class JsonParserCharArray extends BaseJsonParser {
         for (; index < array.length; index++) {
             c = array[index];
             if (c > 32) {
-
                 return index;
             }
         }
@@ -101,7 +98,6 @@ public class JsonParserCharArray extends BaseJsonParser {
     }
 
     protected final Object decodeJsonObject() {
-
         if (__currentChar == '{') {
             __index++;
         }
@@ -109,13 +105,10 @@ public class JsonParserCharArray extends BaseJsonParser {
         LazyMap map = new LazyMap();
 
         for (; __index < this.charArray.length; __index++) {
-
             skipWhiteSpace();
 
             if (__currentChar == '"') {
-
-                String key =
-                        decodeString();
+                String key = decodeString();
 
                 if (internKeys) {
                     String keyPrime = internedKeysCache.get(key);
@@ -130,7 +123,6 @@ public class JsonParserCharArray extends BaseJsonParser {
                 skipWhiteSpace();
 
                 if (__currentChar != ':') {
-
                     complain("expecting current character to be " + charDescription(__currentChar) + "\n");
                 }
                 __index++;
@@ -141,8 +133,8 @@ public class JsonParserCharArray extends BaseJsonParser {
 
                 skipWhiteSpace();
                 map.put(key, value);
-
             }
+
             if (__currentChar == '}') {
                 __index++;
                 break;
@@ -151,7 +143,6 @@ public class JsonParserCharArray extends BaseJsonParser {
             } else {
                 complain(
                         "expecting '}' or ',' but got current char " + charDescription(__currentChar));
-
             }
         }
 
@@ -171,7 +162,6 @@ public class JsonParserCharArray extends BaseJsonParser {
         skipWhiteSpace();
 
         switch (__currentChar) {
-
             case '"':
                 value = decodeString();
                 break;
@@ -215,7 +205,6 @@ public class JsonParserCharArray extends BaseJsonParser {
             default:
                 throw new JsonException(exceptionDetails("Unable to determine the " +
                         "current character, it is not a string, number, array, or object"));
-
         }
 
         return value;
@@ -224,7 +213,6 @@ public class JsonParserCharArray extends BaseJsonParser {
     int[] endIndex = new int[1];
 
     private final Object decodeNumber() {
-
         Number num = CharScanner.parseJsonNumber(charArray, __index, charArray.length, endIndex);
         __index = endIndex[0];
 
@@ -234,7 +222,6 @@ public class JsonParserCharArray extends BaseJsonParser {
     protected static final char[] NULL = Chr.chars("null");
 
     protected final Object decodeNull() {
-
         if (__index + NULL.length <= charArray.length) {
             if (charArray[__index] == 'n' &&
                     charArray[++__index] == 'u' &&
@@ -250,7 +237,6 @@ public class JsonParserCharArray extends BaseJsonParser {
     protected static final char[] TRUE = Chr.chars("true");
 
     protected final boolean decodeTrue() {
-
         if (__index + TRUE.length <= charArray.length) {
             if (charArray[__index] == 't' &&
                     charArray[++__index] == 'r' &&
@@ -259,7 +245,6 @@ public class JsonParserCharArray extends BaseJsonParser {
 
                 __index++;
                 return true;
-
             }
         }
 
@@ -269,7 +254,6 @@ public class JsonParserCharArray extends BaseJsonParser {
     protected static char[] FALSE = Chr.chars("false");
 
     protected final boolean decodeFalse() {
-
         if (__index + FALSE.length <= charArray.length) {
             if (charArray[__index] == 'f' &&
                     charArray[++__index] == 'a' &&
@@ -286,7 +270,6 @@ public class JsonParserCharArray extends BaseJsonParser {
     private CharBuf builder = CharBuf.create(20);
 
     private String decodeString() {
-
         char[] array = charArray;
         int index = __index;
         char currentChar = array[index];
@@ -317,7 +300,6 @@ public class JsonParserCharArray extends BaseJsonParser {
     }
 
     protected final List decodeJsonArray() {
-
         ArrayList<Object> list = null;
 
         boolean foundEnd = false;
@@ -332,7 +314,6 @@ public class JsonParserCharArray extends BaseJsonParser {
 
             skipWhiteSpace();
 
-
         /* the list might be empty  */
             if (__currentChar == ']') {
                 __index++;
@@ -342,7 +323,6 @@ public class JsonParserCharArray extends BaseJsonParser {
             list = new ArrayList();
 
             while (this.hasMore()) {
-
                 Object arrayItem = decodeValueInternal();
 
                 list.add(arrayItem);
@@ -371,7 +351,6 @@ public class JsonParserCharArray extends BaseJsonParser {
                     foundEnd = true;
                     break;
                 } else {
-
                     String charString = charDescription(c);
 
                     complain(
@@ -379,10 +358,8 @@ public class JsonParserCharArray extends BaseJsonParser {
                                     " but got \nthe current character of  %s " +
                                     " on array index of %s \n", charString, list.size())
                     );
-
                 }
             }
-
         } catch (Exception ex) {
             if (ex instanceof JsonException) {
                 JsonException jsonException = (JsonException) ex;
@@ -394,7 +371,6 @@ public class JsonParserCharArray extends BaseJsonParser {
             complain("Did not find end of Json Array");
         }
         return list;
-
     }
 
     protected final char currentChar() {
@@ -408,5 +384,4 @@ public class JsonParserCharArray extends BaseJsonParser {
     public Object parse(char[] chars) {
         return this.decodeFromChars(chars);
     }
-
 }

--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/JsonParserLax.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/JsonParserLax.java
@@ -54,7 +54,6 @@ public class JsonParserLax extends JsonParserCharArray {
     }
 
     private Value decodeJsonObjectLax() {
-
         if (__currentChar == '{')
             this.nextChar();
 
@@ -69,7 +68,6 @@ public class JsonParserLax extends JsonParserCharArray {
 
         done:
         for (; __index < this.charArray.length; __index++) {
-
             skipWhiteSpace();
 
             switch (__currentChar) {
@@ -110,18 +108,17 @@ public class JsonParserLax extends JsonParserCharArray {
                 case '\'':
                     key = decodeStringSingle();
 
-                    //puts ( "key with quote", key );
+                    //puts ("key with quote", key);
 
                     skipWhiteSpace();
 
                     if (__currentChar != ':') {
-
                         complain("expecting current character to be ':' but got " + charDescription(__currentChar) + "\n");
                     }
                     __index++;
                     item = decodeValueInternal();
 
-                    //puts ( "key", "#" + key + "#", value );
+                    //puts ("key", "#" + key + "#", value);
 
                     skipWhiteSpace();
 
@@ -139,18 +136,17 @@ public class JsonParserLax extends JsonParserCharArray {
                 case '"':
                     key = decodeStringDouble();
 
-                    //puts ( "key with quote", key );
+                    //puts ("key with quote", key);
 
                     skipWhiteSpace();
 
                     if (__currentChar != ':') {
-
                         complain("expecting current character to be ':' but got " + charDescription(__currentChar) + "\n");
                     }
                     __index++;
                     item = decodeValueInternal();
 
-                    //puts ( "key", "#" + key + "#", value );
+                    //puts ("key", "#" + key + "#", value);
 
                     skipWhiteSpace();
 
@@ -331,7 +327,6 @@ public class JsonParserLax extends JsonParserCharArray {
     }
 
     private void handleComment() {
-
         if (hasMore()) {
             __index++;
             __currentChar = charArray[__index];
@@ -375,7 +370,6 @@ public class JsonParserLax extends JsonParserCharArray {
     }
 
     protected final Value decodeNumberLax(boolean minus) {
-
         char[] array = charArray;
 
         final int startIndex = __index;
@@ -471,7 +465,6 @@ public class JsonParserLax extends JsonParserCharArray {
     }
 
     private Value decodeStringDouble() {
-
         __currentChar = charArray[__index];
 
         if (__index < charArray.length && __currentChar == '"') {
@@ -518,7 +511,6 @@ public class JsonParserLax extends JsonParserCharArray {
     }
 
     private Value decodeStringSingle() {
-
         __currentChar = charArray[__index];
 
         if (__index < charArray.length && __currentChar == '\'') {
@@ -536,7 +528,6 @@ public class JsonParserLax extends JsonParserCharArray {
         for (; __index < this.charArray.length; __index++) {
             __currentChar = charArray[__index];
             switch (__currentChar) {
-
                 case '\'':
                     if (!escape) {
                         break done;
@@ -553,6 +544,7 @@ public class JsonParserLax extends JsonParserCharArray {
                 case '-':
                     minusCount++;
                     break;
+
                 case ':':
                     colonCount++;
                     break;
@@ -572,7 +564,6 @@ public class JsonParserLax extends JsonParserCharArray {
     }
 
     private Value decodeJsonArrayLax() {
-
         if (__currentChar == '[') {
             __index++;
         }
@@ -595,7 +586,6 @@ public class JsonParserLax extends JsonParserCharArray {
         Value value = new ValueContainer(list);
 
         do {
-
             skipWhiteSpace();
 
             Object arrayItem = decodeValueInternal();
@@ -606,7 +596,6 @@ public class JsonParserLax extends JsonParserCharArray {
 
             done:
             do { // Find either next array element or end of array while ignoring comments
-
                 skipWhiteSpace();
 
                 switch (__currentChar) {
@@ -650,4 +639,3 @@ public class JsonParserLax extends JsonParserCharArray {
         }
     }
 }
-

--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/JsonParserUsingCharacterSource.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/JsonParserUsingCharacterSource.java
@@ -44,7 +44,6 @@ public class JsonParserUsingCharacterSource extends BaseJsonParser {
         LazyMap map = new LazyMap();
 
         try {
-
             CharacterSource characterSource = this.characterSource;
 
             if (characterSource.currentChar() == '{') {
@@ -52,11 +51,9 @@ public class JsonParserUsingCharacterSource extends BaseJsonParser {
             }
 
             while (characterSource.hasChar()) {
-
                 characterSource.skipWhiteSpace();
 
                 if (characterSource.currentChar() == DOUBLE_QUOTE) {
-
                     String key = decodeString();
                     //puts ("key", key);
 
@@ -72,12 +69,10 @@ public class JsonParserUsingCharacterSource extends BaseJsonParser {
 
                     characterSource.skipWhiteSpace();
                     if (characterSource.currentChar() != COLON) {
-
                         complain("expecting current character to be : but was " + charDescription(characterSource.currentChar()) + "\n");
                     }
 
                     characterSource.nextChar();
-
                     characterSource.skipWhiteSpace();
 
                     Object value = decodeValue();
@@ -87,7 +82,6 @@ public class JsonParserUsingCharacterSource extends BaseJsonParser {
                     characterSource.skipWhiteSpace();
 
                     map.put(key, value);
-
                 }
 
                 int ch = characterSource.currentChar();
@@ -100,7 +94,6 @@ public class JsonParserUsingCharacterSource extends BaseJsonParser {
                 } else {
                     complain(
                             "expecting '}' or ',' but got current char " + charDescription(ch));
-
                 }
             }
         } catch (Exception ex) {
@@ -120,7 +113,6 @@ public class JsonParserUsingCharacterSource extends BaseJsonParser {
         characterSource.skipWhiteSpace();
 
         switch (characterSource.currentChar()) {
-
             case '"':
                 value = decodeString();
                 break;
@@ -165,7 +157,6 @@ public class JsonParserUsingCharacterSource extends BaseJsonParser {
             default:
                 throw new JsonException(exceptionDetails("Unable to determine the " +
                         "current character, it is not a string, number, array, or object"));
-
         }
 
         return value;
@@ -198,7 +189,6 @@ public class JsonParserUsingCharacterSource extends BaseJsonParser {
     protected static final char[] TRUE = Chr.chars("true");
 
     protected final boolean decodeTrue() {
-
         if (characterSource.consumeIfMatch(TRUE)) {
             return true;
         } else {
@@ -209,19 +199,16 @@ public class JsonParserUsingCharacterSource extends BaseJsonParser {
     protected static char[] FALSE = Chr.chars("false");
 
     protected final boolean decodeFalse() {
-
         if (characterSource.consumeIfMatch(FALSE)) {
             return false;
         } else {
             throw new JsonException(exceptionDetails("false not parsed properly"));
         }
-
     }
 
     private CharBuf builder = CharBuf.create(20);
 
     private String decodeString() {
-
         CharacterSource characterSource = this.characterSource;
 
         characterSource.nextChar();
@@ -240,12 +227,10 @@ public class JsonParserUsingCharacterSource extends BaseJsonParser {
     }
 
     protected final List decodeJsonArray() {
-
         ArrayList<Object> list = null;
 
         boolean foundEnd = false;
         try {
-
             CharacterSource characterSource = this.characterSource;
 
             if (this.characterSource.currentChar() == '[') {
@@ -253,8 +238,6 @@ public class JsonParserUsingCharacterSource extends BaseJsonParser {
             }
 
             characterSource.skipWhiteSpace();
-
-
 
         /* the list might be empty  */
             if (this.characterSource.currentChar() == ']') {
@@ -265,7 +248,6 @@ public class JsonParserUsingCharacterSource extends BaseJsonParser {
             list = new ArrayList();
 
             do {
-
                 characterSource.skipWhiteSpace();
 
                 Object arrayItem = decodeValue();
@@ -284,7 +266,6 @@ public class JsonParserUsingCharacterSource extends BaseJsonParser {
                     characterSource.nextChar();
                     break;
                 } else {
-
                     String charString = charDescription(c);
 
                     complain(
@@ -295,28 +276,22 @@ public class JsonParserUsingCharacterSource extends BaseJsonParser {
 
                 }
             } while (characterSource.hasChar());
-
         } catch (Exception ex) {
             throw new JsonException(exceptionDetails("Unexpected issue"), ex);
         }
 
         if (!foundEnd) {
             throw new JsonException(exceptionDetails("Could not find end of JSON array"));
-
         }
         return list;
-
     }
 
     public Object parse(Reader reader) {
-
         characterSource = new ReaderCharacterSource(reader);
         return this.decodeValue();
-
     }
 
     public Object parse(char[] chars) {
         return parse(new StringReader(new String(chars)));
     }
-
 }

--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/JsonStringDecoder.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/JsonStringDecoder.java
@@ -23,7 +23,6 @@ package groovy.json.internal;
 public class JsonStringDecoder {
 
     public static String decode(char[] chars, int start, int to) {
-
         if (!Chr.contains(chars, '\\', start, to - start)) {
             return new String(chars, start, to - start);
         }
@@ -31,11 +30,8 @@ public class JsonStringDecoder {
     }
 
     public static String decodeForSure(char[] chars, int start, int to) {
-
         CharBuf builder = CharBuf.create(to - start);
         builder.decodeJsonString(chars, start, to);
         return builder.toString();
-
     }
-
 }

--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/LazyMap.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/LazyMap.java
@@ -47,15 +47,14 @@ public class LazyMap extends AbstractMap<String, Object> {
     public LazyMap(int initialSize) {
         keys = new String[initialSize];
         values = new Object[initialSize];
-
     }
 
     public Object put(String key, Object value) {
         if (map == null) {
-            for (int i=0;i<size;i++) {
+            for (int i = 0; i < size; i++) {
                 String curKey = keys[i];
-                if ((key==null && curKey ==null)
-                    || (key!=null && key.equals(curKey))) {
+                if ((key == null && curKey == null)
+                     || (key != null && key.equals(curKey))) {
                     Object val = values[i];
                     keys[i] = key;
                     values[i] = value;
@@ -113,7 +112,6 @@ public class LazyMap extends AbstractMap<String, Object> {
 
     private void buildIfNeeded() {
         if (map == null) {
-
             /** added to avoid hash collision attack. */
             if (Sys.is1_7OrLater() && JDK_MAP_ALTHASHING_SYSPROP != null) {
                 map = new LinkedHashMap<String, Object>(size, 0.01f);
@@ -150,15 +148,11 @@ public class LazyMap extends AbstractMap<String, Object> {
     public Set<String> keySet() {
         buildIfNeeded();
         return map.keySet();
-
     }
 
     public Collection<Object> values() {
-
         buildIfNeeded();
-
         return map.values();
-
     }
 
     public boolean equals(Object o) {
@@ -172,13 +166,11 @@ public class LazyMap extends AbstractMap<String, Object> {
     }
 
     public String toString() {
-
         buildIfNeeded();
         return map.toString();
     }
 
     protected Object clone() throws CloneNotSupportedException {
-
         if (map == null) {
             return null;
         } else {
@@ -200,11 +192,8 @@ public class LazyMap extends AbstractMap<String, Object> {
     }
 
     public static <V> V[] grow(V[] array) {
-        Object newArray = Array.newInstance(array.getClass().getComponentType(),
-                array.length * 2);
+        Object newArray = Array.newInstance(array.getClass().getComponentType(), array.length * 2);
         System.arraycopy(array, 0, newArray, 0, array.length);
         return (V[]) newArray;
     }
-
 }
-

--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/LazyValueMap.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/LazyValueMap.java
@@ -66,7 +66,6 @@ public class LazyValueMap extends AbstractMap<String, Object> implements ValueMa
     boolean mapChopped = false;
 
     public LazyValueMap(boolean lazyChop) {
-
         this.items = new Entry[5];
         this.lazyChop = lazyChop;
     }
@@ -87,7 +86,6 @@ public class LazyValueMap extends AbstractMap<String, Object> implements ValueMa
         }
         items[len] = miv;
         len++;
-
     }
 
     /**
@@ -96,9 +94,7 @@ public class LazyValueMap extends AbstractMap<String, Object> implements ValueMa
      * @param key to lookup
      * @return the item for the given key
      */
-
     public final Object get(Object key) {
-
         Object object = null;
 
         /* if the map is null, then we create it. */
@@ -125,7 +121,6 @@ public class LazyValueMap extends AbstractMap<String, Object> implements ValueMa
                 list.chopList();
             }
         }
-
     }
 
     /**
@@ -137,7 +132,6 @@ public class LazyValueMap extends AbstractMap<String, Object> implements ValueMa
             return;
         }
         mapChopped = true;
-
 
         /* If the internal map was not create yet, don't. We can chop the value w/o creating the internal map.*/
         if (this.map == null) {
@@ -173,7 +167,6 @@ public class LazyValueMap extends AbstractMap<String, Object> implements ValueMa
                 }
             }
         }
-
     }
 
     /* We need to chop up this child container. */
@@ -201,21 +194,18 @@ public class LazyValueMap extends AbstractMap<String, Object> implements ValueMa
     }
 
     private final void buildMap() {
-
-
         /** added to avoid hash collision attack. */
         if (Sys.is1_7OrLater() && System.getProperty("jdk.map.althashing.threshold") != null) {
-            map = new HashMap<String, Object>( items.length );
+            map = new HashMap<String, Object>(items.length);
         } else {
             map = new TreeMap<String, Object>();
         }
 
-
-        for ( Entry<String, Value> miv : items ) {
-            if ( miv == null ) {
+        for (Entry<String, Value> miv : items) {
+            if (miv == null) {
                 break;
             }
-            map.put( miv.getKey(), miv.getValue().toValue() );
+            map.put(miv.getKey(), miv.getValue().toValue());
         }
 
         len = 0;
@@ -233,10 +223,8 @@ public class LazyValueMap extends AbstractMap<String, Object> implements ValueMa
     }
 
     public String toString() {
-
         if (map == null) buildMap();
         return map.toString();
-
     }
 
     public int len() {
@@ -250,5 +238,4 @@ public class LazyValueMap extends AbstractMap<String, Object> implements ValueMa
     public Entry<String, Value>[] items() {
         return items;
     }
-
 }

--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/MapItemValue.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/MapItemValue.java
@@ -47,13 +47,11 @@ public class MapItemValue implements Map.Entry<String, Value> {
     public MapItemValue(Value name, Value value) {
         this.name = name;
         this.value = value;
-
     }
 
     public String getKey() {
         if (key == null) {
             if (internKeys) {
-
                 key = name.toString();
 
                 String keyPrime = internedKeysCache.get(key);
@@ -64,7 +62,6 @@ public class MapItemValue implements Map.Entry<String, Value> {
                     key = keyPrime;
                 }
             } else {
-
                 key = name.toString();
             }
         }
@@ -79,5 +76,4 @@ public class MapItemValue implements Map.Entry<String, Value> {
         die("not that kind of Entry");
         return null;
     }
-
 }

--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/NumberValue.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/NumberValue.java
@@ -51,7 +51,6 @@ public class NumberValue extends java.lang.Number implements Value {
 
         try {
             if (chop) {
-
                 this.buffer = ArrayUtils.copyRange(buffer, startIndex, endIndex);
                 this.startIndex = 0;
                 this.endIndex = this.buffer.length;
@@ -62,9 +61,7 @@ public class NumberValue extends java.lang.Number implements Value {
                 this.buffer = buffer;
             }
         } catch (Exception ex) {
-            Exceptions.handle(sputs("exception", ex, "start", startIndex, "end", endIndex),
-                    ex);
-
+            Exceptions.handle(sputs("exception", ex, "start", startIndex, "end", endIndex), ex);
         }
     }
 
@@ -81,12 +78,10 @@ public class NumberValue extends java.lang.Number implements Value {
     }
 
     public <T extends Enum> T toEnum(Class<T> cls) {
-
         return toEnum(cls, intValue());
     }
 
     public static <T extends Enum> T toEnum(Class<T> cls, int value) {
-
         T[] enumConstants = cls.getEnumConstants();
         for (T e : enumConstants) {
             if (e.ordinal() == value) {
@@ -102,12 +97,10 @@ public class NumberValue extends java.lang.Number implements Value {
     }
 
     private final Object doToValue() {
-
         switch (type) {
             case DOUBLE:
                 return bigDecimalValue();
             case INTEGER:
-
                 int sign = 1;
                 boolean negative = false;
                 if (buffer[startIndex] == '-') {
@@ -176,13 +169,11 @@ public class NumberValue extends java.lang.Number implements Value {
         if (buffer[startIndex] == '-') {
             startIndex++;
             sign = -1;
-
         }
         return parseIntFromTo(buffer, startIndex, endIndex) * sign;
     }
 
     public long longValue() {
-
         if (isInteger(buffer, startIndex, endIndex - startIndex)) {
             return parseIntFromTo(buffer, startIndex, endIndex);
         } else {
@@ -235,6 +226,4 @@ public class NumberValue extends java.lang.Number implements Value {
     public char charValue() {
         return buffer[startIndex];
     }
-
 }
-

--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/ReaderCharacterSource.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/ReaderCharacterSource.java
@@ -68,7 +68,6 @@ public class ReaderCharacterSource implements CharacterSource {
     }
 
     private void ensureBuffer() {
-
         try {
             if (index >= length && !done) {
                 readNextBuffer();
@@ -114,7 +113,6 @@ public class ReaderCharacterSource implements CharacterSource {
 
     public final boolean consumeIfMatch(char[] match) {
         try {
-
             char[] _chars = readBuf;
             int i = 0;
             int idx = index;
@@ -139,7 +137,6 @@ public class ReaderCharacterSource implements CharacterSource {
             String str = CharScanner.errorDetails("consumeIfMatch issue", readBuf, index, ch);
             return Exceptions.handle(boolean.class, str, ex);
         }
-
     }
 
     public final int location() {
@@ -226,12 +223,11 @@ public class ReaderCharacterSource implements CharacterSource {
                 }
                 return results;
             } else {
-
                 if (index >= length && !done) {
                     ensureBuffer();
                     boolean hasAlreadyFoundEscape = foundEscape;
                     char results2[] = findNextChar(match, esc);
-                    if(hasAlreadyFoundEscape){
+                    if (hasAlreadyFoundEscape) {
                         foundEscape = true; //restore foundEscapeState
                     }
                     return Chr.add(results, results2);
@@ -243,7 +239,6 @@ public class ReaderCharacterSource implements CharacterSource {
             String str = CharScanner.errorDetails("findNextChar issue", readBuf, index, ch);
             return Exceptions.handle(char[].class, str, ex);
         }
-
     }
 
     public boolean hadEscape() {
@@ -254,7 +249,6 @@ public class ReaderCharacterSource implements CharacterSource {
         try {
             index = CharScanner.skipWhiteSpace(readBuf, index, length);
             if (index >= length && more) {
-
                 ensureBuffer();
 
                 skipWhiteSpace();
@@ -287,12 +281,9 @@ public class ReaderCharacterSource implements CharacterSource {
             String str = CharScanner.errorDetails("readNumber issue", readBuf, index, ch);
             return Exceptions.handle(char[].class, str, ex);
         }
-
     }
 
     public String errorDetails(String message) {
-
         return CharScanner.errorDetails(message, readBuf, index, ch);
     }
-
 }

--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/SimpleCache.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/SimpleCache.java
@@ -41,7 +41,6 @@ public class SimpleCache<K, V> implements Cache<K, V> {
     }
 
     public SimpleCache(final int limit, CacheType type) {
-
         if (type.equals(CacheType.LRU)) {
             map = new InternalCacheLinkedList<K, V>(limit, true);
         } else {
@@ -50,9 +49,7 @@ public class SimpleCache<K, V> implements Cache<K, V> {
     }
 
     public SimpleCache(final int limit) {
-
         map = new InternalCacheLinkedList<K, V>(limit, true);
-
     }
 
     public void put(K key, V value) {
@@ -85,5 +82,4 @@ public class SimpleCache<K, V> implements Cache<K, V> {
     public String toString() {
         return map.toString();
     }
-
 }

--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/Sys.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/Sys.java
@@ -17,12 +17,9 @@
  */
 package groovy.json.internal;
 
-
-
 import java.math.BigDecimal;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 
 class Sys {
 
@@ -31,39 +28,36 @@ class Sys {
     private static final boolean is1_7;
     private static final boolean is1_8;
 
-
     static {
-        BigDecimal v = new BigDecimal ( "-1" );
-        String sversion = System.getProperty ( "java.version" );
-        if ( sversion.indexOf ( "_" ) != -1 ) {
-            final String[] split = sversion.split ( "_" );
+        BigDecimal v = new BigDecimal("-1");
+        String sversion = System.getProperty("java.version");
+        if (sversion.indexOf("_") != -1) {
+            final String[] split = sversion.split("_");
             try {
+                String ver = split[0];
 
-                String ver = split [0];
-                if (ver.startsWith ( "1.8" )) {
-                    v = new BigDecimal ("1.8" );
-                }
-                if (ver.startsWith ( "1.7" )) {
-                    v = new BigDecimal ("1.7" );
+                if (ver.startsWith("1.8")) {
+                    v = new BigDecimal("1.8");
                 }
 
-                if (ver.startsWith ( "1.6" )) {
-                    v = new BigDecimal ("1.6" );
+                if (ver.startsWith("1.7")) {
+                    v = new BigDecimal("1.7");
                 }
 
-
-                if (ver.startsWith ( "1.5" )) {
-                    v = new BigDecimal ("1.5" );
+                if (ver.startsWith("1.6")) {
+                    v = new BigDecimal("1.6");
                 }
 
-
-                if (ver.startsWith ( "1.9" )) {
-                    v = new BigDecimal ("1.9" );
+                if (ver.startsWith("1.5")) {
+                    v = new BigDecimal("1.5");
                 }
 
-            } catch ( Exception ex ) {
-                ex.printStackTrace ();
-                System.err.println ( "Unable to determine build number or version" );
+                if (ver.startsWith("1.9")) {
+                    v = new BigDecimal("1.9");
+                }
+            } catch (Exception ex) {
+                ex.printStackTrace();
+                System.err.println("Unable to determine build number or version");
             }
         } else if ("1.8.0".equals(sversion)) {
             v = new BigDecimal("1.8");
@@ -71,26 +65,25 @@ class Sys {
             Pattern p = Pattern.compile("^([1-9]\\.[0-9]+)");
             Matcher matcher = p.matcher(sversion);
             if (matcher.find()) {
-                v = new BigDecimal ( matcher.group(0) );
+                v = new BigDecimal(matcher.group(0));
             }
         }
 
         version = v;
 
-        is1_7OorLater = version.compareTo ( new BigDecimal ( "1.7" )) >=0;
-        is1_7 = version.compareTo ( new BigDecimal ( "1.7" ))==0;
-        is1_8 = version.compareTo ( new BigDecimal ( "1.8" ))==0;
+        is1_7OorLater = version.compareTo(new BigDecimal("1.7")) >= 0;
+        is1_7 = version.compareTo(new BigDecimal("1.7")) == 0;
+        is1_8 = version.compareTo(new BigDecimal("1.8")) == 0;
     }
 
-
-
-    public static boolean is1_7OrLater () {
+    public static boolean is1_7OrLater() {
         return is1_7OorLater;
     }
 
     public static boolean is1_7() {
         return is1_7;
     }
+
     public static boolean is1_8() {
         return is1_8;
     }

--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/ValueContainer.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/ValueContainer.java
@@ -73,7 +73,6 @@ public class ValueContainer implements CharSequence, Value {
     }
 
     public boolean booleanValue() {
-
         switch (type) {
             case FALSE:
                 return false;
@@ -82,7 +81,6 @@ public class ValueContainer implements CharSequence, Value {
         }
         die();
         return false;
-
     }
 
     public String stringValue() {
@@ -116,7 +114,6 @@ public class ValueContainer implements CharSequence, Value {
         }
         die();
         return null;
-
     }
 
     public <T extends Enum> T toEnum(Class<T> cls) {
@@ -173,6 +170,4 @@ public class ValueContainer implements CharSequence, Value {
     public float floatValue() {
         return 0;
     }
-
 }
-

--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/ValueList.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/ValueList.java
@@ -37,7 +37,6 @@ public class ValueList extends AbstractList<Object> implements List<Object> {
     }
 
     public Object get(int index) {
-
         Object obj = list.get(index);
 
         if (obj instanceof Value) {
@@ -47,7 +46,6 @@ public class ValueList extends AbstractList<Object> implements List<Object> {
 
         chopIfNeeded(obj);
         return obj;
-
     }
 
     private Object convert(Value value) {
@@ -70,7 +68,6 @@ public class ValueList extends AbstractList<Object> implements List<Object> {
                 this.get(index);
             }
         }
-
     }
 
     public void clear() {
@@ -82,7 +79,6 @@ public class ValueList extends AbstractList<Object> implements List<Object> {
     }
 
     public void chopList() {
-
         for (Object obj : list) {
             if (obj == null) continue;
 
@@ -107,7 +103,6 @@ public class ValueList extends AbstractList<Object> implements List<Object> {
                 list.chopList();
             }
         }
-
     }
 
     void chopContainer(Value value) {
@@ -125,4 +120,3 @@ public class ValueList extends AbstractList<Object> implements List<Object> {
         return this.list;
     }
 }
-

--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/ValueMap.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/ValueMap.java
@@ -42,5 +42,4 @@ public interface ValueMap<K, V> extends Map<K, V> {
      * Realize that the array is likely larger than the length so array items can be null.
      */
     Entry<String, Value>[] items();
-
 }

--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/ValueMapImpl.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/ValueMapImpl.java
@@ -139,6 +139,4 @@ public class ValueMapImpl extends AbstractMap<String, Value> implements ValueMap
         this.buildIfNeededMap();
         return map.size();
     }
-
 }
-

--- a/subprojects/groovy-json/src/spec/test/json/JsonBuilderTest.groovy
+++ b/subprojects/groovy-json/src/spec/test/json/JsonBuilderTest.groovy
@@ -13,10 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package json
-
-import groovy.util.GroovyTestCase
 
 class JsonBuilderTest extends GroovyTestCase {
 

--- a/subprojects/groovy-json/src/spec/test/json/JsonTest.groovy
+++ b/subprojects/groovy-json/src/spec/test/json/JsonTest.groovy
@@ -98,7 +98,7 @@ class JsonTest extends GroovyTestCase {
 
         assert json == '{"name":"John Doe","age":42}'
 
-        assert JsonOutput.prettyPrint(json) ==  '''\
+        assert JsonOutput.prettyPrint(json) == '''\
         {
             "name": "John Doe",
             "age": 42

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/CharBufTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/CharBufTest.groovy
@@ -13,35 +13,35 @@ class CharBufTest extends GroovyTestCase {
     void testUnicodeAndControl() {
         String str = CharBuf.create(0).addJsonEscapedString("\u0001").toString()
         assert str == '"\\u0001"'
-        
-        str =  CharBuf.create(0).addJsonEscapedString("\u00ff").toString()
+
+        str = CharBuf.create(0).addJsonEscapedString("\u00ff").toString()
         assert str == '"\\u00ff"'
 
-        str =  CharBuf.create(0).addJsonEscapedString("\u0fff").toString()
+        str = CharBuf.create(0).addJsonEscapedString("\u0fff").toString()
         assert str == '"\\u0fff"'
 
-        str =  CharBuf.create(0).addJsonEscapedString("\uefef").toString()
+        str = CharBuf.create(0).addJsonEscapedString("\uefef").toString()
         assert str == '"\\uefef"'
 
-        str =  CharBuf.create(0).addJsonEscapedString(" \b ").toString()
+        str = CharBuf.create(0).addJsonEscapedString(" \b ").toString()
         assert str == '" \\b "'
 
-        str =  CharBuf.create(0).addJsonEscapedString(" \r ").toString()
+        str = CharBuf.create(0).addJsonEscapedString(" \r ").toString()
         assert str == '" \\r "'
 
-        str =  CharBuf.create(0).addJsonEscapedString(" \n ").toString()
+        str = CharBuf.create(0).addJsonEscapedString(" \n ").toString()
         assert str == '" \\n "'
 
-        str =  CharBuf.create(0).addJsonEscapedString(" \n ").toString()
+        str = CharBuf.create(0).addJsonEscapedString(" \n ").toString()
         assert str == '" \\n "'
 
-        str =  CharBuf.create(0).addJsonEscapedString(" \f ").toString()
+        str = CharBuf.create(0).addJsonEscapedString(" \f ").toString()
         assert str == '" \\f "'
 
-        str =  CharBuf.create(0).addJsonEscapedString(' " Hi mom " ').toString()
+        str = CharBuf.create(0).addJsonEscapedString(' " Hi mom " ').toString()
         assert str == '" \\" Hi mom \\" "'
 
-        str =  CharBuf.create(0).addJsonEscapedString(" \\ ").toString()
+        str = CharBuf.create(0).addJsonEscapedString(" \\ ").toString()
         assert str == '" \\\\ "'
     }
 
@@ -57,7 +57,7 @@ class CharBufTest extends GroovyTestCase {
         // CharBuf used underneath through JsonBuilder and JsonOutput
         def obj = [
                 "\u0391\u03a6\u039f\u0399 \u039a\u039f\u039b\u039b\u0399\u0391 \u039a\u03a1\u0395\u03a9\u03a0\u039f\u039b\u0395\u0399\u039f \u03a4\u0391\u0392\u0395\u03a1\u039d\u0391",
-                   "\u039a\u03b1\u03bb\u03cd\u03b2\u03b9\u03b1 \u0398\u03bf\u03c1\u03b9\u03ba\u03bf\u03cd"
+                "\u039a\u03b1\u03bb\u03cd\u03b2\u03b9\u03b1 \u0398\u03bf\u03c1\u03b9\u03ba\u03bf\u03cd"
         ]
         def result = new JsonBuilder(obj).toString()
         assert result == '["\\u0391\\u03a6\\u039f\\u0399 \\u039a\\u039f\\u039b\\u039b\\u0399\\u0391 \\u039a\\u03a1\\u0395\\u03a9\\u03a0\\u039f\\u039b\\u0395\\u0399\\u039f \\u03a4\\u0391\\u0392\\u0395\\u03a1\\u039d\\u0391","\\u039a\\u03b1\\u03bb\\u03cd\\u03b2\\u03b9\\u03b1 \\u0398\\u03bf\\u03c1\\u03b9\\u03ba\\u03bf\\u03cd"]'

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/IOTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/IOTest.groovy
@@ -10,33 +10,32 @@ import groovy.json.internal.IO
  */
 class IOTest extends GroovyTestCase {
 
-	public static final String TEST_STRING = '{"results":[{"columns":["n"],"data":[{"row":[{"name":"Alin Coen Band","type":"group"}]}]}],"errors":[]}'
-	
-	int bufSize = 256
-	
-	void testReadProper() {
-		IO io = new IO()
-		ProperReader reader = new ProperReader();
-		CharBuf buffer = io.read(reader, null, bufSize)
-		int len = buffer.len()
-		char[] rbuf = buffer.readForRecycle()
-		String result = new String(rbuf, 0, len)
-		assertEquals(TEST_STRING,result) 
-	}
+    public static final String TEST_STRING = '{"results":[{"columns":["n"],"data":[{"row":[{"name":"Alin Coen Band","type":"group"}]}]}],"errors":[]}'
 
-	/**
-	 * See https://jira.codehaus.org/browse/GROOVY-7132
-	 */
-	void testReadBumpy() {
-		IO io = new IO()
-		BumpyReader reader = new BumpyReader();
-		CharBuf buffer = io.read(reader, null, bufSize)
-		int len = buffer.len()
-		char[] rbuf = buffer.readForRecycle()
-		String result = new String(rbuf,0,len)
-		assertEquals(TEST_STRING,result) 
-	}
+    int bufSize = 256
 
+    void testReadProper() {
+        IO io = new IO()
+        ProperReader reader = new ProperReader();
+        CharBuf buffer = io.read(reader, null, bufSize)
+        int len = buffer.len()
+        char[] rbuf = buffer.readForRecycle()
+        String result = new String(rbuf, 0, len)
+        assertEquals(TEST_STRING, result)
+    }
+
+    /**
+     * See https://jira.codehaus.org/browse/GROOVY-7132
+     */
+    void testReadBumpy() {
+        IO io = new IO()
+        BumpyReader reader = new BumpyReader();
+        CharBuf buffer = io.read(reader, null, bufSize)
+        int len = buffer.len()
+        char[] rbuf = buffer.readForRecycle()
+        String result = new String(rbuf, 0, len)
+        assertEquals(TEST_STRING, result)
+    }
 }
 
 /**
@@ -45,30 +44,30 @@ class IOTest extends GroovyTestCase {
  */
 class BumpyReader extends Reader {
 
-	int index = 0;
-	def stopIndex = [69, 84, 500]
-	int nextStop=0;
+    int index = 0;
+    def stopIndex = [69, 84, 500]
+    int nextStop = 0;
 
-	@Override
-	public int read(char[] cbuf, int off, int len) throws IOException {
-		if (index>=IOTest.TEST_STRING.size()) {
-			return -1
-		}
-		int num=0
-		while(num<len && index < stopIndex[nextStop] && index<IOTest.TEST_STRING.size()) {
-			cbuf[off+num]=IOTest.TEST_STRING[index]
-			num++
-			index++
-		}
-		if(index==stopIndex[nextStop]) {
-			nextStop++
-		}
-		return num;
-	}
+    @Override
+    public int read(char[] cbuf, int off, int len) throws IOException {
+        if (index >= IOTest.TEST_STRING.size()) {
+            return -1
+        }
+        int num = 0
+        while (num < len && index < stopIndex[nextStop] && index < IOTest.TEST_STRING.size()) {
+            cbuf[off + num] = IOTest.TEST_STRING[index]
+            num++
+            index++
+        }
+        if (index == stopIndex[nextStop]) {
+            nextStop++
+        }
+        return num;
+    }
 
-	@Override
-	public void close() throws IOException {
-	}
+    @Override
+    public void close() throws IOException {
+    }
 }
 
 /**
@@ -77,23 +76,23 @@ class BumpyReader extends Reader {
  */
 class ProperReader extends Reader {
 
-	int index = 0;
+    int index = 0;
 
-	@Override
-	public int read(char[] cbuf, int off, int len) throws IOException {
-		if (index>=IOTest.TEST_STRING.size()) {
-			return -1
-		}
-		int num=0
-		while(num<len && index<IOTest.TEST_STRING.size()) {
-			cbuf[off+num]=IOTest.TEST_STRING[index]
-			num++
-			index++
-		}
-		return num;
-	}
+    @Override
+    public int read(char[] cbuf, int off, int len) throws IOException {
+        if (index >= IOTest.TEST_STRING.size()) {
+            return -1
+        }
+        int num = 0
+        while (num < len && index < IOTest.TEST_STRING.size()) {
+            cbuf[off + num] = IOTest.TEST_STRING[index]
+            num++
+            index++
+        }
+        return num;
+    }
 
-	@Override
-	public void close() throws IOException {
-	}
+    @Override
+    public void close() throws IOException {
+    }
 }

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonBuilderTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonBuilderTest.groovy
@@ -325,4 +325,16 @@ class JsonBuilderTest extends GroovyTestCase {
         deserialized = (new JsonSlurper()).parseText(serialized)
         assert original.elem == deserialized.elem
     }
+
+    void testSpecialCharEscape() {
+        assert new JsonBuilder({'"' 0}).toString() == '{"\\"":0}'
+        assert new JsonBuilder({'\b' 0}).toString() == '{"\\b":0}'
+        assert new JsonBuilder({'\f' 0}).toString() == '{"\\f":0}'
+        assert new JsonBuilder({'\n' 0}).toString() == '{"\\n":0}'
+        assert new JsonBuilder({'\r' 0}).toString() == '{"\\r":0}'
+        assert new JsonBuilder({'\t' 0}).toString() == '{"\\t":0}'
+        assert new JsonBuilder({'\\' 0}).toString() == '{"\\\\":0}'
+        assert new JsonBuilder({'\1' 0}).toString() == '{"\\u0001":0}'
+        assert new JsonBuilder({'\u0002' 0}).toString() == '{"\\u0002":0}'
+    }
 }

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonBuilderTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonBuilderTest.groovy
@@ -138,7 +138,7 @@ class JsonBuilderTest extends GroovyTestCase {
     }
 
     void testCollectionAndClosure() {
-        def authors = [new Author (name: "Guillaume"), new Author (name: "Jochen"), new Author (name: "Paul")]
+        def authors = [new Author(name: "Guillaume"), new Author(name: "Jochen"), new Author(name: "Paul")]
 
         def json = new JsonBuilder()
         json authors, { Author author ->
@@ -149,7 +149,7 @@ class JsonBuilderTest extends GroovyTestCase {
     }
 
     void testMethodWithCollectionAndClosure() {
-        def authors = [new Author (name: "Guillaume"), new Author (name: "Jochen"), new Author (name: "Paul")]
+        def authors = [new Author(name: "Guillaume"), new Author(name: "Jochen"), new Author(name: "Paul")]
 
         def json = new JsonBuilder()
         json.authors authors, { Author author ->
@@ -160,7 +160,7 @@ class JsonBuilderTest extends GroovyTestCase {
     }
 
     void testNestedMethodWithCollectionAndClosure() {
-        def theAuthors = [new Author (name: "Guillaume"), new Author (name: "Jochen"), new Author (name: "Paul")]
+        def theAuthors = [new Author(name: "Guillaume"), new Author(name: "Jochen"), new Author(name: "Paul")]
 
         def json = new JsonBuilder()
         json {
@@ -210,7 +210,7 @@ class JsonBuilderTest extends GroovyTestCase {
     void testNestedListMap() {
         def json = new JsonBuilder()
         json.content {
-            list([:],[another:[a:[1,2,3]]])
+            list([:], [another: [a: [1, 2, 3]]])
         }
 
         assert json.toString() == '''{"content":{"list":[{},{"another":{"a":[1,2,3]}}]}}'''
@@ -305,7 +305,7 @@ class JsonBuilderTest extends GroovyTestCase {
     void testStringEscape() {
         def original, serialized, deserialized
 
-        original = [elem:"\\n"]
+        original = [elem: "\\n"]
         serialized = (new JsonBuilder(original)).toString()
         deserialized = (new JsonSlurper()).parseText(serialized)
         assert original.elem == deserialized.elem
@@ -324,6 +324,5 @@ class JsonBuilderTest extends GroovyTestCase {
         serialized = (new JsonBuilder(original)).toString()
         deserialized = (new JsonSlurper()).parseText(serialized)
         assert original.elem == deserialized.elem
-
     }
 }

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonLexerTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonLexerTest.groovy
@@ -16,8 +16,8 @@
 package groovy.json
 
 import static groovy.json.JsonTokenType.*
-import groovy.io.LineColumnReader
 
+import groovy.io.LineColumnReader
 
 /**
  * @author Guillaume Laforge
@@ -112,7 +112,7 @@ class JsonLexerTest extends GroovyTestCase {
     void testUnescapingWithLexer() {
         // use string concatenation so that the unicode escape characters are not decoded 
         // by Groovy's lexer but by the JsonLexer
-        def lexer = new JsonLexer(new StringReader('"\\' + 'u004A\\' + 'u0053\\' + 'u004F\\' + 'u004E"')) 
+        def lexer = new JsonLexer(new StringReader('"\\' + 'u004A\\' + 'u0053\\' + 'u004F\\' + 'u004E"'))
 
         assert lexer.nextToken().value == 'JSON'
     }
@@ -129,7 +129,7 @@ class JsonLexerTest extends GroovyTestCase {
 
         // use string concatenation so that the unicode escape characters are not decoded
         // by Groovy's lexer but by the JsonLexer
-        assert JsonLexer.unescape('\\' + 'u004A\\' + 'u0053\\' + 'u004F\\' + 'u004E') == 'JSON' 
+        assert JsonLexer.unescape('\\' + 'u004A\\' + 'u0053\\' + 'u004F\\' + 'u004E') == 'JSON'
     }
 
     void testBackSlashEscaping() {

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonOutputTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonOutputTest.groovy
@@ -16,6 +16,7 @@
 package groovy.json
 
 import static groovy.json.JsonOutput.toJson
+
 import groovy.transform.Canonical
 
 /**
@@ -23,11 +24,11 @@ import groovy.transform.Canonical
  * @author Andrey Bloschetsov
  */
 class JsonOutputTest extends GroovyTestCase {
-    
+
     // Check for GROOVY-5918
     void testExpando() {
-        assert toJson( new Expando( a:42 ) ) == '{"a":42}'
-        assert new JsonBuilder( new Expando( a:42 ) ).toString() == '{"a":42}'
+        assert toJson(new Expando(a: 42)) == '{"a":42}'
+        assert new JsonBuilder(new Expando(a: 42)).toString() == '{"a":42}'
     }
 
     void testBooleanValues() {
@@ -61,24 +62,25 @@ class JsonOutputTest extends GroovyTestCase {
         assert toJson(100) == "100"
         assert toJson(100) == "100"
 
-        assert toJson((short)100) == "100"
-        assert toJson((byte)100) == "100"
+        assert toJson((short) 100) == "100"
+        assert toJson((byte) 100) == "100"
 
         // Long
         assert toJson(1000000000000000000) == "1000000000000000000"
+
         // BigInteger
         assert toJson(1000000000000000000000000) == "1000000000000000000000000"
 
         // BigDecimal
         assert toJson(0.0) == "0.0"
-        assert toJson(0.0) == "0.0"
 
         // Double
         assert toJson(Math.PI) == "3.141592653589793"
+
         // Float
         assert toJson(1.2345f) == "1.2345"
 
-        // exponant
+        // exponent
         assert toJson(1234.1234e12) == "1.2341234E+15"
 
         shouldFail { toJson(Double.NaN) }
@@ -132,7 +134,7 @@ class JsonOutputTest extends GroovyTestCase {
 //        assert toJson("/") == '"\\/"'
         assert toJson("\\") == '"\\\\"'
 
-        assert toJson("\u0001") == '"\\u0001"' 
+        assert toJson("\u0001") == '"\\u0001"'
         assert toJson("\u0002") == '"\\u0002"'
         assert toJson("\u0003") == '"\\u0003"'
         assert toJson("\u0004") == '"\\u0004"'
@@ -189,7 +191,7 @@ class JsonOutputTest extends GroovyTestCase {
         assert toJson([name: 'Guillaume', age: 33, address: [line1: "1 main street", line2: "", zip: 1234], pets: ['dog', 'cat']]) ==
                 '{"name":"Guillaume","age":33,"address":{"line1":"1 main street","line2":"","zip":1234},"pets":["dog","cat"]}'
 
-        assert toJson([[:],[:]]) == '[{},{}]'
+        assert toJson([[:], [:]]) == '[{},{}]'
     }
 
     void testClosure() {
@@ -265,14 +267,15 @@ class JsonOutputTest extends GroovyTestCase {
             }""".stripIndent()
     }
 
-    private stripWhiteSpace( String str ) {
-      return str.replaceAll( ~/\s/, '' )
+    private stripWhiteSpace(String str) {
+        return str.replaceAll(~/\s/, '')
     }
+
     void testPrettyPrintStringZeroLen() {
-      def tree = [ myStrings: [ str3:'abc', str0:'' ] ]
-      def result   = stripWhiteSpace( new JsonBuilder( tree ).toPrettyString() )
-      def expected = stripWhiteSpace( '{ "myStrings":{ "str3":"abc","str0":"" } }' )
-      assert result == expected
+        def tree = [myStrings: [str3: 'abc', str0: '']]
+        def result = stripWhiteSpace(new JsonBuilder(tree).toPrettyString())
+        def expected = stripWhiteSpace('{ "myStrings":{ "str3":"abc","str0":"" } }')
+        assert result == expected
     }
 
     void testPrettyPrintDoubleQuoteEscape() {
@@ -290,10 +293,10 @@ class JsonOutputTest extends GroovyTestCase {
         def city = new JsonCity("Paris", [
                 new JsonDistrict(1, [
                         new JsonStreet("Saint-Honore", JsonStreetKind.street),
-                        new JsonStreet("de l'Opera",   JsonStreetKind.avenue)
+                        new JsonStreet("de l'Opera", JsonStreetKind.avenue)
                 ] as JsonStreet[]),
                 new JsonDistrict(2, [
-                        new JsonStreet("des Italiens",   JsonStreetKind.boulevard),
+                        new JsonStreet("des Italiens", JsonStreetKind.boulevard),
                         new JsonStreet("Bonne Nouvelle", JsonStreetKind.boulevard)
                 ] as JsonStreet[])
         ])
@@ -344,16 +347,16 @@ class JsonOutputTest extends GroovyTestCase {
         assert toJson(m) == '{"a":1}'
     }
 
-	void testObjectWithDeclaredPropertiesField() {
-		def person = new JsonObject(name: "pillow", properties: [state: "fluffy", color: "white"])
-		def json = toJson(person)
-		assert json == '{"properties":{"state":"fluffy","color":"white"},"name":"pillow"}'
-	}
-	
-	void testGROOVY5494() {
-		def json = toJson(new JsonFoo(name: "foo"))
-		assert json == '{"properties":0,"name":"foo"}'
-	}
+    void testObjectWithDeclaredPropertiesField() {
+        def person = new JsonObject(name: "pillow", properties: [state: "fluffy", color: "white"])
+        def json = toJson(person)
+        assert json == '{"properties":{"state":"fluffy","color":"white"},"name":"pillow"}'
+    }
+
+    void testGROOVY5494() {
+        def json = toJson(new JsonFoo(name: "foo"))
+        assert json == '{"properties":0,"name":"foo"}'
+    }
 
     void testCharacter() {
         assert toJson('a' as char) == '"a"'
@@ -388,13 +391,13 @@ class JsonStreet {
 }
 
 class JsonObject {
-	String name
-	Map properties
+    String name
+    Map properties
 }
 
 class JsonFoo {
-	String name
-	int getProperties() { return 0 }
+    String name
+    int getProperties() { return 0 }
 }
 
 enum JsonStreetKind {

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonOutputTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonOutputTest.groovy
@@ -370,6 +370,48 @@ class JsonOutputTest extends GroovyTestCase {
         assert toJson(1 as char) == '"\\u0001"'
         assert toJson('\u0002' as char) == '"\\u0002"'
     }
+
+    void testEmptyValue() {
+        assert toJson('') == '""'
+        assert toJson(['']) == '[""]'
+        assert toJson(['': '']) == '{"":""}'
+        assert toJson(new Expando('': '')) == '{"":""}'
+    }
+
+    void testSpecialCharEscape() {
+        // Map
+        assert toJson(['"': 0]) == '{"\\"":0}'
+        assert toJson(['\b': 0]) == '{"\\b":0}'
+        assert toJson(['\f': 0]) == '{"\\f":0}'
+        assert toJson(['\n': 0]) == '{"\\n":0}'
+        assert toJson(['\r': 0]) == '{"\\r":0}'
+        assert toJson(['\t': 0]) == '{"\\t":0}'
+        assert toJson(['\\': 0]) == '{"\\\\":0}'
+        assert toJson([(1 as char): 0]) == '{"\\u0001":0}'
+        assert toJson(['\u0002': 0]) == '{"\\u0002":0}'
+
+        // Expando
+        assert toJson(new Expando('"': 0)) == '{"\\"":0}'
+        assert toJson(new Expando('\b': 0)) == '{"\\b":0}'
+        assert toJson(new Expando('\f': 0)) == '{"\\f":0}'
+        assert toJson(new Expando('\n': 0)) == '{"\\n":0}'
+        assert toJson(new Expando('\r': 0)) == '{"\\r":0}'
+        assert toJson(new Expando('\t': 0)) == '{"\\t":0}'
+        assert toJson(new Expando('\\': 0)) == '{"\\\\":0}'
+        assert toJson(new Expando((1 as char): 0)) == '{"\\u0001":0}'
+        assert toJson(new Expando('\u0002': 0)) == '{"\\u0002":0}'
+
+        // Closure
+        assert toJson({'"' 0}) == '{"\\"":0}'
+        assert toJson({'\b' 0}) == '{"\\b":0}'
+        assert toJson({'\f' 0}) == '{"\\f":0}'
+        assert toJson({'\n' 0}) == '{"\\n":0}'
+        assert toJson({'\r' 0}) == '{"\\r":0}'
+        assert toJson({'\t' 0}) == '{"\\t":0}'
+        assert toJson({'\\' 0}) == '{"\\\\":0}'
+        assert toJson({'\1' 0}) == '{"\\u0001":0}'
+        assert toJson({'\u0002' 0}) == '{"\\u0002":0}'
+    }
 }
 
 @Canonical

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperCharSourceTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperCharSourceTest.groovy
@@ -1,7 +1,5 @@
 package groovy.json
 
-
-
 /**
  * Created by Richard on 2/2/14.
  */

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperIndexOverlayTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperIndexOverlayTest.groovy
@@ -1,7 +1,5 @@
 package groovy.json
 
-
-
 /**
  * Created by Richard on 2/2/14.
  */

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperLaxTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperLaxTest.groovy
@@ -1,6 +1,5 @@
 package groovy.json
 
-
 /**
  * Created by Richard on 2/2/14.
  */
@@ -11,27 +10,26 @@ class JsonSlurperLaxTest extends JsonSlurperTest {
     }
 
     void testNullEmptyMalformedPayloads() {
-        shouldFail(IllegalArgumentException) { parser.parseText(null)   }
-        shouldFail(IllegalArgumentException) { parser.parseText("")     }
+        shouldFail(IllegalArgumentException) { parser.parseText(null) }
+        shouldFail(IllegalArgumentException) { parser.parseText("") }
 
-        shouldFail(JsonException) { parser.parseText("[")           }
-        shouldFail(JsonException) { parser.parseText('{"')          }
-        shouldFail(JsonException) { parser.parseText("[a")           }
-        shouldFail(JsonException) { parser.parseText('{a"')          }
-        shouldFail(JsonException) { parser.parseText("[\"a\"")           }
-        shouldFail(JsonException) { parser.parseText('{"a"')          }
-
+        shouldFail(JsonException) { parser.parseText("[") }
+        shouldFail(JsonException) { parser.parseText('{"') }
+        shouldFail(JsonException) { parser.parseText("[a") }
+        shouldFail(JsonException) { parser.parseText('{a"') }
+        shouldFail(JsonException) { parser.parseText("[\"a\"") }
+        shouldFail(JsonException) { parser.parseText('{"a"') }
     }
 
     void testObjectWithSimpleValues() {
         assert parser.parseText('{"a": 1, "b" : true , "c":false, "d": null}') == [a: 1, b: true, c: false, d: null]
 
-         parser.parseText('{true}')
-         shouldFail { parser.parseText('{"a"}') }
-         parser.parseText('{"a":true')
-         parser.parseText('{"a":}')
-         shouldFail {parser.parseText('{"a":"b":"c"}') }
-         parser.parseText('{:true}')
+        parser.parseText('{true}')
+        shouldFail { parser.parseText('{"a"}') }
+        parser.parseText('{"a":true')
+        parser.parseText('{"a":}')
+        shouldFail {parser.parseText('{"a":"b":"c"}') }
+        parser.parseText('{:true}')
     }
 
     void testArrayOfArrayWithSimpleValues() {
@@ -69,9 +67,7 @@ class JsonSlurperLaxTest extends JsonSlurperTest {
     }
 
     void testLaxCommentsAndKeys() {
-
         String jsonString = """
-
             {
             foo:bar,    //look mom no quotes
             'foo1': 'bar1',  //I can do single quotes if I want to
@@ -95,7 +91,7 @@ class JsonSlurperLaxTest extends JsonSlurperTest {
             }
         """
 
-        Map <String, Object> map = parser.parseText(jsonString)
+        Map<String, Object> map = parser.parseText(jsonString)
         assert map.foo == "bar"
         assert map.foo1 == "bar1"
         assert map.foo2 == "bar2"

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperTest.groovy
@@ -31,7 +31,6 @@ class JsonSlurperTest extends GroovyTestCase {
     void testJsonShouldStartWithCurlyOrBracket() {
         /* We can handle parsing boolean, numbers, and such. */
         parser.parseText("true")
-
     }
 
     void testEmptyStructures() {
@@ -55,7 +54,7 @@ class JsonSlurperTest extends GroovyTestCase {
         def list = parser.parseText('[]')
         list << "Hello"
         list << "World"
-        assert list == [ "Hello", "World" ]
+        assert list == ["Hello", "World"]
     }
 
     void testParseNum() {
@@ -68,56 +67,48 @@ class JsonSlurperTest extends GroovyTestCase {
         int i = parser.parseText('-123')
         int i2 = -123
         assert i == i2
-
     }
 
     void testNegNumWithSpace() {
         int i = parser.parseText('   -123')
         int i2 = -123
         assert i == i2
-
     }
 
     void testLargeNegNumWithSpace() {
         int i = parser.parseText('   -1234567891')
         int i2 = -1234567891
         assert i == i2
-
     }
 
     void testWithSpaces() {
-        int num = ((Number)parser.parseText( "           123")).intValue()
+        int num = ((Number) parser.parseText("           123")).intValue()
         int num2 = 123
-        boolean ok = num == num2 || die ( "" + num)
-
+        boolean ok = num == num2 || die("" + num)
     }
 
     void testParseLargeNum() {
-        long num = parser.parseText(""+Long.MAX_VALUE)
+        long num = parser.parseText("" + Long.MAX_VALUE)
         long num2 = Long.MAX_VALUE
         assert num == num2
-
     }
 
     void testParseSmallNum() {
-        long num = parser.parseText(""+Long.MIN_VALUE)
+        long num = parser.parseText("" + Long.MIN_VALUE)
         long num2 = Long.MIN_VALUE
         assert num == num2
-
     }
 
     void testParseLargeDecimal() {
-        double num  = parser.parseText(""+Double.MAX_VALUE)
+        double num = parser.parseText("" + Double.MAX_VALUE)
         double num2 = Double.MAX_VALUE
         assert num == num2
-
     }
 
     void testParseSmallDecimal() {
-        double num  = parser.parseText(""+Double.MIN_VALUE)
+        double num = parser.parseText("" + Double.MIN_VALUE)
         double num2 = Double.MIN_VALUE
         assert num == num2
-
     }
 
     void testOutputTypes() {
@@ -306,11 +297,11 @@ class JsonSlurperTest extends GroovyTestCase {
             parser.parseText('{"a":"c:\\\"}')
         }
     }
-  
+
     void testParseWithByteArray() {
         def slurper = new JsonSlurper()
-        
+
         assert slurper.parse('{"a":true}'.bytes) == [a: true]
-        
+
     }
 }

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonTokenTypeTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonTokenTypeTest.groovy
@@ -84,33 +84,33 @@ class JsonTokenTypeTest extends GroovyTestCase {
     }
 
     void testMatchingLongStringWithBackslashes() {
-        assert STRING.matching('"a' + '\\"'*10000 + '"')
+        assert STRING.matching('"a' + '\\"' * 10000 + '"')
     }
 
     void testTokenStartingWithChar() {
-        assert startingWith('{' as char)      == OPEN_CURLY
-        assert startingWith('}' as char)      == CLOSE_CURLY
-        assert startingWith('[' as char)      == OPEN_BRACKET
-        assert startingWith(']' as char)      == CLOSE_BRACKET
-        assert startingWith(',' as char)      == COMMA
-        assert startingWith(':' as char)      == COLON
+        assert startingWith('{' as char) == OPEN_CURLY
+        assert startingWith('}' as char) == CLOSE_CURLY
+        assert startingWith('[' as char) == OPEN_BRACKET
+        assert startingWith(']' as char) == CLOSE_BRACKET
+        assert startingWith(',' as char) == COMMA
+        assert startingWith(':' as char) == COLON
 
-        assert startingWith('t' as char)      == TRUE
-        assert startingWith('f' as char)      == FALSE
-        assert startingWith('n' as char)      == NULL
+        assert startingWith('t' as char) == TRUE
+        assert startingWith('f' as char) == FALSE
+        assert startingWith('n' as char) == NULL
 
-        assert startingWith('"' as char)      == STRING
+        assert startingWith('"' as char) == STRING
 
-        assert startingWith('-' as char)      == NUMBER
-        assert startingWith('1' as char)      == NUMBER
-        assert startingWith('2' as char)      == NUMBER
-        assert startingWith('3' as char)      == NUMBER
-        assert startingWith('4' as char)      == NUMBER
-        assert startingWith('5' as char)      == NUMBER
-        assert startingWith('6' as char)      == NUMBER
-        assert startingWith('7' as char)      == NUMBER
-        assert startingWith('8' as char)      == NUMBER
-        assert startingWith('9' as char)      == NUMBER
-        assert startingWith('0' as char)      == NUMBER
+        assert startingWith('-' as char) == NUMBER
+        assert startingWith('1' as char) == NUMBER
+        assert startingWith('2' as char) == NUMBER
+        assert startingWith('3' as char) == NUMBER
+        assert startingWith('4' as char) == NUMBER
+        assert startingWith('5' as char) == NUMBER
+        assert startingWith('6' as char) == NUMBER
+        assert startingWith('7' as char) == NUMBER
+        assert startingWith('8' as char) == NUMBER
+        assert startingWith('9' as char) == NUMBER
+        assert startingWith('0' as char) == NUMBER
     }
 }

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonTokenValueTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonTokenValueTest.groovy
@@ -17,9 +17,6 @@ package groovy.json
 
 import static JsonTokenType.*
 
-
-import groovy.util.GroovyTestCase
-
 /**
  * @author Guillaume Laforge
  */

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/RealJsonPayloadsTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/RealJsonPayloadsTest.groovy
@@ -15,8 +15,6 @@
  */
 package groovy.json
 
-
-
 /**
  * @author Guillaume Laforge
  */

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/StreamingJsonBuilderTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/StreamingJsonBuilderTest.groovy
@@ -15,7 +15,6 @@
  */
 package groovy.json
 
-
 /**
  * @author Tim Yates
  * @author Guillaume Laforge
@@ -24,14 +23,14 @@ class StreamingJsonBuilderTest extends GroovyTestCase {
 
     void testJsonBuilderConstructor() {
         new StringWriter().with { w ->
-            new StreamingJsonBuilder( w, [a: 1, b: true])
+            new StreamingJsonBuilder(w, [a: 1, b: true])
             assert w.toString() == '{"a":1,"b":true}'
         }
     }
 
     void testEmptyArray() {
         new StringWriter().with { w ->
-            def json = new StreamingJsonBuilder( w )
+            def json = new StreamingJsonBuilder(w)
             json([])
             assert w.toString() == '[]'
         }
@@ -39,7 +38,7 @@ class StreamingJsonBuilderTest extends GroovyTestCase {
 
     void testSimpleArray() {
         new StringWriter().with { w ->
-            def json = new StreamingJsonBuilder( w )
+            def json = new StreamingJsonBuilder(w)
             json 1, 2, "a", "b"
 
             assert w.toString() == '[1,2,"a","b"]'
@@ -48,7 +47,7 @@ class StreamingJsonBuilderTest extends GroovyTestCase {
 
     void testComplexArray() {
         new StringWriter().with { w ->
-            def json = new StreamingJsonBuilder( w )
+            def json = new StreamingJsonBuilder(w)
             json 1, 2, [k: true], "a", "b", [3, "c"]
 
             assert w.toString() == '[1,2,{"k":true},"a","b",[3,"c"]]'
@@ -57,7 +56,7 @@ class StreamingJsonBuilderTest extends GroovyTestCase {
 
     void testMap() {
         new StringWriter().with { w ->
-            def json = new StreamingJsonBuilder( w )
+            def json = new StreamingJsonBuilder(w)
             json a: 1, b: 2
 
             assert w.toString() == '{"a":1,"b":2}'
@@ -66,7 +65,7 @@ class StreamingJsonBuilderTest extends GroovyTestCase {
 
     void testEmptyObject() {
         new StringWriter().with { w ->
-            def json = new StreamingJsonBuilder( w )
+            def json = new StreamingJsonBuilder(w)
             json {}
 
             assert w.toString() == '{}'
@@ -75,7 +74,7 @@ class StreamingJsonBuilderTest extends GroovyTestCase {
 
     void testBasicObject() {
         new StringWriter().with { w ->
-            def json = new StreamingJsonBuilder( w )
+            def json = new StreamingJsonBuilder(w)
             json {
                 a 1
                 b true
@@ -88,7 +87,7 @@ class StreamingJsonBuilderTest extends GroovyTestCase {
     
     void testNestedObjects() {
         new StringWriter().with { w ->
-            def json = new StreamingJsonBuilder( w )
+            def json = new StreamingJsonBuilder(w)
             json {
                 a {
                     b {
@@ -103,7 +102,7 @@ class StreamingJsonBuilderTest extends GroovyTestCase {
 
     void testStandardBuilderStyle() {
         new StringWriter().with { w ->
-            def json = new StreamingJsonBuilder( w )
+            def json = new StreamingJsonBuilder(w)
             json.person {
                 name "Guillaume"
                 age 33
@@ -115,7 +114,7 @@ class StreamingJsonBuilderTest extends GroovyTestCase {
 
     void testMethodCallWithNamedArguments() {
         new StringWriter().with { w ->
-            def json = new StreamingJsonBuilder( w )
+            def json = new StreamingJsonBuilder(w)
             json.person name: "Guillaume", age: 33
 
             assert w.toString() == '{"person":{"name":"Guillaume","age":33}}'
@@ -124,7 +123,7 @@ class StreamingJsonBuilderTest extends GroovyTestCase {
 
     void testThrowAnExceptionWhenPassingSomethingElseThanAClosure() {
         new StringWriter().with { w ->
-            def json = new StreamingJsonBuilder( w )
+            def json = new StreamingJsonBuilder(w)
 
             shouldFail(JsonException) {
                 json.something 1, 2, 3
@@ -134,7 +133,7 @@ class StreamingJsonBuilderTest extends GroovyTestCase {
 
     void testListWithAnEmptyObject() {
         new StringWriter().with { w ->
-            def json = new StreamingJsonBuilder( w )
+            def json = new StreamingJsonBuilder(w)
             json([[:]])
 
             assert w.toString() == '[{}]'
@@ -143,7 +142,7 @@ class StreamingJsonBuilderTest extends GroovyTestCase {
 
     void testListOfObjects() {
         new StringWriter().with { w ->
-            def json = new StreamingJsonBuilder( w )
+            def json = new StreamingJsonBuilder(w)
             json([name: "Guillaume"], [name: "Jochen"], [name: "Paul"])
 
             assert w.toString() == '[{"name":"Guillaume"},{"name":"Jochen"},{"name":"Paul"}]'
@@ -152,7 +151,7 @@ class StreamingJsonBuilderTest extends GroovyTestCase {
 
     void testElementHasListOfObjects() {
         new StringWriter().with { w ->
-            def json = new StreamingJsonBuilder( w )
+            def json = new StreamingJsonBuilder(w)
             json.response {
                 results 1, [a: 2]
             }
@@ -166,10 +165,10 @@ class StreamingJsonBuilderTest extends GroovyTestCase {
     }
 
     void testCollectionAndClosure() {
-        def authors = [new Author (name: "Guillaume"), new Author (name: "Jochen"), new Author (name: "Paul")]
+        def authors = [new Author(name: "Guillaume"), new Author(name: "Jochen"), new Author(name: "Paul")]
 
         new StringWriter().with { w ->
-            def json = new StreamingJsonBuilder( w )
+            def json = new StreamingJsonBuilder(w)
             json authors, { Author author ->
                 name author.name
             }
@@ -179,10 +178,10 @@ class StreamingJsonBuilderTest extends GroovyTestCase {
     }
 
     void testMethodWithCollectionAndClosure() {
-        def authors = [new Author (name: "Guillaume"), new Author (name: "Jochen"), new Author (name: "Paul")]
+        def authors = [new Author(name: "Guillaume"), new Author(name: "Jochen"), new Author(name: "Paul")]
 
         new StringWriter().with { w ->
-            def json = new StreamingJsonBuilder( w )
+            def json = new StreamingJsonBuilder(w)
             json.authors authors, { Author author ->
                 name author.name
             }
@@ -192,10 +191,10 @@ class StreamingJsonBuilderTest extends GroovyTestCase {
     }
 
     void testNestedMethodWithCollectionAndClosure() {
-        def theAuthors = [new Author (name: "Guillaume"), new Author (name: "Jochen"), new Author (name: "Paul")]
+        def theAuthors = [new Author(name: "Guillaume"), new Author(name: "Jochen"), new Author(name: "Paul")]
 
         new StringWriter().with { w ->
-            def json = new StreamingJsonBuilder( w )
+            def json = new StreamingJsonBuilder(w)
             json {
                 authors theAuthors, { Author author ->
                     name author.name
@@ -208,7 +207,7 @@ class StreamingJsonBuilderTest extends GroovyTestCase {
 
     void testComplexStructureFromTheGuardian() {
         new StringWriter().with { w ->
-            def json = new StreamingJsonBuilder( w )
+            def json = new StreamingJsonBuilder(w)
             json.response {
                 status "ok"
                 userTier "free"
@@ -245,9 +244,9 @@ class StreamingJsonBuilderTest extends GroovyTestCase {
 
     void testNestedListMap() {
         new StringWriter().with { w ->
-            def json = new StreamingJsonBuilder( w )
+            def json = new StreamingJsonBuilder(w)
             json.content {
-                list([:],[another:[a:[1,2,3]]])
+                list([:], [another: [a: [1, 2, 3]]])
             }
 
             assert w.toString() == '''{"content":{"list":[{},{"another":{"a":[1,2,3]}}]}}'''
@@ -256,7 +255,7 @@ class StreamingJsonBuilderTest extends GroovyTestCase {
 
     void testEmptyList() {
         new StringWriter().with { w ->
-            def json = new StreamingJsonBuilder( w )
+            def json = new StreamingJsonBuilder(w)
             json()
 
             assert w.toString() == '''[]'''
@@ -265,7 +264,7 @@ class StreamingJsonBuilderTest extends GroovyTestCase {
 
     void testTrendsFromTwitter() {
         new StringWriter().with { w ->
-            def json = new StreamingJsonBuilder( w )
+            def json = new StreamingJsonBuilder(w)
             json.trends {
                 "2010-06-22 17:20" ([
                         name: "Groovy rules",
@@ -291,7 +290,7 @@ class StreamingJsonBuilderTest extends GroovyTestCase {
 
     void testExampleFromTheGep7Page() {
         new StringWriter().with { w ->
-            def builder = new StreamingJsonBuilder( w )
+            def builder = new StreamingJsonBuilder(w)
             builder.people {
                 person {
                     firstName 'Guillame'
@@ -313,37 +312,35 @@ class StreamingJsonBuilderTest extends GroovyTestCase {
 
     void testEdgeCases() {
         new StringWriter().with { w ->
-            def builder = new StreamingJsonBuilder( w )
+            def builder = new StreamingJsonBuilder(w)
             builder { elem 1, 2, 3 }
             
             assert w.toString() == '{"elem":[1,2,3]}'
         }
         new StringWriter().with { w ->
-            def builder = new StreamingJsonBuilder( w )
+            def builder = new StreamingJsonBuilder(w)
             builder.elem()
-            
+
             assert w.toString() == '{"elem":{}}'
         }
         new StringWriter().with { w ->
-            def builder = new StreamingJsonBuilder( w )
+            def builder = new StreamingJsonBuilder(w)
             builder.elem(a: 1, b: 2) { c 3 }
             
             assert w.toString() == '{"elem":{"a":1,"b":2,"c":3}}'
         }
         new StringWriter().with { w ->
-            def builder = new StreamingJsonBuilder( w )
-            builder.elem( [:] ) { c 3 }
+            def builder = new StreamingJsonBuilder(w)
+            builder.elem([:]) { c 3 }
             
             assert w.toString() == '{"elem":{"c":3}}'
         }
         new StringWriter().with { w ->
-            def builder = new StreamingJsonBuilder( w )
+            def builder = new StreamingJsonBuilder(w)
+
             shouldFail(JsonException) {
                 builder.elem(a: 1, b: 2, "ABCD")
             }
         }
     }
-
-
-
 }

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/internal/CharScannerTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/internal/CharScannerTest.groovy
@@ -60,7 +60,6 @@ class CharScannerTest extends GroovyTestCase {
     }
 
     void testParseIntMax() {
-
         int i = 0
         i = CharScanner.parseInt(("" + Integer.MAX_VALUE).toCharArray())
         assert i == Integer.MAX_VALUE
@@ -85,7 +84,6 @@ class CharScannerTest extends GroovyTestCase {
     }
 
     void testParseDouble() {
-
         String str = "123456789"
         double num =
             CharScanner.parseJsonNumber(str.toCharArray(), 0, str.length()).doubleValue()
@@ -93,7 +91,6 @@ class CharScannerTest extends GroovyTestCase {
     }
 
     void testParseDoubleNegative() {
-
         String str = "-1.23456789E8"
         double num =
             (Double) CharScanner.parseJsonNumber(str.toCharArray(), 0, str.length())
@@ -227,7 +224,6 @@ class CharScannerTest extends GroovyTestCase {
     }
 
     void testParseLong() {
-
         String str = "12345678910"
         long l1 = CharScanner.parseLongFromTo(str.toCharArray(), 0, str.length())
         assert l1 == 12345678910L
@@ -246,7 +242,6 @@ class CharScannerTest extends GroovyTestCase {
     }
 
     void testAutoSplitThisEndsInSpace() {
-
         def letters = chars("This is a string ")
         def splitted = CharScanner.split(letters, ' ' as char)
 
@@ -260,18 +255,15 @@ class CharScannerTest extends GroovyTestCase {
                 splitted[0] as char[]
         )
 
-
         assertArrayEquals(
                 chars("is"),
                 splitted[1] as char[]
         )
 
-
         assertArrayEquals(
                 chars("a"),
                 splitted[2] as char[]
         )
-
 
         assertArrayEquals(
                 chars("string"),
@@ -285,9 +277,7 @@ class CharScannerTest extends GroovyTestCase {
     }
 
     void testAutoSplitThis() {
-
-        def letters =
-            chars("This is a string")
+        def letters = chars("This is a string")
 
         def splitted = CharScanner.split(letters, ' ' as char)
 
@@ -301,18 +291,15 @@ class CharScannerTest extends GroovyTestCase {
                 splitted[0] as char[]
         )
 
-
         assertArrayEquals(
                 chars("is"),
                 splitted[1] as char[]
         )
 
-
         assertArrayEquals(
                 chars("a"),
                 splitted[2] as char[]
         )
-
 
         assertArrayEquals(
                 chars("string"),
@@ -326,8 +313,7 @@ class CharScannerTest extends GroovyTestCase {
     }
 
     void testAutoSplitThisStartSpace() {
-        def letters =
-            chars(" This is a string")
+        def letters = chars(" This is a string")
 
         def splitted = CharScanner.split(letters, ' ' as char)
 
@@ -368,9 +354,8 @@ class CharScannerTest extends GroovyTestCase {
     }
 
     void testAutoSplitThisByTabOrSpace() {
+        def letters = chars("This\tis a string")
 
-        def letters =
-            chars("This\tis a string")
         def splitted = CharScanner.splitByChars(letters, '\t' as char, ' ' as char)
 
         assertEquals(
@@ -405,10 +390,7 @@ class CharScannerTest extends GroovyTestCase {
     }
 
     void testAutoSplitThis3DoubleSpaceAfterA() {
-
-        def letters =
-            chars("This is a  string")
-
+        def letters = chars("This is a  string")
 
         def splitted = CharScanner.split(letters, ' ' as char)
 
@@ -449,9 +431,7 @@ class CharScannerTest extends GroovyTestCase {
     }
 
     void testSplitThisEndsInSpace() {
-
-        def letters =
-            chars("This is a string ")
+        def letters = chars("This is a string ")
 
         def splitted = CharScanner.splitExact(letters, ' ' as char, 10)
 
@@ -487,9 +467,7 @@ class CharScannerTest extends GroovyTestCase {
     }
 
     void testSplitThis() {
-
-        def letters =
-            chars("This is a string")
+        def letters = chars("This is a string")
 
         def splitted = CharScanner.splitExact(letters, ' ' as char, 10)
 
@@ -526,8 +504,7 @@ class CharScannerTest extends GroovyTestCase {
     }
 
     void testSplitThisStartSpace() {
-        def letters =
-            chars(" This is a string")
+        def letters = chars(" This is a string")
 
         def splitted = CharScanner.splitExact(letters, ' ' as char, 10)
 
@@ -568,8 +545,7 @@ class CharScannerTest extends GroovyTestCase {
     }
 
     void testSplitThisByTabOrSpace() {
-        def letters =
-            chars("This\tis a string")
+        def letters = chars("This\tis a string")
 
         def splitted = CharScanner.splitExact(letters, 10, '\t' as char, ' ' as char)
 
@@ -605,8 +581,7 @@ class CharScannerTest extends GroovyTestCase {
     }
 
     void testSplitThis3DoubleSpaceAfterA() {
-        def letters =
-            chars("This is a  string")
+        def letters = chars("This is a  string")
 
         def splitted = CharScanner.splitExact(letters, ' ' as char, 10)
 

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/internal/ChrTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/internal/ChrTest.groovy
@@ -109,7 +109,6 @@ class ChrTest extends GroovyTestCase {
     }
 
     void testByteCopyIntoCharArray() {
-
         def charArray = new char[1000]
         def bytes = "0123456789000".bytes
 

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/internal/FastStringUtilsUnsafeDisabledTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/internal/FastStringUtilsUnsafeDisabledTest.groovy
@@ -16,6 +16,7 @@
 package groovy.json.internal
 
 class FastStringUtilsUnsafeDisabledTest extends GroovyTestCase {
+
     FastStringUtils.StringImplementation oldStringImplementation
 
     void setUp() {

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/internal/LazyMapTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/internal/LazyMapTest.groovy
@@ -17,6 +17,7 @@
 package groovy.json.internal
 
 class LazyMapTest extends GroovyTestCase {
+
     // GROOVY-7302
     void testSizeWhenNoBackingMapCreated() {
         def map = new LazyMap()
@@ -31,17 +32,17 @@ class LazyMapTest extends GroovyTestCase {
     void testSizeWhenLazyCreated() {
         def map = new LazyMap()
         map.someProperty1 = '1'
-        assert map.@map==null
+        assert map.@map == null
         map.someProperty2 = '2'
-        assert map.@map==null
+        assert map.@map == null
         map.someProperty3 = '3'
-        assert map.@map==null
+        assert map.@map == null
         map.someProperty4 = '4'
-        assert map.@map==null
+        assert map.@map == null
         map.someProperty5 = '5'
-        assert map.@map==null
+        assert map.@map == null
         map.someProperty6 = '6'
-        assert map.@map==null
+        assert map.@map == null
         map.someProperty7 = '7'
         assert map.someProperty6 == '6'
         assert map.@map?.size() == 7

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/internal/ReaderCharacterSourceTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/internal/ReaderCharacterSourceTest.groovy
@@ -18,21 +18,21 @@ package groovy.json.internal;
 
 class ReaderCharacterSourceTest extends GroovyTestCase {
 
-	void testFindNextCharWithRecursionHadEscape() {
-		int[] control = '"\\'.toCharArray() as int[]
+    void testFindNextCharWithRecursionHadEscape() {
+        int[] control = '"\\'.toCharArray() as int[]
 
-		// create a ReaderCharacterSource with a very small buffer, findNextChar must be invoked recursive
+        // create a ReaderCharacterSource with a very small buffer, findNextChar must be invoked recursive
 
         // use a string where escape-character is in last invocation
-		ReaderCharacterSource cs = new ReaderCharacterSource(new StringReader('"value\\u0026"'), 6)
-		cs.findNextChar(control[0], control[1])
+        ReaderCharacterSource cs = new ReaderCharacterSource(new StringReader('"value\\u0026"'), 6)
+        cs.findNextChar(control[0], control[1])
 
-		assert cs.hadEscape()
+        assert cs.hadEscape()
 
-		// use a string where escape-character is in first invocation
-		cs = new ReaderCharacterSource(new StringReader('"\\u0026value"'), 6)
-		cs.findNextChar(control[0], control[1])
+        // use a string where escape-character is in first invocation
+        cs = new ReaderCharacterSource(new StringReader('"\\u0026value"'), 6)
+        cs.findNextChar(control[0], control[1])
 
-		assert cs.hadEscape()
-	}
+        assert cs.hadEscape()
+    }
 }


### PR DESCRIPTION
First I cleaned up the groovy-json module so the code is more consistent.

Then I fixed the issue reported in [GROOVY-7008](https://jira.codehaus.org/browse/GROOVY-7008):
* formerly no escaping has been performed at all
* now functionality is similar to JsonOutput#writeCharSequence()
* performance degradation is about 15% for a map entry with key size 50