### PR TITLE
GROOVY-7344: Disallow numbers with multiple decimal points from being parsed incorrectly.

### DIFF
--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/CharScanner.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/CharScanner.java
@@ -629,6 +629,9 @@ public class CharScanner {
             } else if (ch <= 32 || isDelimiter(ch)) {
                 break;
             } else if (ch == '.') {
+                if (foundDot) {
+                    die("unexpected character " + ch);
+                }
                 foundDot = true;
             } else if (ch == 'E' || ch == 'e' || ch == '-' || ch == '+') {
                 simple = false;
@@ -710,6 +713,9 @@ public class CharScanner {
                     digitsPastPoint++;
                 }
             } else if (ch == '.') {
+                if (foundDot) {
+                    die("unexpected character " + ch);
+                }
                 foundDot = true;
             } else if (ch == 'E' || ch == 'e' || ch == '-' || ch == '+') {
                 simple = false;

--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/NumberValue.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/NumberValue.java
@@ -17,6 +17,8 @@
  */
 package groovy.json.internal;
 
+import groovy.json.JsonException;
+
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Arrays;
@@ -145,7 +147,11 @@ public class NumberValue extends java.lang.Number implements Value {
     }
 
     public BigDecimal bigDecimalValue() {
-        return new BigDecimal(buffer, startIndex, endIndex - startIndex);
+        try {
+            return new BigDecimal(buffer, startIndex, endIndex - startIndex);
+        } catch (NumberFormatException e) {
+            throw new JsonException("unable to parse " + new String(buffer, startIndex, endIndex - startIndex), e);
+        }
     }
 
     public BigInteger bigIntegerValue() {

--- a/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperTest.groovy
+++ b/subprojects/groovy-json/src/test/groovy/groovy/json/JsonSlurperTest.groovy
@@ -271,6 +271,7 @@ class JsonSlurperTest extends GroovyTestCase {
         shouldFail(JsonException) { parser.parseText('["a"')        }
         shouldFail(JsonException) { parser.parseText('["a", ')      }
         shouldFail(JsonException) { parser.parseText('["a", true')  }
+        shouldFail(JsonException) { parser.parseText('[1.1.1]')     }
     }
 
     void testBackSlashEscaping() {


### PR DESCRIPTION
Prevents groovy from incorrectly parsing JSON numbers like e.g. 1.1.1 as 1.11.