### PR TITLE
Updated fix for GROOVY-7344

### DIFF
--- a/subprojects/groovy-json/src/main/java/groovy/json/internal/JsonFastParser.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/internal/JsonFastParser.java
@@ -161,6 +161,7 @@ public class JsonFastParser extends JsonParserCharArray {
         int index = __index;
         char currentChar;
         boolean doubleFloat = false;
+        boolean foundDot = false;
 
         if (minus && index + 1 < array.length) {
             index++;
@@ -174,6 +175,12 @@ public class JsonFastParser extends JsonParserCharArray {
                 break;
             } else if (isDelimiter(currentChar)) {
                 break;
+            } else if (currentChar == '.') {
+                if (foundDot) {
+                    complain("unexpected character " + currentChar);
+                }
+                foundDot = true;
+                doubleFloat = true;
             } else if (isDecimalChar(currentChar)) {
                 doubleFloat = true;
             }


### PR DESCRIPTION
Sorry about the test failure.  The fast parser seems to lazily evaluate numbers, so the test wouldn't trigger the new validation.  This fix detects the error a bit earlier.