### PR TITLE
Fixed Groovy Logo url path

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -12,7 +12,7 @@ The Groovy development team
 :bintray-watch-link: https://bintray.com/groovy/maven/groovy/view?source=watch
 
 [.left.text-left]
-image::http://groovy.codehaus.org/images/groovy-logo.png[]
+image::http://groovy.codehaus.org/img/groovy-logo.png[]
 {groovy-www}[Groovy] is a powerful, optionally typed and dynamic language, with static-typing and static compilation capabilities, for the Java platform aimed at multiplying developers’ productivity thanks to a concise, familiar and easy to learn syntax.
 
 It integrates smoothly with any Java program, and immediately delivers to your application powerful features, including scripting capabilities, Domain-Specific Language authoring, runtime and compile-time meta-programming and functional programming. 


### PR DESCRIPTION
Looks like the `image` folder was renamed to `img`.