### PR TITLE
Lazy initialization of "static" fields should be "synchronized"

### DIFF
--- a/buildSrc/src/main/java/JavadocFixTool.java
+++ b/buildSrc/src/main/java/JavadocFixTool.java
@@ -192,7 +192,7 @@ public class JavadocFixTool {
     /*
      * Lazily initialize the readme document, reading it from README file inside the jar
      */
-    public static void initReadme() {
+    public static synchronized void initReadme() {
         try {
             InputStream readmeStream = JavadocFixTool.class.getResourceAsStream("/README");
             if (readmeStream != null) {

--- a/src/examples/swing/binding/caricature/JCaricature.java
+++ b/src/examples/swing/binding/caricature/JCaricature.java
@@ -42,7 +42,7 @@ import javax.swing.JPanel;
  * @author sky
  */
 public class JCaricature extends JPanel {
-    private static Map/*<String,Image>*/ imageMap;
+    private Map/*<String,Image>*/ imageMap;
     
     private boolean empty;
     private int mouthStyle;

--- a/src/main/org/codehaus/groovy/runtime/HandleMetaClass.java
+++ b/src/main/org/codehaus/groovy/runtime/HandleMetaClass.java
@@ -24,7 +24,7 @@ import java.lang.reflect.Method;
 
 public class HandleMetaClass extends DelegatingMetaClass {
     private Object object;
-    private static MetaClass myMetaClass;
+    private MetaClass myMetaClass;
     private static final Object NONE = new Object();
 
     public HandleMetaClass(MetaClass mc) {

--- a/src/main/org/codehaus/groovy/runtime/metaclass/MetaClassRegistryImpl.java
+++ b/src/main/org/codehaus/groovy/runtime/metaclass/MetaClassRegistryImpl.java
@@ -413,7 +413,7 @@ public class MetaClassRegistryImpl implements MetaClassRegistry{
      * @param includeExtension
      * @return the registry
      */
-    public static MetaClassRegistry getInstance(int includeExtension) {
+    public static synchronized MetaClassRegistry getInstance(int includeExtension) {
         if (includeExtension != DONT_LOAD_DEFAULT) {
             if (instanceInclude == null) {
                 instanceInclude = new MetaClassRegistryImpl();

--- a/src/main/org/codehaus/groovy/tools/shell/util/Logger.java
+++ b/src/main/org/codehaus/groovy/tools/shell/util/Logger.java
@@ -45,9 +45,13 @@ public final class Logger {
     private void log(final String level, Object msg, Throwable cause) {
         assert level != null;
         assert msg != null;
-        
+
         if (io == null) {
-            io = new IO();
+            synchronized (Logger.class) {
+                if (io == null) {
+                    io = new IO();
+                }
+            }
         }
 
         // Allow the msg to be a Throwable, and handle it properly if no cause is given

--- a/src/main/org/codehaus/groovy/vmplugin/v7/IndyInterface.java
+++ b/src/main/org/codehaus/groovy/vmplugin/v7/IndyInterface.java
@@ -109,9 +109,12 @@ public class IndyInterface {
             if (LOG_ENABLED) {
                  LOG.info("invalidating switch point");
             }
-        	SwitchPoint old = switchPoint;
-            switchPoint = new SwitchPoint();
-            synchronized(IndyInterface.class) { SwitchPoint.invalidateAll(new SwitchPoint[]{old}); }
+
+            synchronized(IndyInterface.class) {
+                SwitchPoint old = switchPoint;
+                switchPoint = new SwitchPoint();
+                SwitchPoint.invalidateAll(new SwitchPoint[]{old});
+            }
         }
 
         /**


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S2444 - Lazy initialization of "static" fields should be "synchronized"
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2444
Please let me know if you have any questions.
Kirill Vlasov