### PR TITLE
null-safe number parsing of xml

### DIFF
--- a/subprojects/groovy-xml/src/main/java/groovy/util/slurpersupport/GPathResult.java
+++ b/subprojects/groovy-xml/src/main/java/groovy/util/slurpersupport/GPathResult.java
@@ -272,12 +272,19 @@ public abstract class GPathResult extends GroovyObjectSupport implements Writabl
         return text();
     }
 
+    public static boolean asBoolean(Object object) {
+        return !((GPathResult)object).isEmpty();
+    }
+
     /**
      * Converts the text of this GPathResult to a Integer object.
      *
      * @return the GPathResult, converted to a <code>Integer</code>
      */
     public Integer toInteger() {
+        if(textIsEmptyOrNull()){
+            return null;
+        }
         return StringGroovyMethods.toInteger(text());
     }
 
@@ -287,6 +294,9 @@ public abstract class GPathResult extends GroovyObjectSupport implements Writabl
      * @return the GPathResult, converted to a <code>Long</code>
      */
     public Long toLong() {
+        if(textIsEmptyOrNull()){
+            return null;
+        }
         return StringGroovyMethods.toLong(text());
     }
 
@@ -296,6 +306,9 @@ public abstract class GPathResult extends GroovyObjectSupport implements Writabl
      * @return the GPathResult, converted to a <code>Float</code>
      */
     public Float toFloat() {
+        if(textIsEmptyOrNull()){
+            return null;
+        }
         return StringGroovyMethods.toFloat(text());
     }
 
@@ -305,6 +318,9 @@ public abstract class GPathResult extends GroovyObjectSupport implements Writabl
      * @return the GPathResult, converted to a <code>Double</code>
      */
     public Double toDouble() {
+        if(textIsEmptyOrNull()){
+            return null;
+        }
         return StringGroovyMethods.toDouble(text());
     }
 
@@ -314,6 +330,9 @@ public abstract class GPathResult extends GroovyObjectSupport implements Writabl
      * @return the GPathResult, converted to a <code>BigDecimal</code>
      */
     public BigDecimal toBigDecimal() {
+        if(textIsEmptyOrNull()){
+            return null;
+        }
         return StringGroovyMethods.toBigDecimal(text());
     }
 
@@ -323,7 +342,14 @@ public abstract class GPathResult extends GroovyObjectSupport implements Writabl
      * @return the GPathResult, converted to a <code>BigInteger</code>
      */
     public BigInteger toBigInteger() {
+        if(textIsEmptyOrNull()){
+            return null;
+        }
         return StringGroovyMethods.toBigInteger(text());
+    }
+
+    private boolean textIsEmptyOrNull() {
+        return text() == null || text().equals("");
     }
 
     /**
@@ -602,7 +628,7 @@ public abstract class GPathResult extends GroovyObjectSupport implements Writabl
                     } else {
                         delegate.invokeMethod("yield", new Object[]{child});
                     }
-                }                
+                }
             }
         };
     }

--- a/subprojects/groovy-xml/src/test/groovy/groovy/util/SafeNumberParsingTest.groovy
+++ b/subprojects/groovy-xml/src/test/groovy/groovy/util/SafeNumberParsingTest.groovy
@@ -1,0 +1,34 @@
+package groovy.util
+
+
+class SafeNumberParsingTest extends GroovyTestCase {
+
+    void testSafetyWhenConvertingToNumbers() {
+        def xmlText = '''
+            <someNumberValues>
+                <someBigDecimal>123.4</someBigDecimal>
+                <someEmptyBigDecimal></someEmptyBigDecimal>
+                <someLong>123</someLong>
+                <someEmptyLong></someEmptyLong>
+                <someFloat>123.4</someFloat>
+                <someEmptyFloat></someEmptyFloat>
+                <someInteger>123</someInteger>
+                <someEmptyInteger></someEmptyInteger>
+            </someNumberValues>
+        '''
+        def xml = new XmlSlurper().parseText(xmlText)
+
+        assert xml.'**'.find{it.name() == 'someBigDecimal'}.toBigDecimal() == 123.4
+        assert xml.'**'.find{it.name() == 'someEmptyBigDecimal'}.toBigDecimal() == null
+        assert xml.'**'.find{it.name() == 'someMissingBigDecimal'}?.toBigDecimal() == null
+        assert xml.'**'.find{it.name() == 'someLong'}.toLong() == 123
+        assert xml.'**'.find{it.name() == 'someEmptyLong'}.toLong() == null
+        assert xml.'**'.find{it.name() == 'someMissingLong'}?.toLong() == null
+        assert xml.'**'.find{it.name() == 'someFloat'}.toFloat() == 123.4.toFloat()
+        assert xml.'**'.find{it.name() == 'someEmptyFloat'}.toFloat() == null
+        assert xml.'**'.find{it.name() == 'someMissingFloat'}?.toFloat() == null
+        assert xml.'**'.find{it.name() == 'someInteger'}.toInteger() == 123
+        assert xml.'**'.find{it.name() == 'someEmptyInteger'}.toInteger() == null
+        assert xml.'**'.find{it.name() == 'someMissingInteger'}?.toInteger() == null
+    }
+}


### PR DESCRIPTION
The following results in af NumberFormatException: 
```xml.'**'.find{it.name()` == 'someBigDecimal'}.toBigDecimal()```
if the element content is empty which means the following construct is necessary:
```
xml.'**'.find{it.name()` == 'someBigDecimal'}.with { it.text() ? return null : toBigDecimal() }
```
This pull request ensures that `null` is returned if the element is empty for the following methods:

- toBigInteger()
- toBigDecimal()
- toBigLong()
- toBigFloat()