### PR TITLE
Add support for custom prefix in script name in JSR223 script engine

### DIFF
--- a/subprojects/groovy-jsr223/src/main/java/org/codehaus/groovy/jsr223/GroovyScriptEngineImpl.java
+++ b/subprojects/groovy-jsr223/src/main/java/org/codehaus/groovy/jsr223/GroovyScriptEngineImpl.java
@@ -399,7 +399,8 @@ public class GroovyScriptEngineImpl
 
     // generate a unique name for top-level Script classes
     private synchronized String generateScriptName() {
-        return "Script" + (++counter) + ".groovy";
+        String prefix = (String) ctx.getAttribute("#jsr223.groovy.engine.script.name.prefix", ScriptContext.ENGINE_SCOPE);
+        return (prefix == null ? '' : prefix + "_") + "Script" + (++counter) + ".groovy";
     }
 
     @SuppressWarnings("unchecked")


### PR DESCRIPTION
- read attribute "#jsr223.groovy.engine.script.name.prefix" from engine scope script context
- keep Script + counter to avoid name collision