### PR TITLE
Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"

### DIFF
--- a/src/main/groovy/lang/MetaClassImpl.java
+++ b/src/main/groovy/lang/MetaClassImpl.java
@@ -2314,7 +2314,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
                 } else {
                     result = new MetaBeanProperty(propertyName, propertyType, getterMethod, setterMethod);
                 }
-            } else if (getter && !setter) {
+            } else if (getter /*&& !setter*/) {    // setter is unset
                 if (getterMethod == null) {
                     result = metaField;
                 } else {
@@ -2322,7 +2322,7 @@ public class MetaClassImpl implements MetaClass, MutableMetaClass {
                     if (field) newmp.setField(metaField);
                     result = newmp;
                 }
-            } else if (setter && !getter) {
+            } else if (setter /*&& !getter*/) {    // getter is unset
                 if (setterMethod == null) {
                     result = metaField;
                 } else {

--- a/src/main/groovy/util/ObservableList.java
+++ b/src/main/groovy/util/ObservableList.java
@@ -299,13 +299,12 @@ public class ObservableList implements List {
         }
 
         List values = new ArrayList();
-        if (c != null) {
-            for (Object element : c) {
-                if (delegate.contains(element)) {
-                    values.add(element);
-                }
+        for (Object element : c) {
+            if (delegate.contains(element)) {
+                values.add(element);
             }
         }
+
 
         int oldSize = size();
         boolean success = delegate.removeAll(c);
@@ -323,11 +322,9 @@ public class ObservableList implements List {
         }
 
         List values = new ArrayList();
-        if (c != null) {
-            for (Object element : delegate) {
-                if (!c.contains(element)) {
-                    values.add(element);
-                }
+        for (Object element : delegate) {
+            if (!c.contains(element)) {
+                values.add(element);
             }
         }
 

--- a/src/main/org/codehaus/groovy/classgen/asm/BytecodeHelper.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/BytecodeHelper.java
@@ -281,9 +281,6 @@ public class BytecodeHelper implements Opcodes {
             return name;
         }
 
-        if (name == null) {
-            return "java.lang.Object;";
-        }
 
         if (name.startsWith("[")) {
             return name.replace('/', '.');

--- a/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
+++ b/src/main/org/codehaus/groovy/transform/stc/StaticTypeCheckingVisitor.java
@@ -1423,7 +1423,7 @@ public class StaticTypeCheckingVisitor extends ClassCodeVisitorSupport {
             MethodNode mn = (MethodNode) member;
             isStatic = mn.isStatic();
         }
-        if (staticOnly && !isStatic) return null;
+        if (/*staticOnly && */!isStatic) return null;   // staticOnly is set
         return member;
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2583 - Conditions should not unconditionally evaluate to "TRUE" or to "FALSE"
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2583
Please let me know if you have any questions.
Kirill Vlasov