### PR TITLE
Fixed bug that if the numberOfArguments exceed 255 will throw ArrayIndexOutOfBoundsException in method getCreateArraySignature

### DIFF
--- a/src/main/org/codehaus/groovy/classgen/asm/CallSiteWriter.java
+++ b/src/main/org/codehaus/groovy/classgen/asm/CallSiteWriter.java
@@ -55,6 +55,11 @@ public class CallSiteWriter {
     }
     private static String [] sig = new String [255];
     private static String getCreateArraySignature(int numberOfArguments) {
+        if (numberOfArguments >= 255) {
+            throw new IllegalArgumentException(String.format(
+                      "The number of incoming parameters '%s' exceeded expectations '%s'",
+                      numberOfArguments, 255);
+        }
         if (sig[numberOfArguments] == null) {
             StringBuilder sb = new StringBuilder("(");
             for (int i = 0; i != numberOfArguments; ++i) {


### PR DESCRIPTION
I am using graph data query through [tinkerpop](http://tinkerpop.apache.org/), when I do the following query "g.V(1, 2, ..., 300)", it throws an ArrayIndexOutOfBoundsException.It may be that tinkerpop has incorrectly called your code, but this phenomenon shows that this is a hidden danger.