### PR TITLE
Fix 404 Error

### DIFF
--- a/gradle/asciidoctor.gradle
+++ b/gradle/asciidoctor.gradle
@@ -71,6 +71,7 @@ asciidoctor.onlyIf { project.file('src/spec/doc').exists() }
 
 task asciidoctorAssets(type:Copy) {
     from project.fileTree('src/spec/assets')
+    from project.fileTree('src/spec/doc/assets')
     into "${asciidoctor.outputDir}/html5/assets"
     into "${rootProject.asciidoctor.outputDir}/html5/assets"
 }


### PR DESCRIPTION
The documentation at http://docs.groovy-lang.org/docs/latest/html/documentation/ has a lot of missing images.
The reason being http://docs.groovy-lang.org/docs/latest/html/documentation/assets/img/ contains the wrong set of images. The images should come from [/src/spec/doc/assets/img](https://github.com/groovy/groovy-core/tree/master/src/spec/doc/assets/img), not [/src/spec/assets/img](https://github.com/groovy/groovy-core/tree/master/src/spec/assets/img)
A simple fix is to copy doc/assets/img into assets during the build process.
