### PR TITLE
Collection.isEmpty() should be used to test for emptiness

### DIFF
--- a/src/main/groovy/grape/GrabAnnotationTransformation.java
+++ b/src/main/groovy/grape/GrabAnnotationTransformation.java
@@ -396,7 +396,7 @@ public class GrabAnnotationTransformation extends ClassCodeVisitorSupport implem
 
         List<Expression> argList = new ArrayList<Expression>();
         argList.add(basicArgs);
-        if (grabMapsInit.size() == 0) return;
+        if (grabMapsInit.isEmpty()) return;
         for (Map<String, Object> grabMap : grabMapsInit) {
             // add Grape.grab(excludeArgs, [group:group, module:module, version:version, classifier:classifier])
             // or Grape.grab([group:group, module:module, version:version, classifier:classifier])

--- a/src/main/groovy/lang/MetaClassImpl.java
+++ b/src/main/groovy/lang/MetaClassImpl.java
@@ -3206,7 +3206,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
             ParameterTypes paramTypes = (ParameterTypes) method;
             long dist = MetaClassHelper.calculateParameterDistance(arguments, paramTypes);
             if (dist == 0) return method;
-            if (matches.size() == 0) {
+            if (matches.isEmpty()) {
                 matches.add(method);
                 matchesDistance = dist;
             } else if (dist < matchesDistance) {
@@ -3221,7 +3221,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
         if (matches.size() == 1) {
             return matches.getFirst();
         }
-        if (matches.size() == 0) {
+        if (matches.isEmpty()) {
             return null;
         }
 

--- a/src/main/groovy/time/BaseDuration.java
+++ b/src/main/groovy/time/BaseDuration.java
@@ -113,7 +113,7 @@ public abstract class BaseDuration implements Comparable<BaseDuration> {
             buffer.add((norm_seconds == 0 ? (norm_millis < 0 ? "-0" : "0") : norm_seconds) + "." + StringGroovyMethods.padLeft("" + Math.abs(norm_millis), 3, "0") + " seconds");
         }
 
-        if (buffer.size() != 0) {
+        if (!buffer.isEmpty()) {
             return DefaultGroovyMethods.join(buffer.iterator(), ", ");
         } else {
             return "0";

--- a/src/main/groovy/util/ConfigObject.java
+++ b/src/main/groovy/util/ConfigObject.java
@@ -181,7 +181,7 @@ public class ConfigObject extends GroovyObjectSupport implements Writable, Map, 
 
                 continue;
             } else {
-                if (configEntry instanceof Map && ((Map)configEntry).size() > 0 && value instanceof Map) {
+                if (configEntry instanceof Map && !((Map) configEntry).isEmpty() && value instanceof Map) {
                     // recur
                     doMerge((Map) configEntry, (Map) value);
                 } else {

--- a/src/main/groovy/util/FactoryBuilderSupport.java
+++ b/src/main/groovy/util/FactoryBuilderSupport.java
@@ -836,18 +836,18 @@ public abstract class FactoryBuilderSupport extends Binding {
             // the builder and there is nothing we can really do to prevent
             // that
 
-            if ((list.size() > 0)
+            if ((!list.isEmpty())
                     && (list.get(0) instanceof LinkedHashMap)) {
                 namedArgs = (Map) list.get(0);
                 list = list.subList(1, list.size());
             }
-            if ((list.size() > 0)
+            if ((!list.isEmpty())
                     && (list.get(list.size() - 1) instanceof Closure)) {
                 closure = (Closure) list.get(list.size() - 1);
                 list = list.subList(0, list.size() - 1);
             }
             Object arg;
-            if (list.size() == 0) {
+            if (list.isEmpty()) {
                 arg = null;
             } else if (list.size() == 1) {
                 arg = list.get(0);

--- a/src/main/groovy/util/GroovyCollections.java
+++ b/src/main/groovy/util/GroovyCollections.java
@@ -140,7 +140,7 @@ public class GroovyCollections {
      */
     public static List transpose(List lists) {
         List result = new ArrayList();
-        if (lists.isEmpty() || lists.size() == 0) return result;
+        if (lists.isEmpty() || lists.isEmpty()) return result;
         int minSize = Integer.MAX_VALUE;
         for (Object listLike : lists) {
             List list = (List) DefaultTypeTransformation.castToType(listLike, List.class);

--- a/src/main/groovy/util/ObservableList.java
+++ b/src/main/groovy/util/ObservableList.java
@@ -185,7 +185,7 @@ public class ObservableList implements List {
                     values.add(element);
                 }
             }
-            if (values.size() > 0) {
+            if (!values.isEmpty()) {
                 fireMultiElementAddedEvent(index, values);
                 fireSizeChangedEvent(oldSize, size());
             }
@@ -210,7 +210,7 @@ public class ObservableList implements List {
                     values.add(element);
                 }
             }
-            if (values.size() > 0) {
+            if (!values.isEmpty()) {
                 fireMultiElementAddedEvent(index, values);
                 fireSizeChangedEvent(oldSize, size());
             }

--- a/src/main/groovy/util/ObservableMap.java
+++ b/src/main/groovy/util/ObservableMap.java
@@ -240,7 +240,7 @@ public class ObservableMap implements Map {
                     }
                 }
             }
-            if (events.size() > 0) {
+            if (!events.isEmpty()) {
                 fireMultiPropertyEvent(events);
                 fireSizeChangedEvent(oldSize, size());
             }

--- a/src/main/groovy/util/ObservableSet.java
+++ b/src/main/groovy/util/ObservableSet.java
@@ -236,7 +236,7 @@ public class ObservableSet<E> implements Set<E> {
                     values.add(element);
                 }
             }
-            if (values.size() > 0) {
+            if (!values.isEmpty()) {
                 fireMultiElementAddedEvent(values);
                 fireSizeChangedEvent(oldSize, size());
             }

--- a/src/main/org/codehaus/groovy/antlr/AntlrParserPlugin.java
+++ b/src/main/org/codehaus/groovy/antlr/AntlrParserPlugin.java
@@ -254,7 +254,7 @@ public class AntlrParserPlugin extends ASTHelper implements ParserPlugin, Groovy
             ClassNode scriptClassNode = output.getScriptClassDummy();
             if (scriptClassNode != null) {
                 List<Statement> statements = output.getStatementBlock().getStatements();
-                if (statements.size() > 0) {
+                if (!statements.isEmpty()) {
                     Statement firstStatement = statements.get(0);
                     Statement lastStatement = statements.get(statements.size() - 1);
 
@@ -1636,7 +1636,7 @@ public class AntlrParserPlugin extends ASTHelper implements ParserPlugin, Groovy
             node = node.getNextSibling();
         }
 
-        if (finallyStatement instanceof EmptyStatement && catches.size() == 0) {
+        if (finallyStatement instanceof EmptyStatement && catches.isEmpty()) {
             throw new ASTRuntimeException(tryStatementNode, "A try statement must have at least one catch or finally block.");
         }
 
@@ -2512,7 +2512,7 @@ public class AntlrParserPlugin extends ASTHelper implements ParserPlugin, Groovy
 
     private void setTypeArgumentsOnMethodCallExpression(MethodCallExpression expression,
                                                         List<GenericsType> typeArgumentList) {
-        if (typeArgumentList != null && typeArgumentList.size() > 0) {
+        if (typeArgumentList != null && !typeArgumentList.isEmpty()) {
             expression.setGenericsTypes(typeArgumentList.toArray(new GenericsType[typeArgumentList.size()]));
         }
     }
@@ -2561,7 +2561,7 @@ public class AntlrParserPlugin extends ASTHelper implements ParserPlugin, Groovy
         if (arguments instanceof TupleExpression) {
             TupleExpression te = (TupleExpression) arguments;
             List<Expression> expressions = te.getExpressions();
-            if (expressions.size() == 0) return null;
+            if (expressions.isEmpty()) return null;
             Expression last = expressions.remove(expressions.size() - 1);
             if (last instanceof AnonymousInnerClassCarrier) {
                 AnonymousInnerClassCarrier carrier = (AnonymousInnerClassCarrier) last;
@@ -2965,7 +2965,7 @@ public class AntlrParserPlugin extends ASTHelper implements ParserPlugin, Groovy
             configureAST(bound, boundsNode);
             bounds.add(bound);
         }
-        if (bounds.size() == 0) return null;
+        if (bounds.isEmpty()) return null;
         return (ClassNode[]) bounds.toArray(new ClassNode[bounds.size()]);
     }
 

--- a/src/main/org/codehaus/groovy/antlr/treewalker/SourceCodeTraversal.java
+++ b/src/main/org/codehaus/groovy/antlr/treewalker/SourceCodeTraversal.java
@@ -73,7 +73,7 @@ public class SourceCodeTraversal extends TraversalHelper {
     }
 
     protected void accept(GroovySourceAST currentNode) {
-        if (currentNode != null && unvisitedNodes != null && unvisitedNodes.size() > 0) {
+        if (currentNode != null && unvisitedNodes != null && !unvisitedNodes.isEmpty()) {
             GroovySourceAST t = currentNode;
 
             if (!(unvisitedNodes.contains(currentNode))) {

--- a/src/main/org/codehaus/groovy/ast/VariableScope.java
+++ b/src/main/org/codehaus/groovy/ast/VariableScope.java
@@ -99,17 +99,17 @@ public class VariableScope  {
     public VariableScope copy() {
         VariableScope copy = new VariableScope();
         copy.clazzScope = clazzScope;
-        if (declaredVariables.size() > 0) {
+        if (!declaredVariables.isEmpty()) {
           copy.declaredVariables = new HashMap<String, Variable>();
           copy.declaredVariables.putAll(declaredVariables);
         }
         copy.inStaticContext = inStaticContext;
         copy.parent = parent;
-        if (referencedClassVariables.size() > 0) {
+        if (!referencedClassVariables.isEmpty()) {
             copy.referencedClassVariables = new HashMap<String, Variable>();
             copy.referencedClassVariables.putAll(referencedClassVariables);
         }
-        if (referencedLocalVariables.size() > 0) {
+        if (!referencedLocalVariables.isEmpty()) {
             copy.referencedLocalVariables = new HashMap<String, Variable>();
             copy.referencedLocalVariables.putAll(referencedLocalVariables);
         }

--- a/src/main/org/codehaus/groovy/ast/expr/DeclarationExpression.java
+++ b/src/main/org/codehaus/groovy/ast/expr/DeclarationExpression.java
@@ -79,7 +79,7 @@ public class DeclarationExpression extends BinaryExpression {
             //nothing
         } else if (left instanceof TupleExpression) {
             TupleExpression tuple = (TupleExpression) left;
-            if (tuple.getExpressions().size()==0) throw new GroovyBugError("one element required for left side");
+            if (tuple.getExpressions().isEmpty()) throw new GroovyBugError("one element required for left side");
         } else {
             throw new GroovyBugError("illegal left expression for declaration: "+left);
         }

--- a/src/main/org/codehaus/groovy/ast/expr/GStringExpression.java
+++ b/src/main/org/codehaus/groovy/ast/expr/GStringExpression.java
@@ -89,7 +89,7 @@ public class GStringExpression extends Expression {
     public void addValue(Expression value) {
         // If the first thing is an value, then we need a dummy empty string in front of it so that when we
         // toString it they come out in the correct order.
-        if (strings.size() == 0)
+        if (strings.isEmpty())
             strings.add(ConstantExpression.EMPTY_STRING);
         values.add(value);
     }

--- a/src/main/org/codehaus/groovy/classgen/AnnotationVisitor.java
+++ b/src/main/org/codehaus/groovy/classgen/AnnotationVisitor.java
@@ -169,7 +169,7 @@ public class AnnotationVisitor {
         // if size is >1, then the method was overwritten or something, we ignore that
         // if it is an error, we have to test it at another place. But size==0 is
         // an error, because it means that no such attribute exists.
-        if (methods.size() == 0) {
+        if (methods.isEmpty()) {
             addError("'" + attrName + "'is not part of the annotation " + classNode, node);
             return ClassHelper.OBJECT_TYPE;
         }

--- a/src/main/org/codehaus/groovy/classgen/EnumCompletionVisitor.java
+++ b/src/main/org/codehaus/groovy/classgen/EnumCompletionVisitor.java
@@ -58,7 +58,7 @@ public class EnumCompletionVisitor extends ClassCodeVisitorSupport {
 
     private void completeEnum(ClassNode enumClass) {
         boolean isAic = isAnonymousInnerClass(enumClass);
-        if (enumClass.getDeclaredConstructors().size() == 0) {
+        if (enumClass.getDeclaredConstructors().isEmpty()) {
             addImplicitConstructors(enumClass, isAic);
         }
 
@@ -74,7 +74,7 @@ public class EnumCompletionVisitor extends ClassCodeVisitorSupport {
         if (aic) {
             ClassNode sn = enumClass.getSuperClass();
             List<ConstructorNode> sctors = new ArrayList<ConstructorNode>(sn.getDeclaredConstructors());
-            if (sctors.size() == 0) {
+            if (sctors.isEmpty()) {
                 addMapConstructors(enumClass, false);
             } else {
                 for (ConstructorNode constructorNode : sctors) {

--- a/src/main/org/codehaus/groovy/classgen/EnumVisitor.java
+++ b/src/main/org/codehaus/groovy/classgen/EnumVisitor.java
@@ -361,7 +361,7 @@ public class EnumVisitor extends ClassCodeVisitorSupport {
                     }
                     args.addExpression(exp);
                 }
-                if (savedMapEntries.size() > 0) {
+                if (!savedMapEntries.isEmpty()) {
                     args.getExpressions().add(2, new MapExpression(savedMapEntries));
                 }
             }

--- a/src/main/org/codehaus/groovy/classgen/Verifier.java
+++ b/src/main/org/codehaus/groovy/classgen/Verifier.java
@@ -1209,7 +1209,7 @@ public class Verifier implements GroovyClassVisitor, Opcodes {
         addCovariantMethods(classNode, declaredMethods, abstractMethods, methodsToAdd, genericsSpec);
 
         Map<String, MethodNode> declaredMethodsMap = new HashMap<String, MethodNode>();
-        if (methodsToAdd.size() > 0) {
+        if (!methodsToAdd.isEmpty()) {
             for (MethodNode mn : declaredMethods) {
                 declaredMethodsMap.put(mn.getTypeDescriptor(), mn);
             }

--- a/src/main/org/codehaus/groovy/classgen/asm/CompileStack.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/CompileStack.java
@@ -195,7 +195,7 @@ public class CompileStack implements Opcodes {
     }
 
     private void popState() {
-        if (stateStack.size()==0) {
+        if (stateStack.isEmpty()) {
              throw new GroovyBugError("Tried to do a pop on the compile stack without push.");
         }
         StateStackElement element = (StateStackElement) stateStack.removeLast();
@@ -762,7 +762,7 @@ public class CompileStack implements Opcodes {
     }
 
     private void applyBlockRecorder(List<BlockRecorder> blocks) {
-        if (blocks.size()==0 || blocks.size()==visitedBlocks.size()) return;
+        if (blocks.isEmpty() || blocks.size()==visitedBlocks.size()) return;
 
         MethodVisitor mv = controller.getMethodVisitor();
 

--- a/src/main/org/codehaus/groovy/classgen/asm/MopWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/MopWriter.java
@@ -84,7 +84,7 @@ public class MopWriter {
     }
 
     private Set<MopKey> buildCurrentClassSignatureSet(List<MethodNode> methods) {
-        if (methods.size()==0) return Collections.EMPTY_SET;
+        if (methods.isEmpty()) return Collections.EMPTY_SET;
         HashSet<MopKey> result = new HashSet<MopKey>(methods.size());
         for (MethodNode mn : methods) {
             MopKey key = new MopKey(mn.getName(), mn.getParameters());

--- a/src/main/org/codehaus/groovy/classgen/asm/sc/StaticInvocationWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/sc/StaticInvocationWriter.java
@@ -333,7 +333,7 @@ public class StaticInvocationWriter extends InvocationWriter {
         AsmClassGenerator acg = controller.getAcg();
         TypeChooser typeChooser = controller.getTypeChooser();
         OperandStack operandStack = controller.getOperandStack();
-        ClassNode lastArgType = argumentList.size()>0?
+        ClassNode lastArgType = !argumentList.isEmpty() ?
                 typeChooser.resolveType(argumentList.get(argumentList.size()-1), controller.getClassNode()):null;
         if (lastParaType.isArray()
                 && ((argumentList.size() > para.length)

--- a/src/main/org/codehaus/groovy/control/ErrorCollector.java
+++ b/src/main/org/codehaus/groovy/control/ErrorCollector.java
@@ -317,7 +317,7 @@ public class ErrorCollector {
 
 
     private void write(PrintWriter writer, Janitor janitor, List messages, String txt) {
-        if (messages==null || messages.size()==0) return;
+        if (messages==null || messages.isEmpty()) return;
         Iterator iterator = messages.iterator();
         while (iterator.hasNext()) {
             Message message = (Message) iterator.next();

--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethods.java
@@ -3051,7 +3051,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
     public static <T> List<List<T>> collate(Iterable<T> self, int size, int step, boolean keepRemainder) {
         List<T> selfList = asList(self);
         List<List<T>> answer = new ArrayList<List<T>>();
-        if (size <= 0 || selfList.size() == 0) {
+        if (size <= 0 || selfList.isEmpty()) {
             answer.add(selfList);
         } else {
             for (int pos = 0; pos < selfList.size() && pos > -1; pos += step) {
@@ -3785,7 +3785,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
         } else if (newEntry instanceof List) {
             List list = (List) newEntry;
             // def (key, value) == list
-            Object key = list.size() == 0 ? null : list.get(0);
+            Object key = list.isEmpty() ? null : list.get(0);
             Object value = list.size() <= 1 ? null : list.get(1);
             leftShift(result, new MapEntry(key, value));
         } else {
@@ -11358,7 +11358,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      */
     public static <K,V> Map<K,V> intersect(Map<K,V> left, Map<K,V> right) {
         final Map<K,V> ansMap = createSimilarMap(left);
-        if (right != null && right.size() > 0) {
+        if (right != null && !right.isEmpty()) {
             for (Map.Entry<K, V> e1 : left.entrySet()) {
                 for (Map.Entry<K, V> e2 : right.entrySet()) {
                     if (DefaultTypeTransformation.compareEqual(e1, e2)) {
@@ -11593,7 +11593,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
             if (!found) return false;
             otherItems.remove(foundItem);
         }
-        return otherItems.size() == 0;
+        return otherItems.isEmpty();
     }
 
     /**
@@ -11780,7 +11780,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
      */
     public static <T> Collection<T> minus(Collection<T> self, Collection<?> removeMe) {
         Collection<T> ansCollection = createSimilarCollection(self);
-        if (self.size() == 0)
+        if (self.isEmpty())
             return ansCollection;
         T head = self.iterator().next();
 
@@ -11931,7 +11931,7 @@ public class DefaultGroovyMethods extends DefaultGroovyMethodsSupport {
     public static <K,V> Map<K,V> minus(Map<K,V> self, Map removeMe) {
         final Map<K,V> ansMap = createSimilarMap(self);
         ansMap.putAll(self);
-        if (removeMe != null && removeMe.size() > 0) {
+        if (removeMe != null && !removeMe.isEmpty()) {
             for (Map.Entry<K, V> e1 : self.entrySet()) {
                 for (Object e2 : removeMe.entrySet()) {
                     if (DefaultTypeTransformation.compareEqual(e1, e2)) {

--- a/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethodsSupport.java
+++ b/src/main/org/codehaus/groovy/runtime/DefaultGroovyMethodsSupport.java
@@ -306,7 +306,7 @@ public class DefaultGroovyMethodsSupport {
         for (Collection col : cols) {
             all.addAll(col);
         }
-        if (all.size() == 0)
+        if (all.isEmpty())
             return true;
 
         Object first = all.get(0);

--- a/src/main/org/codehaus/groovy/tools/javac/JavaAwareCompilationUnit.java
+++ b/src/main/org/codehaus/groovy/tools/javac/JavaAwareCompilationUnit.java
@@ -65,7 +65,7 @@ public class JavaAwareCompilationUnit extends CompilationUnit {
 
         addPhaseOperation(new PrimaryClassNodeOperation() {
             public void call(SourceUnit source, GeneratorContext context, ClassNode node) throws CompilationFailedException {
-                if (javaSources.size() != 0) {
+                if (!javaSources.isEmpty()) {
                     VariableScopeVisitor scopeVisitor = new VariableScopeVisitor(source);
                     scopeVisitor.visitClass(node);
                     new JavaAwareResolveVisitor(JavaAwareCompilationUnit.this).startResolving(node, source);
@@ -85,7 +85,7 @@ public class JavaAwareCompilationUnit extends CompilationUnit {
         addPhaseOperation(new PrimaryClassNodeOperation() {
             public void call(SourceUnit source, GeneratorContext context, ClassNode classNode) throws CompilationFailedException {
                 try {
-                    if (javaSources.size() != 0) stubGenerator.generateClass(classNode);
+                    if (!javaSources.isEmpty()) stubGenerator.generateClass(classNode);
                 } catch (FileNotFoundException fnfe) {
                     source.addException(fnfe);
                 }
@@ -96,7 +96,7 @@ public class JavaAwareCompilationUnit extends CompilationUnit {
     public void gotoPhase(int phase) throws CompilationFailedException {
         super.gotoPhase(phase);
         // compile Java and clean up
-        if (phase == Phases.SEMANTIC_ANALYSIS && javaSources.size() > 0) {
+        if (phase == Phases.SEMANTIC_ANALYSIS && !javaSources.isEmpty()) {
             for (ModuleNode module : getAST().getModules()) {
                 module.setImportsResolved(false);
             }

--- a/src/main/org/codehaus/groovy/tools/javac/JavaStubGenerator.java
+++ b/src/main/org/codehaus/groovy/tools/javac/JavaStubGenerator.java
@@ -362,7 +362,7 @@ public class JavaStubGenerator {
     }
 
     private void printEnumFields(PrintWriter out, List<FieldNode> fields) {
-        if (fields.size() != 0) {
+        if (!fields.isEmpty()) {
             boolean first = true;
             for (FieldNode field : fields) {
                 if (!first) {
@@ -436,7 +436,7 @@ public class JavaStubGenerator {
 
         BlockStatement block = (BlockStatement) code;
         List stats = block.getStatements();
-        if (stats == null || stats.size() == 0)
+        if (stats == null || stats.isEmpty())
             return null;
 
         Statement stat = (Statement) stats.get(0);

--- a/src/main/org/codehaus/groovy/transform/AbstractASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/AbstractASTTransformation.java
@@ -184,7 +184,7 @@ public abstract class AbstractASTTransformation implements Opcodes, ASTTransform
 
     public boolean hasAnnotation(ClassNode cNode, ClassNode annotation) {
         List annots = cNode.getAnnotations(annotation);
-        return (annots != null && annots.size() > 0);
+        return (annots != null && !annots.isEmpty());
     }
 
     protected List<String> tokenize(String rawExcludes) {

--- a/src/main/org/codehaus/groovy/transform/AnnotationCollectorTransform.java
+++ b/src/main/org/codehaus/groovy/transform/AnnotationCollectorTransform.java
@@ -168,7 +168,7 @@ public class AnnotationCollectorTransform {
         }
         ListExpression memberListExp = (ListExpression) memberValue;
         List<Expression> memberList = memberListExp.getExpressions();
-        if (memberList.size()==0) return Collections.EMPTY_LIST;
+        if (memberList.isEmpty()) return Collections.EMPTY_LIST;
         ArrayList<AnnotationNode> ret = new ArrayList<AnnotationNode>();
         for (Expression e : memberList) {
             AnnotationNode toAdd = new AnnotationNode(e.getType());
@@ -234,7 +234,7 @@ public class AnnotationCollectorTransform {
 
             @SuppressWarnings("unchecked")
             Map<String,Object> member = (Map<String, Object>) inner[1];
-            if (member.size()==0) continue;
+            if (member.isEmpty()) continue;
             Map<String, Expression> generated = new HashMap<String, Expression>(member.size());
             for (String name : member.keySet()) {
                 Object val = member.get(name);
@@ -313,7 +313,7 @@ public class AnnotationCollectorTransform {
             }
         }
 
-        if (unusedNames.size()>0) {
+        if (!unusedNames.isEmpty()) {
             String message = "Annotation collector got unmapped names "+unusedNames.toString()+".";
             addError(message, aliasAnnotationUsage, source);
         }

--- a/src/main/org/codehaus/groovy/transform/AutoCloneASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/AutoCloneASTTransformation.java
@@ -137,7 +137,7 @@ public class AutoCloneASTTransformation extends AbstractASTTransformation {
     }
 
     private void createCloneCopyConstructor(ClassNode cNode, List<FieldNode> list, List<String> excludes) {
-        if (cNode.getDeclaredConstructors().size() == 0) {
+        if (cNode.getDeclaredConstructors().isEmpty()) {
             // add no-arg constructor
             BlockStatement noArgBody = new BlockStatement();
             noArgBody.addStatement(EmptyStatement.INSTANCE);
@@ -198,7 +198,7 @@ public class AutoCloneASTTransformation extends AbstractASTTransformation {
     }
 
     private void createSimpleClone(ClassNode cNode, List<FieldNode> fieldNodes, List<String> excludes) {
-        if (cNode.getDeclaredConstructors().size() == 0) {
+        if (cNode.getDeclaredConstructors().isEmpty()) {
             // add no-arg constructor
             cNode.addConstructor(ACC_PUBLIC, Parameter.EMPTY_ARRAY, ClassNode.EMPTY_ARRAY, block(EmptyStatement.INSTANCE));
         }

--- a/src/main/org/codehaus/groovy/transform/ImmutableASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/ImmutableASTTransformation.java
@@ -181,7 +181,7 @@ public class ImmutableASTTransformation extends AbstractASTTransformation {
                 createToString(cNode, false, false, null, null, false, true);
             }
             if( memberHasValue(node, MEMBER_ADD_COPY_WITH, true) &&
-                pList.size() > 0 &&
+                    !pList.isEmpty() &&
                 !hasDeclaredMethod(cNode, COPY_WITH_METHOD, 1) ) {
                 createCopyWith( cNode, pList ) ;
             }
@@ -366,7 +366,7 @@ public class ImmutableASTTransformation extends AbstractASTTransformation {
         // check for missing properties
         body.addStatement(stmt(callX(SELF_TYPE, "checkPropNames", args("this", "args"))));
         createConstructorMapCommon(cNode, body);
-        if (list.size() > 0) {
+        if (!list.isEmpty()) {
             createNoArgConstructor(cNode);
         }
     }
@@ -529,7 +529,7 @@ public class ImmutableASTTransformation extends AbstractASTTransformation {
             return false;
         return fieldType.isEnum() ||
                 ClassHelper.isPrimitiveType(fieldType) ||
-                fieldType.getAnnotations(MY_TYPE).size() != 0;
+                !fieldType.getAnnotations(MY_TYPE).isEmpty();
     }
 
     private boolean isKnownImmutable(String fieldName, List<String> knownImmutables) {

--- a/src/main/org/codehaus/groovy/transform/SingletonASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/SingletonASTTransformation.java
@@ -116,7 +116,7 @@ public class SingletonASTTransformation extends AbstractASTTransformation {
             }
         }
 
-        if (isStrict && cNodes.size() != 0) {
+        if (isStrict && !cNodes.isEmpty()) {
             for (ConstructorNode cNode : cNodes) {
                 addError("@Singleton didn't expect to find one or more additional constructors: remove constructor(s) or set strict=false", cNode);
             }

--- a/src/main/org/codehaus/groovy/transform/TupleConstructorASTTransformation.java
+++ b/src/main/org/codehaus/groovy/transform/TupleConstructorASTTransformation.java
@@ -186,7 +186,7 @@ public class TupleConstructorASTTransformation extends AbstractASTTransformation
         cNode.addConstructor(new ConstructorNode(ACC_PUBLIC, params.toArray(new Parameter[params.size()]), ClassNode.EMPTY_ARRAY, body));
         // add map constructor if needed, don't do it for LinkedHashMap for now (would lead to duplicate signature)
         // or if there is only one Map property (for backwards compatibility)
-        if (params.size() > 0) {
+        if (!params.isEmpty()) {
             ClassNode firstParam = params.get(0).getType();
             if (params.size() > 1 || firstParam.equals(ClassHelper.OBJECT_TYPE)) {
                 if (firstParam.equals(ClassHelper.MAP_TYPE)) {

--- a/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -4375,7 +4375,7 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
         if (arguments instanceof ArgumentListExpression) {
             ArgumentListExpression al = (ArgumentListExpression) arguments;
             List<Expression> list = al.getExpressions();
-            if (list.size()==0) return declaringClass;
+            if (list.isEmpty()) return declaringClass;
             Expression exp = list.get(0);
             ClassNode cn = exp.getNodeMetaData(ExtensionMethodDeclaringClass.class);
             if (cn!=null) return cn;

--- a/src/main/org/codehaus/groovy/transform/trait/TraitComposer.java
+++ b/src/main/org/codehaus/groovy/transform/trait/TraitComposer.java
@@ -356,7 +356,7 @@ public abstract class TraitComposer {
             }
         }
         if (!modified) return oldTypes;
-        if (l.size()==0) return null;
+        if (l.isEmpty()) return null;
         return l.toArray(new GenericsType[l.size()]);
     }
 

--- a/subprojects/groovy-ant/src/main/java/org/codehaus/groovy/ant/FileScanner.java
+++ b/subprojects/groovy-ant/src/main/java/org/codehaus/groovy/ant/FileScanner.java
@@ -55,7 +55,7 @@ public class FileScanner extends Task {
     }
 
     public boolean hasFiles() {
-        return filesets.size() > 0;
+        return !filesets.isEmpty();
     }
 
     /**

--- a/subprojects/groovy-ant/src/main/java/org/codehaus/groovy/ant/Groovydoc.java
+++ b/subprojects/groovy-ant/src/main/java/org/codehaus/groovy/ant/Groovydoc.java
@@ -321,7 +321,7 @@ public class Groovydoc extends Task {
         // and nested excludepackage elements
         if (this.sourcePath != null) {
             PatternSet ps = new PatternSet();
-            if (packageNames.size() > 0) {
+            if (!packageNames.isEmpty()) {
                 for (String pn : packageNames) {
                     String pkg = pn.replace('.', '/');
                     if (pkg.endsWith("*")) {

--- a/subprojects/groovy-console/src/main/groovy/groovy/ui/text/TextUndoManager.java
+++ b/subprojects/groovy-console/src/main/groovy/groovy/ui/text/TextUndoManager.java
@@ -189,7 +189,7 @@ public class TextUndoManager extends UndoManager {
         }
 
         public boolean canUndo() {
-            return edits.size() > 0;
+            return !edits.isEmpty();
         }
 
         protected long editedTime() {

--- a/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/SimpleGroovyClassDoc.java
+++ b/subprojects/groovy-groovydoc/src/main/java/org/codehaus/groovy/tools/groovydoc/SimpleGroovyClassDoc.java
@@ -253,7 +253,7 @@ public class SimpleGroovyClassDoc extends SimpleGroovyAbstractableElementDoc imp
         result.add(this);
         Set<GroovyClassDoc> next = new HashSet<GroovyClassDoc>();
         next.addAll(Arrays.asList(this.interfaces()));
-        while (next.size() > 0) {
+        while (!next.isEmpty()) {
             Set<GroovyClassDoc> temp = next;
             next = new HashSet<GroovyClassDoc>();
             for (GroovyClassDoc t : temp) {

--- a/subprojects/groovy-json/src/main/java/groovy/json/StreamingJsonBuilder.java
+++ b/subprojects/groovy-json/src/main/java/groovy/json/StreamingJsonBuilder.java
@@ -312,7 +312,7 @@ public class StreamingJsonBuilder extends GroovyObjectSupport {
                         writer.write(":");
                         writer.write(JsonOutput.toJson(entry.getValue()));
                     }
-                    StreamingJsonDelegate.cloneDelegateAndGetContent(writer, (Closure) arr[1], map.size() == 0);
+                    StreamingJsonDelegate.cloneDelegateAndGetContent(writer, (Closure) arr[1], map.isEmpty());
                     writer.write("}}");
                 } else if (StreamingJsonDelegate.isCollectionWithClosure(arr)) {
                     writer.write("{");

--- a/subprojects/groovy-sql/src/main/java/groovy/sql/DataSet.java
+++ b/subprojects/groovy-sql/src/main/java/groovy/sql/DataSet.java
@@ -211,7 +211,7 @@ public class DataSet extends Sql {
         withinDataSetBatch = true;
         closure.call(this);
         withinDataSetBatch = false;
-        if (batchData.size() == 0) {
+        if (batchData.isEmpty()) {
             return EMPTY_INT_ARRAY;
         }
         Closure transformedClosure = new Closure(null) {
@@ -232,7 +232,7 @@ public class DataSet extends Sql {
      */
     public void add(Map<String, Object> map) throws SQLException {
         if (withinDataSetBatch) {
-            if (batchData.size() == 0) {
+            if (batchData.isEmpty()) {
                 batchKeys = map.keySet();
             } else {
                 if (!map.keySet().equals(batchKeys)) {

--- a/subprojects/groovy-templates/src/main/groovy/groovy/text/StreamingTemplateEngine.java
+++ b/subprojects/groovy-templates/src/main/groovy/groovy/text/StreamingTemplateEngine.java
@@ -802,7 +802,7 @@ public class StreamingTemplateEngine extends TemplateEngine {
             ErrorCollector collector = e.getErrorCollector();
             @SuppressWarnings({"unchecked"})
             List<Message> errors = (List<Message>) collector.getErrors();
-            if (errors.size() > 0) {
+            if (!errors.isEmpty()) {
                 Message firstMessage = errors.get(0);
                 if (firstMessage instanceof SyntaxErrorMessage) {
                     @SuppressWarnings({"ThrowableResultOfMethodCallIgnored"})

--- a/subprojects/groovy-test/src/main/java/org/codehaus/groovy/transform/NotYetImplementedASTTransformation.java
+++ b/subprojects/groovy-test/src/main/java/org/codehaus/groovy/transform/NotYetImplementedASTTransformation.java
@@ -66,7 +66,7 @@ public class NotYetImplementedASTTransformation extends AbstractASTTransformatio
             statements.addAll(((BlockStatement) statement).getStatements());
         }
 
-        if (statements.size() == 0) return;
+        if (statements.isEmpty()) return;
 
         BlockStatement rewrittenMethodCode = new BlockStatement();
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 - Collection.isEmpty() should be used to test for emptiness
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1155
Please let me know if you have any questions.
Kirill Vlasov