### PR TITLE
GROOVY-7378: Support JAVA_OPTS containing quoted arguments on *nix

### DIFF
--- a/src/bin/startGroovy
+++ b/src/bin/startGroovy
@@ -261,18 +261,18 @@ startGroovy ( ) {
     if $useprofiler ; then
         runProfiler
     else
-        exec "$JAVACMD" $JAVA_OPTS \
-            -classpath "$STARTER_CLASSPATH" \
-            -Dscript.name="$SCRIPT_PATH" \
-            -Dprogram.name="$PROGNAME" \
-            -Dgroovy.starter.conf="$GROOVY_CONF" \
-            -Dgroovy.home="$GROOVY_HOME" \
-            -Dtools.jar="$TOOLS_JAR" \
+        eval exec "\"\$JAVACMD\"" $JAVA_OPTS \
+            -classpath "\"\$STARTER_CLASSPATH\"" \
+            -Dscript.name="\"\$SCRIPT_PATH\"" \
+            -Dprogram.name="\"\$PROGNAME\"" \
+            -Dgroovy.starter.conf="\"\$GROOVY_CONF\"" \
+            -Dgroovy.home="\"\$GROOVY_HOME\"" \
+            -Dtools.jar="\"\$TOOLS_JAR\"" \
             $STARTER_MAIN_CLASS \
             --main $CLASS \
-            --conf "$GROOVY_CONF" \
-            --classpath "$CP" \
-            "$@"
+            --conf "\"\$GROOVY_CONF\"" \
+            --classpath "\"\$CP\"" \
+            "\"\$@\""
     fi
 }
 


### PR DESCRIPTION
Fix for GROOVY-7378 startGroovy script when JAVA_OPTS contains quoted arguments.