### PR TITLE
Escaped <= so that does not appear as ⇐

### DIFF
--- a/src/spec/doc/core-operators.adoc
+++ b/src/spec/doc/core-operators.adoc
@@ -110,7 +110,7 @@ The following operators are available:
 | `<`
 | less than
 
-| `<=`
+| `\<=`
 | less than or equal
 
 | `>`


### PR DESCRIPTION
Fixes ⇐ being displayed where <= should be at http://docs.groovy-lang.org/latest/html/documentation/index.html#groovy-operators