### PR TITLE
update geb dependency

### DIFF
--- a/src/spec/doc/core-testing-guide.adoc
+++ b/src/spec/doc/core-testing-guide.adoc
@@ -550,7 +550,7 @@ JUnit4 tests. The module that is needed for JUnit 3/4 support is `geb-junit`:
 --------------------------------------------------------------------
 @Grapes([
     @Grab("org.gebish:geb-core:0.9.2"),
-    @Grab("org.gebish:geb-junit:0.9.2"),
+    @Grab("org.gebish:geb-junit4:0.9.2"),
     @Grab("org.seleniumhq.selenium:selenium-firefox-driver:2.26.0"),
     @Grab("org.seleniumhq.selenium:selenium-support:2.26.0")
 ])


### PR DESCRIPTION
don't know if `org.gebish:geb-junit:0.9.2` existed previously but currently only `org.gebish:geb-junit4:0.9.2` or `org.gebish:geb-junit3:0.9.2` are available in mavenCentral