### PR TITLE
Identical expressions should not be used on both sides of a binary operator

### DIFF
--- a/src/main/groovy/transform/builder/DefaultStrategy.java
+++ b/src/main/groovy/transform/builder/DefaultStrategy.java
@@ -177,7 +177,7 @@ public class DefaultStrategy extends BuilderASTTransformation.AbstractBuilderStr
     }
 
     public void buildMethod(BuilderASTTransformation transform, MethodNode mNode, AnnotationNode anno) {
-        if (transform.getMemberValue(anno, "includes") != null || transform.getMemberValue(anno, "includes") != null) {
+        if (transform.getMemberValue(anno, "includes") != null || transform.getMemberValue(anno, "excludes") != null) {
             transform.addError("Error during " + BuilderASTTransformation.MY_TYPE_NAME +
                     " processing: includes/excludes only allowed on classes", anno);
         }

--- a/src/main/groovy/transform/builder/InitializerStrategy.java
+++ b/src/main/groovy/transform/builder/InitializerStrategy.java
@@ -157,7 +157,7 @@ public class InitializerStrategy extends BuilderASTTransformation.AbstractBuilde
     }
 
     private void createBuilderForAnnotatedMethod(BuilderASTTransformation transform, MethodNode mNode, AnnotationNode anno, boolean useSetters) {
-        if (transform.getMemberValue(anno, "includes") != null || transform.getMemberValue(anno, "includes") != null) {
+        if (transform.getMemberValue(anno, "includes") != null || transform.getMemberValue(anno, "excludes") != null) {
             transform.addError("Error during " + BuilderASTTransformation.MY_TYPE_NAME +
                     " processing: includes/excludes only allowed on classes", anno);
         }

--- a/src/main/groovy/util/FactoryBuilderSupport.java
+++ b/src/main/groovy/util/FactoryBuilderSupport.java
@@ -68,7 +68,7 @@ public abstract class FactoryBuilderSupport extends Binding {
         public int compare(final Method o1, final Method o2) {
             int cmp = o1.getName().compareTo(o2.getName());
             if (cmp != 0) return cmp;
-            cmp = o1.getParameterTypes().length - o1.getParameterTypes().length;
+            cmp = o1.getParameterTypes().length - o2.getParameterTypes().length;
             return cmp;
         }
     };

--- a/subprojects/groovy-xml/src/main/java/groovy/util/slurpersupport/NamespaceAwareHashMap.java
+++ b/subprojects/groovy-xml/src/main/java/groovy/util/slurpersupport/NamespaceAwareHashMap.java
@@ -69,7 +69,7 @@ public class NamespaceAwareHashMap extends HashMap<String, String> {
 
     private Object adjustForNamespaceIfNeeded(Object key) {
         String keyString = key.toString();
-        if (keyString.contains("{") || namespaceTagHints == null || namespaceTagHints.isEmpty() || keyString.contains("{") || !keyString.contains(":")) {
+        if (keyString.contains("{") || namespaceTagHints == null || namespaceTagHints.isEmpty() || !keyString.contains(":")) {
             return key;
         }
         final int i = keyString.indexOf(":");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1764 - Identical expressions should not be used on both sides of a binary operator
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1764
Please let me know if you have any questions.
Kirill Vlasov