### PR TITLE
make CompilerConfiguration.ALLOWED_JDKS public

### DIFF
--- a/src/main/org/codehaus/groovy/control/CompilerConfiguration.java
+++ b/src/main/org/codehaus/groovy/control/CompilerConfiguration.java
@@ -56,7 +56,8 @@ public class CompilerConfiguration {
     /** This (<code>"1.4"</code>) is the value for targetBytecode to compile for a JDK 1.4 JVM. **/
     public static final String PRE_JDK5 = JDK4;
 
-    private static final String[] ALLOWED_JDKS = { JDK4, JDK5, JDK6, JDK7, JDK8 };
+    /** An array of the valid targetBytecode values **/
+    public static final String[] ALLOWED_JDKS = { JDK4, JDK5, JDK6, JDK7, JDK8 };
 
     // Just call getVMVersion() once.
     public static final String currentJVMVersion = getVMVersion();


### PR DESCRIPTION
I'd like to make CompilerConfiguration.ALLOWED_JDKS public so that tooling (like GMavenPlus) can programmatically inspect what target bytecodes are valid for each version of Groovy.