### PR TITLE
GROOVY-4654: groovy.transform.ToString annotation does not handle cycles

### DIFF
--- a/src/main/groovy/transform/ToString.java
+++ b/src/main/groovy/transform/ToString.java
@@ -175,4 +175,11 @@ public @interface ToString {
      */
     boolean cache() default false;
 
+    /**
+     * Whether to handle cycles in the toString generation.
+     * Without this option toString can lead to stack overflow.
+     * FIXME since TBD
+     */
+    boolean handleCycles() default false;
+
 }

--- a/src/main/org/codehaus/groovy/transform/ToStringASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/ToStringASTTransformation.java
@@ -161,7 +161,7 @@ public class ToStringASTTransformation extends AbstractASTTransformation {
                     ));
 
         } else {
-            appendClassContextStatements(cNode, includeSuper, includeFields, excludes, includes, includeNames, ignoreNulls, includeSuperProperties, body, result, className);
+            appendClassContentStatements(cNode, includeSuper, includeFields, excludes, includes, includeNames, ignoreNulls, includeSuperProperties, body, result, className);
         }
         // wrap up
         MethodCallExpression toString = callX(result, "toString");
@@ -174,7 +174,7 @@ public class ToStringASTTransformation extends AbstractASTTransformation {
     private static TryCatchStatement createInitialAppendStatements(ClassNode cNode, boolean includeSuper, boolean includeFields, List<String> excludes, List<String> includes, boolean includeNames, boolean ignoreNulls, boolean includeSuperProperties, Expression result, String className, VariableExpression generatingThreadLocal) {
         BlockStatement tryBlock = new BlockStatement();
         tryBlock.addStatement(threadLocalSetS(generatingThreadLocal, constX(0)));
-        appendClassContextStatements(cNode, includeSuper, includeFields, excludes, includes, includeNames, ignoreNulls, includeSuperProperties, tryBlock, result, className);
+        appendClassContentStatements(cNode, includeSuper, includeFields, excludes, includes, includeNames, ignoreNulls, includeSuperProperties, tryBlock, result, className);
 
         return new TryCatchStatement(
                 tryBlock,
@@ -192,7 +192,7 @@ public class ToStringASTTransformation extends AbstractASTTransformation {
         return block;
     }
 
-    private static void appendClassContextStatements(ClassNode cNode, boolean includeSuper, boolean includeFields, List<String> excludes, List<String> includes, boolean includeNames, boolean ignoreNulls, boolean includeSuperProperties, BlockStatement block, Expression result, String className) {
+    private static void appendClassContentStatements(ClassNode cNode, boolean includeSuper, boolean includeFields, List<String> excludes, List<String> includes, boolean includeNames, boolean ignoreNulls, boolean includeSuperProperties, BlockStatement block, Expression result, String className) {
 
         // append <class_name>(
         block.addStatement(appendS(result, constX(className + "(")));

--- a/src/test/org/codehaus/groovy/transform/ToStringTransformTest.groovy
+++ b/src/test/org/codehaus/groovy/transform/ToStringTransformTest.groovy
@@ -261,7 +261,30 @@ class ToStringTransformTest extends GroovyShellTestCase {
 
         assert toString == 'Tree(val:foo, left:(this), right:(this))'
     }
-    
+
+
+    void testCircularReferenceSingleClass2Levels()  {
+
+        def toString = evaluate("""
+            import groovy.transform.*
+
+            @ToString(includeFields=true, includeNames=true, handleCycles=true) class A {
+                String val
+                A next
+            }
+
+            def a1 = new A(val:'a1', next:null)
+            def a2 = new A(val:'a2', next:a1)
+            a1.next = a2
+
+            a1.toString()
+        """)
+
+        assert toString == 'A(val:a1, next:A(val:a2, next:A(...)))'
+    }
+
+
+
     void testIncludePackage() {
         def toString = evaluate("""
                 package my.company


### PR DESCRIPTION
Hi,

https://jira.codehaus.org/browse/GROOVY-4654

I wanted to play a bit with groovy AST transformation so I worked on this issue.
# Overview

As demonstrated in the test case the proposed fixed gives 'A(val:a1, next:A(val:a2, next:A(...)))' as a result for the following code:

``` groovy
   import groovy.transform.*

  @ToString(includeFields=true, includeNames=true, handleCycles=true) class A {
     String val
     A next
   }

   def a1 = new A(val:'a1', next:null)
   def a2 = new A(val:'a2', next:a1)
   a1.next = a2

   a1.toString()
```

This fix adds handleCycles to ToString Annotation.
When handleCycles is true ASTTransform add a "$to$string$callCounter" ThreadLocal field to the class. 
This field is then used to now if we cycles happen. And if a cycle is detected it generates classname(...) for recursive calls instead of the standard toString.
I made this handleCycles optional and disabled by default because I didn't want to bloat all existing classes using  ToString AST with an additional field.
# Possible improvement

I was considering adding some pseudo id (maybe System.identityhashcode) when cycles are detected to be able to understand which instance is repeated
That would lead to a result like this 'A#1(val:a1, next:A(val:a2, next:A#1(...)))'
Let me know if you think it would be useful.
# Additional Fix

Additionally I fixed a bug in one of the createToString() implementation where the "cache" parameter was not propagated (at original line 123) 
