### PR TITLE
Update Gradle to latest 2.4 nightly.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -420,6 +420,7 @@ allprojects {
 
 compileTestGroovy {
     groovyOptions.fork(memoryMaximumSize: groovycTest_mx)
+    options.compilerArgs << "-proc:none"
 }
 
 apply from: 'gradle/test.gradle'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,5 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-#distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-2.4-20150326230024+0000-bin.zip
-distributionUrl=http\://services.gradle.org/distributions/gradle-2.3-bin.zip
+distributionUrl=http\://services.gradle.org/distributions-snapshots/gradle-2.4-20150402010640+0000-bin.zip


### PR DESCRIPTION
Also disable annotation processing for stubs generated form test source set of the root project.

Verified by running `./gradlew clean check`

See [this forum response](http://old-forums.gradle.org/gradle/topics/groovy-builds-fails-with-gradle-2-4-nightly-build#reply_15544416) for details.