### PR TITLE
Tighten the filtering prefixes

### DIFF
--- a/src/main/org/codehaus/groovy/runtime/StackTraceUtils.java
+++ b/src/main/org/codehaus/groovy/runtime/StackTraceUtils.java
@@ -63,9 +63,8 @@ public class StackTraceUtils {
             System.getProperty("groovy.sanitized.stacktraces",
                     "groovy.," +
                             "org.codehaus.groovy.," +
-                            "java.," +
-                            "javax.," +
-                            "sun.," +
+                            "java.lang.reflect," +
+                            "sun.reflect," +
                             "gjdk.groovy.,"
             ).split("(\\s|,)+");
 


### PR DESCRIPTION
as the current rules are a bit overzealous and may filter relevant
information.