### PR TITLE
Tests for boundary Integer & Long literals

### DIFF
--- a/src/spec/test/SyntaxTest.groovy
+++ b/src/spec/test/SyntaxTest.groovy
@@ -153,6 +153,33 @@ class SyntaxTest extends CompilableTestSupport {
         '''
     }
 
+    void testValidIntegerLiterals() {
+        shouldCompile '''
+             def a = 2147483647I
+             def b = -2147483648I
+             def c = -2147483647I
+             def d = 9223372036854775807L
+             def e = -9223372036854775808L
+             def f = -9223372036854775807L
+         '''
+    }
+
+    void testInvalidIntegerLiteral() {
+        shouldNotCompile '''
+            // tag::invalid_integer_literal[]
+            def n = 2147483648I
+            // end::invalid_integer_literal[]
+        '''
+    }
+
+    void testInvalidLongLiteral() {
+        shouldNotCompile '''
+            // tag::invalid_long_literal[]
+            def n = 9223372036854775808L
+            // end::invalid_long_literal[]
+        '''
+    }
+
     void testAllKeywordsAreValidIdentifiersFollowingADot() {
         shouldCompile '''
         def foo = [:]


### PR DESCRIPTION
These tests highlight two compile-time errors that should be occurring that are not. They also provide some boundary literal values that should compile.

According to the Java Language Specification:

>It is a compile-time error if a decimal literal of type int is larger than 2147483648 (231), or if the decimal literal 2147483648 appears anywhere other than as the operand of the unary minus operator (§15.15.4).

and

>It is a compile-time error if a decimal literal of type long is larger than 9223372036854775808L (263), or if the decimal literal 9223372036854775808L appears anywhere other than as the operand of the unary minus operator (§15.15.4).

http://docs.oracle.com/javase/specs/jls/se7/html/jls-3.html#jls-3.10.1

Edit: Sorry I don't have the time or ability to submit a fix along with these tests.